### PR TITLE
feat: enforce auth via middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,60 +1,73 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
 
-const PUBLIC_FILE = /\.(.*)$/;
+const PUBLIC_PATHS = ['/auth', '/api', '/health'];
 
 export async function middleware(req: NextRequest) {
-  const res = NextResponse.next();
-  const { pathname } = req.nextUrl;
+  const { pathname, search } = req.nextUrl;
 
-  // Skip static assets
-  if (PUBLIC_FILE.test(pathname)) {
-    return res;
-  }
+  const isAsset =
+    pathname.startsWith('/_next/') ||
+    pathname.startsWith('/static/') ||
+    /\.(png|jpg|jpeg|gif|svg|webp|ico|css|js|txt|map)$/.test(pathname);
 
-  // Allow public routes
-  if (pathname.startsWith("/api")) {
-    return res;
-  }
+  const isPublic =
+    isAsset || PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(p + '/'));
 
+  // Create a mutable response; pass { request } for edge correctness
+  const res = NextResponse.next({ request: req });
+
+  // Build Supabase client using Next 15 cookie API (getAll/setAll)
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_URL || '',
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
     {
       cookies: {
-        get: (name) => req.cookies.get(name)?.value,
-        set: (name, value, options) => res.cookies.set(name, value, options),
-        remove: (name, options) =>
-          res.cookies.set(name, "", { ...options, maxAge: 0 }),
+        getAll() {
+          return req.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              res.cookies.set(name, value, options);
+            });
+          } catch {
+            // Called from a Server Component during build? Ignore.
+          }
+        },
       },
-    },
+    }
   );
 
+  // Refresh session + read user
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user && !pathname.startsWith("/auth")) {
-    const redirectUrl = req.nextUrl.clone();
-    redirectUrl.pathname = "/auth";
-    redirectUrl.searchParams.set(
-      "redirect",
-      pathname + req.nextUrl.search,
-    );
-    return NextResponse.redirect(redirectUrl, { headers: res.headers });
+  // Gate non-public routes
+  if (!user && !isPublic) {
+    const redirectTo = encodeURIComponent(pathname + (search || ''));
+    const url = req.nextUrl.clone();
+    url.pathname = '/auth';
+    url.search = `?redirect=${redirectTo}`;
+    return NextResponse.redirect(url);
   }
 
-  if (user && pathname.startsWith("/auth")) {
-    const redirectParam = req.nextUrl.searchParams.get("redirect");
-    const dest = redirectParam || "/";
-    return NextResponse.redirect(new URL(dest, req.url), {
-      headers: res.headers,
-    });
+  // Keep signed-in users out of /auth
+  if (user && pathname.startsWith('/auth')) {
+    const params = new URLSearchParams(search);
+    const dest = params.get('redirect') || '/';
+    const url = req.nextUrl.clone();
+    url.pathname = dest;
+    url.search = '';
+    return NextResponse.redirect(url);
   }
 
   return res;
 }
 
+// Apply to all app routes; assets are filtered above
 export const config = {
-  matcher: ["/((?!_next/|favicon.ico).*)"],
+  matcher: ['/((?!_next/|favicon.ico).*)'],
 };
+

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,7 @@
 {
-  "buildCommand": "pnpm install --frozen-lockfile && pnpm approve-builds @tailwindcss/oxide sharp unrs-resolver || true && pnpm run build"
+  "buildCommand": "pnpm install --frozen-lockfile && pnpm approve-builds @tailwindcss/oxide sharp unrs-resolver || true && pnpm run build",
+  "env": {
+    "NEXT_PUBLIC_SUPABASE_URL": "@next_public_supabase_url",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "@next_public_supabase_anon_key"
+  }
 }


### PR DESCRIPTION
## Summary
- add middleware using Supabase to redirect unauthenticated users to `/auth`
- send signed-in users away from `/auth` to home or the `redirect` parameter

## Testing
- `pnpm lint`
- `pnpm test:run`
- `pnpm dev` *(fails: terminated after startup)*


------
https://chatgpt.com/codex/tasks/task_e_68aa4b49dc54832cb9e96e3c905aa7b1