### PR TITLE
refactor: unify skill field names

### DIFF
--- a/components/ui/SkillRow.tsx
+++ b/components/ui/SkillRow.tsx
@@ -41,25 +41,25 @@ export function SkillRow({ skill }: SkillRowProps) {
     <div className="flex items-center gap-3 p-3 bg-[#1E1E1E] rounded-md border border-[#333] hover:bg-[#252525] transition-colors">
       {/* Skill Icon */}
       <div className="text-xl flex-shrink-0">
-        {getSkillIcon(skill.skill_name, skill.skill_icon)}
+        {getSkillIcon(skill.name, skill.icon)}
       </div>
       
       {/* Skill Name */}
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-[#E0E0E0] truncate">
-          {skill.skill_name}
+          {skill.name}
         </div>
       </div>
       
       {/* Level Badge */}
       <div className="text-xs text-[#A0A0A0] bg-[#404040] px-2 py-1 rounded-full flex-shrink-0">
-        Lv {skill.skill_level}
+        Lv {skill.level}
       </div>
       
       {/* Progress Bar */}
       <div className="w-20 flex-shrink-0">
         <div className="w-full h-2 bg-[#333] rounded-full overflow-hidden">
-          <div 
+          <div
             className="h-full bg-[#BBB] rounded-full transition-all duration-300"
             style={{ width: `${skill.progress}%` }}
           />

--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -12,10 +12,11 @@ import type { GoalItem } from "@/types/dashboard";
 
 interface Skill {
   skill_id: string;
-  skill_name: string;
-  skill_icon: string;
-  skill_level: number;
+  name: string;
+  icon: string;
+  level: number;
   progress: number | null;
+  cat_id: string | null;
 }
 
 interface Category {

--- a/src/app/(app)/dashboard/components/ClientDashboard.tsx
+++ b/src/app/(app)/dashboard/components/ClientDashboard.tsx
@@ -421,7 +421,7 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                           >
                             {/* Skill Icon */}
                             <div style={{ fontSize: "20px", flexShrink: "0" }}>
-                              {skill.skill_icon || "💡"}
+                              {skill.icon || "💡"}
                             </div>
 
                             {/* Skill Name */}
@@ -433,7 +433,7 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                                   color: "#E0E0E0",
                                 }}
                               >
-                                {skill.skill_name}
+                                {skill.name}
                               </div>
                             </div>
 
@@ -448,7 +448,7 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                                 flexShrink: "0",
                               }}
                             >
-                              Lv {skill.skill_level}
+                              Lv {skill.level}
                             </div>
 
                             {/* Progress Bar */}

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -125,10 +125,11 @@ export async function GET() {
 
       acc[key].skills.push({
         skill_id: skill.id,
-        skill_name: skill.name, // Use real name, no placeholder
-        skill_icon: skill.icon || "🧩", // Handle null icon case
-        skill_level: skill.level ?? 1,
+        name: skill.name,
+        icon: skill.icon || "🧩",
+        level: skill.level ?? 1,
         progress: 0,
+        cat_id: catId,
       });
       acc[key].skill_count = acc[key].skills.length;
       return acc;

--- a/src/components/skills/CategorySection.tsx
+++ b/src/components/skills/CategorySection.tsx
@@ -9,9 +9,9 @@ interface CategorySectionProps {
   skillCount: number;
   skills: Array<{
     skill_id: string;
-    skill_name: string;
-    skill_icon: string;
-    skill_level: number;
+    name: string;
+    icon: string;
+    level: number;
     progress: number | null;
   }>;
 }
@@ -51,9 +51,9 @@ export function CategorySection({
             skills.map((skill) => (
               <SkillCard
                 key={skill.skill_id}
-                icon={skill.skill_icon}
-                name={skill.skill_name}
-                level={skill.skill_level}
+                icon={skill.icon}
+                name={skill.name}
+                level={skill.level}
                 percent={skill.progress || 0}
                 skillId={skill.skill_id}
               />

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -5,10 +5,11 @@ export type MonumentCounts = Record<
 >;
 export type SkillItem = {
   skill_id: string | number;
-  skill_name: string;
-  skill_icon: string;
-  skill_level: number;
+  name: string;
+  icon: string;
+  level: number;
   progress: number;
+  cat_id: string | null;
 };
 
 export type CatItem = {


### PR DESCRIPTION
## Summary
- use `name`, `icon`, and `level` in `SkillItem`
- return skills from dashboard API with updated fields and `cat_id`
- adjust dashboard client and UI components to consume new skill structure

## Testing
- `pnpm lint` *(fails: A `require()` style import is forbidden)*
- `pnpm exec tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68af48c8a46c832ca86bef248798a2a9