### PR TITLE
Wrap ClientProviders with AuthProvider for persistent auth session

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ export const runtime = "nodejs";
 import "./globals.css";
 import ClientProviders from "@/components/ClientProviders";
 import ErrorBoundary from "@/components/debug/ErrorBoundary";
+import AuthProvider from "@/components/auth/AuthProvider";
 import React from "react";
 
 export default function RootLayout({
@@ -16,9 +17,11 @@ export default function RootLayout({
     <html lang="en">
       <body className="flex min-h-screen flex-col">
         <ErrorBoundary>
-          <ClientProviders>
-            <main className="flex-1">{children}</main>
-          </ClientProviders>
+          <AuthProvider>
+            <ClientProviders>
+              <main className="flex-1">{children}</main>
+            </ClientProviders>
+          </AuthProvider>
         </ErrorBoundary>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- import and wrap `ClientProviders` with `AuthProvider` in app layout so `useAuth` has access to current session

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected undefined to be defined)*

------
https://chatgpt.com/codex/tasks/task_e_68acb6691978832cad43fcad90f478a3