### PR TITLE
style: use dark gradient for progress bars

### DIFF
--- a/components/ui/Progress.tsx
+++ b/components/ui/Progress.tsx
@@ -10,15 +10,15 @@ export function Progress({ value, trackClass = '', barClass = '', className = ''
   
   return (
     <div className={`w-full ${className}`}>
-      <div 
-        className={`h-2 rounded-full bg-white/10 ${trackClass}`}
+      <div
+        className={`h-2 rounded-full bg-gray-800 ${trackClass}`}
         role="progressbar"
         aria-valuenow={clampedValue}
         aria-valuemin={0}
         aria-valuemax={100}
       >
-        <div 
-          className={`h-2 rounded-full bg-white/80 transition-all duration-300 ${barClass}`}
+        <div
+          className={`h-2 rounded-full bg-gradient-to-r from-gray-700 to-gray-900 transition-all duration-300 ${barClass}`}
           style={{ width: `${clampedValue}%` }}
         />
       </div>

--- a/src/components/ui/LevelBanner.tsx
+++ b/src/components/ui/LevelBanner.tsx
@@ -11,7 +11,10 @@ export function LevelBanner({
       </div>
       <div className="relative">
         <div className="h-[12px] w-full rounded-full bg-[#0c0f14] inner-hair" />
-        <div className="absolute left-0 top-0 h-[12px] rounded-full bg-[var(--accent)]" style={{width:`${pct}%`}} />
+        <div
+          className="absolute left-0 top-0 h-[12px] rounded-full bg-gradient-to-r from-gray-700 to-gray-900"
+          style={{ width: `${pct}%` }}
+        />
         <div className="absolute right-1 -top-6 text-[11px] px-2 py-[2px] rounded-full bg-[#0c0f14] border border-white/10">
           {current} / {total}
         </div>

--- a/src/components/ui/SkillPill.tsx
+++ b/src/components/ui/SkillPill.tsx
@@ -15,7 +15,10 @@ export function SkillPill({
         <div className="flex-1">
           <div className="font-semibold">{title}</div>
           <div className="mt-1 h-[6px] rounded-full bg-[#0c0f14]">
-            <div className="h-[6px] rounded-full bg-[var(--accent)]" style={{width:`${w}%`}} />
+            <div
+              className="h-[6px] rounded-full bg-gradient-to-r from-gray-700 to-gray-900"
+              style={{ width: `${w}%` }}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- use gradient grey for generic progress bar and dark track
- update SkillPill and LevelBanner to match gradient progress style

## Testing
- `pnpm test` *(fails: expected undefined to be defined)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaacffe764832cb9b7e5fb83e0432b