### PR TITLE
feat: add skills page with create form

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import { Section } from "@/components/ui/Section";
 import { LevelBanner } from "@/components/ui/LevelBanner";
 import { SkillPill } from "@/components/ui/SkillPill";
@@ -12,7 +13,14 @@ export default function DashboardPage(){
 
       <MonumentContainer />
 
-      <Section title="Skills" className="mt-1 px-4">
+      <Section
+        title={
+          <Link href="/skills" className="block">
+            Skills
+          </Link>
+        }
+        className="mt-1 px-4"
+      >
         <SkillPill emoji="🖊️" title="Writing" pct={65} />
         <SkillPill emoji="⏱️" title="Time Management" pct={40} />
         <SkillPill emoji="🗣️" title="Public Speaking" pct={30} />

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, FormEvent } from "react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import {
   PageHeader,
@@ -11,24 +11,178 @@ import {
   useToastHelpers,
 } from "@/components/ui";
 import { Button } from "@/components/ui/button";
-import { Plus, Star, TrendingUp, Award } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import { Plus } from "lucide-react";
+import { getSupabaseBrowser } from "@/lib/supabase";
 
 interface Skill {
   id: string;
   name: string;
-  description: string;
-  currentLevel: number;
-  targetLevel: number;
-  category: string;
-  lastPracticed?: string;
-  totalPracticeHours: number;
+  icon: string | null;
+}
+
+interface Monument {
+  id: string;
+  title: string;
 }
 
 export default function SkillsPage() {
+  const supabase = getSupabaseBrowser();
+  const { success, error } = useToastHelpers();
+
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [monuments, setMonuments] = useState<Monument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [open, setOpen] = useState(false);
+
+  const [name, setName] = useState("");
+  const [icon, setIcon] = useState("");
+  const [monumentId, setMonumentId] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function fetchSkills() {
+    if (!supabase) return;
+    setLoading(true);
+    await supabase.auth.getSession();
+    const { data, error: err } = await supabase
+      .from("skills")
+      .select("id,name,icon")
+      .order("created_at", { ascending: false });
+    if (err) console.error(err);
+    setSkills(data ?? []);
+    setLoading(false);
+  }
+
+  async function fetchMonuments() {
+    if (!supabase) return;
+    await supabase.auth.getSession();
+    const { data, error: err } = await supabase
+      .from("monuments")
+      .select("id,title")
+      .order("created_at", { ascending: false });
+    if (err) console.error(err);
+    setMonuments(data ?? []);
+  }
+
+  useEffect(() => {
+    fetchSkills();
+    fetchMonuments();
+  }, []);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!supabase) return;
+    setSaving(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setSaving(false);
+      return;
+    }
+    const { error: insertError } = await supabase.from("skills").insert({
+      name,
+      icon,
+      monument_id: monumentId || null,
+      user_id: user.id,
+    });
+    setSaving(false);
+    if (insertError) {
+      console.error(insertError);
+      error("Failed to create skill", insertError.message);
+      return;
+    }
+    success("Skill created");
+    setOpen(false);
+    setName("");
+    setIcon("");
+    setMonumentId("");
+    fetchSkills();
+  }
+
   return (
-    <div className="p-6 text-white">
-      <h1>Skills Page</h1>
-      <p>Coming soon...</p>
-    </div>
+    <ProtectedRoute>
+      <div className="p-4 sm:p-6 space-y-4">
+        <PageHeader title="Skills">
+          <Button size="sm" onClick={() => setOpen(true)} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Create Skill
+          </Button>
+        </PageHeader>
+
+        {loading ? (
+          <GridSkeleton />
+        ) : skills.length === 0 ? (
+          <SkillsEmptyState onAction={() => setOpen(true)} />
+        ) : (
+          <GridContainer cols={1} className="gap-4">
+            {skills.map((skill) => (
+              <ContentCard
+                key={skill.id}
+                className="flex items-center gap-4"
+                padding="sm"
+              >
+                <div className="text-2xl">{skill.icon || "⭐"}</div>
+                <div className="font-medium">{skill.name}</div>
+              </ContentCard>
+            ))}
+          </GridContainer>
+        )}
+
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetContent side="bottom">
+            <SheetHeader>
+              <SheetTitle>Create Skill</SheetTitle>
+            </SheetHeader>
+            <form onSubmit={handleSubmit} className="space-y-4 p-4">
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Name</label>
+                <Input
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Icon</label>
+                <Input
+                  value={icon}
+                  onChange={(e) => setIcon(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Related Monument</label>
+                <select
+                  value={monumentId}
+                  onChange={(e) => setMonumentId(e.target.value)}
+                  className="w-full rounded-md border border-input bg-background p-2"
+                >
+                  <option value="">None</option>
+                  {monuments.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <SheetFooter>
+                <Button type="submit" disabled={saving} className="w-full">
+                  {saving ? "Saving..." : "Save Skill"}
+                </Button>
+              </SheetFooter>
+            </form>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </ProtectedRoute>
   );
 }
+


### PR DESCRIPTION
## Summary
- navigate from dashboard skills header to full skills page
- list user skills with add-skill modal

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68aac0b8eea0832cb28ecb115cf48fff