### PR TITLE
Add top and bottom navigation components with placeholder routes

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Home,
+  Calendar,
+  Users,
+  MoreHorizontal,
+  Plus,
+} from "lucide-react";
+
+export default function BottomNav() {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 text-gray-400 flex justify-around items-center py-2">
+      <Link href="/" className="flex flex-col items-center gap-1 hover:text-blue-400">
+        <Home className="h-6 w-6" />
+        <span className="text-xs">Dashboard</span>
+      </Link>
+      <Link href="/schedule" className="flex flex-col items-center gap-1 hover:text-blue-400">
+        <Calendar className="h-6 w-6" />
+        <span className="text-xs">Schedule</span>
+      </Link>
+      <div className="relative">
+        <Link
+          href="/"
+          className="flex items-center justify-center h-14 w-14 -translate-y-6 rounded-full bg-gradient-to-br from-gray-900 to-black text-gray-300 drop-shadow-lg hover:scale-110 transition"
+        >
+          <Plus className="h-8 w-8" />
+        </Link>
+      </div>
+      <Link href="/friends" className="flex flex-col items-center gap-1 hover:text-blue-400">
+        <Users className="h-6 w-6" />
+        <span className="text-xs">Friends</span>
+      </Link>
+      <Link href="/coming-soon" className="flex flex-col items-center gap-1 hover:text-blue-400">
+        <MoreHorizontal className="h-6 w-6" />
+        <span className="text-xs">Coming Soon</span>
+      </Link>
+    </nav>
+  );
+}
+

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Menu } from "lucide-react";
+
+interface TopNavProps {
+  username: string;
+}
+
+export default function TopNav({ username }: TopNavProps) {
+  const toggleSidebar = () => {
+    // Placeholder for future sidebar toggle
+    console.log("toggle sidebar");
+  };
+
+  return (
+    <nav className="w-full flex items-center justify-between px-4 py-2 bg-gray-900 text-white">
+      <button onClick={toggleSidebar} className="p-2 hover:text-blue-400">
+        <Menu className="h-6 w-6" />
+      </button>
+      <span className="font-semibold" data-testid="username">
+        {username}
+      </span>
+      <div className="h-8 w-8 rounded-full bg-gray-700" />
+    </nav>
+  );
+}
+

--- a/src/app/coming-soon/page.tsx
+++ b/src/app/coming-soon/page.tsx
@@ -1,0 +1,8 @@
+export default function ComingSoon() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-950 text-gray-200">
+      <h1 className="text-2xl">Coming Soon…</h1>
+    </div>
+  );
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,8 @@ export const runtime = "nodejs";
 import "./globals.css";
 import ClientProviders from "@/components/ClientProviders";
 import ErrorBoundary from "@/components/debug/ErrorBoundary";
+import TopNav from "@/components/TopNav";
+import BottomNav from "@/components/BottomNav";
 import React from "react";
 
 export default function RootLayout({
@@ -14,9 +16,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>
+      <body className="flex min-h-screen flex-col">
         <ErrorBoundary>
-          <ClientProviders>{children}</ClientProviders>
+          <ClientProviders>
+            <TopNav username="MackVali" />
+            <main className="flex-1">{children}</main>
+            <BottomNav />
+          </ClientProviders>
         </ErrorBoundary>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- add reusable `TopNav` and `BottomNav` components using lucide-react icons
- include a placeholder `/coming-soon` page and wire up navigation
- mount new navigation components in root layout for global display

## Testing
- `pnpm lint` *(fails: Unexpected any in existing code)*
- `pnpm test-views` *(fails: Missing environment variables: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fb13e7a8832c922989f305f5465c