### PR TITLE
Expand monument list and adjust card layout

### DIFF
--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -25,7 +25,7 @@ export function MonumentContainer() {
         .from("monuments")
         .select("id,title,emoji")
         .order("created_at", { ascending: false })
-        .limit(3);
+        .limit(8);
       if (!cancelled) {
         if (error) console.error(error);
         setMonuments(data ?? []);
@@ -59,17 +59,17 @@ export function MonumentContainer() {
           </Link>
         </div>
       ) : (
-        <div className="px-4 overflow-x-auto scroll-snap">
-          <div className="flex">
+        <div className="px-4">
+          <div className="grid grid-cols-4 gap-2">
             {monuments.map((m) => (
               <div
                 key={m.id}
-                className="card mr-3 flex h-[128px] w-[128px] snap-start flex-col items-center justify-center p-3"
+                className="card flex h-16 w-16 flex-col items-center justify-center p-1"
               >
-                <div className="mb-2 text-2xl" aria-hidden>
+                <div className="mb-1 text-lg" aria-hidden>
                   {m.emoji || "🏛️"}
                 </div>
-                <div className="w-full truncate text-center text-sm font-semibold">
+                <div className="w-full truncate text-center text-xs font-semibold">
                   {m.title}
                 </div>
               </div>

--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -25,7 +25,7 @@ export function MonumentContainer() {
         .from("monuments")
         .select("id,title,emoji")
         .order("created_at", { ascending: false })
-        .limit(8);
+        .range(0, 7);
       if (!cancelled) {
         if (error) console.error(error);
         setMonuments(data ?? []);
@@ -69,7 +69,7 @@ export function MonumentContainer() {
                 <div className="mb-1 text-lg" aria-hidden>
                   {m.emoji || "🏛️"}
                 </div>
-                <div className="w-full break-words text-center text-xs font-semibold leading-tight">
+                <div className="w-full break-words text-center text-[10px] font-semibold leading-tight">
                   {m.title}
                 </div>
               </div>

--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -69,7 +69,7 @@ export function MonumentContainer() {
                 <div className="mb-1 text-lg" aria-hidden>
                   {m.emoji || "🏛️"}
                 </div>
-                <div className="w-full truncate text-center text-xs font-semibold">
+                <div className="w-full break-words text-center text-xs font-semibold leading-tight">
                   {m.title}
                 </div>
               </div>

--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -60,11 +60,11 @@ export function MonumentContainer() {
         </div>
       ) : (
         <div className="px-4">
-          <div className="grid grid-cols-4 gap-2">
+          <div className="grid grid-cols-4 gap-1">
             {monuments.map((m) => (
               <div
                 key={m.id}
-                className="card flex h-16 w-16 flex-col items-center justify-center p-1"
+                className="card flex aspect-square w-full flex-col items-center justify-center p-1"
               >
                 <div className="mb-1 text-lg" aria-hidden>
                   {m.emoji || "🏛️"}


### PR DESCRIPTION
## Summary
- Show up to eight monuments instead of three
- Display monument cards in a compact 4x2 grid for mobile

## Testing
- `pnpm lint src/components/ui/MonumentContainer.tsx`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=test pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68abf304c0ec832cb41ebf05d7a31be0