### PR TITLE
Increase monument fetch limit

### DIFF
--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -25,7 +25,7 @@ export function MonumentContainer() {
         .from("monuments")
         .select("id,title,emoji")
         .order("created_at", { ascending: false })
-        .limit(3);
+        .limit(8);
       if (!cancelled) {
         if (error) console.error(error);
         setMonuments(data ?? []);
@@ -64,7 +64,7 @@ export function MonumentContainer() {
             {monuments.map((m) => (
               <div
                 key={m.id}
-                className="card mr-3 flex h-[128px] w-[128px] snap-start flex-col items-center justify-center p-3"
+                className="card mr-3 flex h-[128px] w-[128px] flex-shrink-0 snap-start flex-col items-center justify-center p-3"
               >
                 <div className="mb-2 text-2xl" aria-hidden>
                   {m.emoji || "🏛️"}


### PR DESCRIPTION
## Summary
- fetch up to 8 monuments instead of 3
- prevent monument cards from shrinking in the container

## Testing
- `pnpm lint`
- `pnpm test:run` *(fails: expected undefined to be defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ab840bd8c0832ca056be88e3b5538b