### PR TITLE
refactor: unify skill fields

### DIFF
--- a/components/ui/SkillRow.tsx
+++ b/components/ui/SkillRow.tsx
@@ -41,19 +41,19 @@ export function SkillRow({ skill }: SkillRowProps) {
     <div className="flex items-center gap-3 p-3 bg-[#1E1E1E] rounded-md border border-[#333] hover:bg-[#252525] transition-colors">
       {/* Skill Icon */}
       <div className="text-xl flex-shrink-0">
-        {getSkillIcon(skill.skill_name, skill.skill_icon)}
+        {getSkillIcon(skill.name, skill.icon)}
       </div>
       
       {/* Skill Name */}
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-[#E0E0E0] truncate">
-          {skill.skill_name}
+          {skill.name}
         </div>
       </div>
       
       {/* Level Badge */}
       <div className="text-xs text-[#A0A0A0] bg-[#404040] px-2 py-1 rounded-full flex-shrink-0">
-        Lv {skill.skill_level}
+        Lv {skill.level}
       </div>
       
       {/* Progress Bar */}

--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -12,10 +12,11 @@ import type { GoalItem } from "@/types/dashboard";
 
 interface Skill {
   skill_id: string;
-  skill_name: string;
-  skill_icon: string;
-  skill_level: number;
-  progress: number | null;
+  cat_id: string;
+  name: string;
+  icon: string;
+  level: number;
+  progress: number;
 }
 
 interface Category {

--- a/src/app/(app)/dashboard/components/ClientDashboard.tsx
+++ b/src/app/(app)/dashboard/components/ClientDashboard.tsx
@@ -421,7 +421,7 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                           >
                             {/* Skill Icon */}
                             <div style={{ fontSize: "20px", flexShrink: "0" }}>
-                              {skill.skill_icon || "💡"}
+                              {skill.icon || "💡"}
                             </div>
 
                             {/* Skill Name */}
@@ -433,7 +433,7 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                                   color: "#E0E0E0",
                                 }}
                               >
-                                {skill.skill_name}
+                                {skill.name}
                               </div>
                             </div>
 
@@ -448,7 +448,7 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                                 flexShrink: "0",
                               }}
                             >
-                              Lv {skill.skill_level}
+                              Lv {skill.level}
                             </div>
 
                             {/* Progress Bar */}

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -125,9 +125,10 @@ export async function GET() {
 
       acc[key].skills.push({
         skill_id: skill.id,
-        skill_name: skill.name, // Use real name, no placeholder
-        skill_icon: skill.icon || "🧩", // Handle null icon case
-        skill_level: skill.level ?? 1,
+        cat_id: skill.cat_id,
+        name: skill.name, // Use real name, no placeholder
+        icon: skill.icon || "🧩", // Handle null icon case
+        level: skill.level ?? 1,
         progress: 0,
       });
       acc[key].skill_count = acc[key].skills.length;

--- a/src/components/skills/CategorySection.tsx
+++ b/src/components/skills/CategorySection.tsx
@@ -9,10 +9,11 @@ interface CategorySectionProps {
   skillCount: number;
   skills: Array<{
     skill_id: string;
-    skill_name: string;
-    skill_icon: string;
-    skill_level: number;
-    progress: number | null;
+    cat_id: string | number;
+    name: string;
+    icon: string;
+    level: number;
+    progress: number;
   }>;
 }
 
@@ -51,10 +52,10 @@ export function CategorySection({
             skills.map((skill) => (
               <SkillCard
                 key={skill.skill_id}
-                icon={skill.skill_icon}
-                name={skill.skill_name}
-                level={skill.skill_level}
-                percent={skill.progress || 0}
+                icon={skill.icon}
+                name={skill.name}
+                level={skill.level}
+                percent={skill.progress}
                 skillId={skill.skill_id}
               />
             ))

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -5,9 +5,10 @@ export type MonumentCounts = Record<
 >;
 export type SkillItem = {
   skill_id: string | number;
-  skill_name: string;
-  skill_icon: string;
-  skill_level: number;
+  cat_id: string | number;
+  name: string;
+  icon: string;
+  level: number;
   progress: number;
 };
 

--- a/supabase/migrations/20250827050223_add_skills_view.sql
+++ b/supabase/migrations/20250827050223_add_skills_view.sql
@@ -11,9 +11,9 @@ SELECT
   ARRAY_AGG(
     json_build_object(
       'skill_id', s.id,
-      'skill_name', COALESCE(s.name, 'Unnamed Skill'),
-      'skill_icon', COALESCE(s.icon, '💡'),
-      'skill_level', COALESCE(s.level, 1),
+      'name', COALESCE(s.name, 'Unnamed Skill'),
+      'icon', COALESCE(s.icon, '💡'),
+      'level', COALESCE(s.level, 1),
       'progress', 0
     ) ORDER BY COALESCE(s.name, 'Unnamed Skill')
   ) FILTER (WHERE s.id IS NOT NULL) as skills


### PR DESCRIPTION
## Summary
- unify SkillItem structure to standard fields
- emit unified skill objects from dashboard API
- update dashboard client and UI components to use new field names

## Testing
- `pnpm lint` *(fails: A `require()` style import is forbidden)*
- `pnpm test:run` *(fails: expected undefined to be defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af4c8d92b0832c9684d1b80abcd829