### PR TITLE
Add RLS policies for profiles table

### DIFF
--- a/supabase/migrations/20250827050224_profiles_rls.sql
+++ b/supabase/migrations/20250827050224_profiles_rls.sql
@@ -1,0 +1,30 @@
+-- Enable RLS and self-service policies for profiles
+-- This migration ensures users can only interact with their own profile
+
+-- Enable row level security on profiles table (idempotent)
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to read their own profile
+DROP POLICY IF EXISTS "profiles_select_own" ON public.profiles;
+CREATE POLICY "profiles_select_own"
+  ON public.profiles FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Allow users to update their own profile
+DROP POLICY IF EXISTS "profiles_update_own" ON public.profiles;
+CREATE POLICY "profiles_update_own"
+  ON public.profiles FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Allow users to insert a profile for themselves
+DROP POLICY IF EXISTS "profiles_insert_own" ON public.profiles;
+CREATE POLICY "profiles_insert_own"
+  ON public.profiles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Optionally allow users to delete their own profile
+DROP POLICY IF EXISTS "profiles_delete_own" ON public.profiles;
+CREATE POLICY "profiles_delete_own"
+  ON public.profiles FOR DELETE
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- ensure profiles table has RLS policies allowing users to select, insert, update, or delete only their own row

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af479d2b3c832c944edf028636f246