### PR TITLE
Enhance profile image uploads with drag-and-drop, cropping and validation

### DIFF
--- a/components/ui/dropzone.tsx
+++ b/components/ui/dropzone.tsx
@@ -1,0 +1,64 @@
+import React, { useRef, useState } from "react";
+
+interface DropzoneProps {
+  onDrop: (file: File) => void;
+  accept?: string;
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function Dropzone({ onDrop, accept, className = "", children }: DropzoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) {
+      onDrop(file);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onDrop(file);
+    }
+  };
+
+  const openFileDialog = () => {
+    inputRef.current?.click();
+  };
+
+  return (
+    <div
+      onClick={openFileDialog}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      className={`border-2 border-dashed rounded-lg cursor-pointer flex items-center justify-center text-center p-2 transition-colors ${isDragging ? "border-blue-500 bg-blue-50" : "border-gray-300 hover:border-blue-400"} ${className}`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={handleFileChange}
+      />
+      {children || <p className="text-sm text-gray-500">Drop or click to upload</p>}
+    </div>
+  );
+}
+
+export default Dropzone;

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,6 +1,7 @@
 export { PageShell } from "./PageShell";
 export { SectionCard } from "./SectionCard";
 export { Progress } from "./Progress";
+export { Dropzone } from "./dropzone";
 export { MonumentCard } from "./MonumentCard";
 export { SkillPill } from "./SkillPill";
 export { GoalList } from "./GoalList";

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -220,8 +220,8 @@ export async function getProfileByUsername(
 export async function updateProfile(
   userId: string,
   profileData: ProfileFormData,
-  avatarUrl?: string,
-  bannerUrl?: string
+  avatarUrl?: string | null,
+  bannerUrl?: string | null
 ): Promise<ProfileUpdateResult> {
   try {
     console.log("🔍 updateProfile called with userId:", userId);
@@ -244,11 +244,11 @@ export async function updateProfile(
       accent_color: profileData.accent_color,
     };
 
-    // Add avatar and banner URLs if provided
-    if (avatarUrl) {
+    // Add avatar and banner URLs if provided (allow explicit null)
+    if (avatarUrl !== undefined) {
       updateData.avatar_url = avatarUrl;
     }
-    if (bannerUrl) {
+    if (bannerUrl !== undefined) {
       updateData.banner_url = bannerUrl;
     }
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -8,7 +8,8 @@ export interface AvatarUploadResult {
 
 export async function uploadAvatar(
   file: File,
-  userId: string
+  userId: string,
+  onProgress?: (percent: number) => void
 ): Promise<AvatarUploadResult> {
   const supabase = getSupabaseBrowser();
   if (!supabase) {
@@ -36,6 +37,12 @@ export async function uploadAvatar(
       .upload(fileName, file, {
         cacheControl: "3600",
         upsert: false,
+        onUploadProgress: (event) => {
+          if (event.total) {
+            const percent = (event.loaded / event.total) * 100;
+            onProgress?.(Math.round(percent));
+          }
+        },
       });
 
     if (error) {
@@ -52,6 +59,57 @@ export async function uploadAvatar(
   } catch (error) {
     console.error("Error in uploadAvatar:", error);
     return { success: false, error: "Failed to upload avatar" };
+  }
+}
+
+export async function uploadBanner(
+  file: File,
+  userId: string,
+  onProgress?: (percent: number) => void
+): Promise<AvatarUploadResult> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    return { success: false, error: "Supabase client not initialized" };
+  }
+
+  try {
+    if (!file.type.startsWith("image/")) {
+      return { success: false, error: "File must be an image" };
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      return { success: false, error: "File size must be less than 5MB" };
+    }
+
+    const fileExt = file.name.split(".").pop();
+    const fileName = `${userId}-banner-${Date.now()}.${fileExt}`;
+
+    const { data, error } = await supabase.storage
+      .from("banners")
+      .upload(fileName, file, {
+        cacheControl: "3600",
+        upsert: false,
+        onUploadProgress: (event) => {
+          if (event.total) {
+            const percent = (event.loaded / event.total) * 100;
+            onProgress?.(Math.round(percent));
+          }
+        },
+      });
+
+    if (error) {
+      console.error("Error uploading banner:", error);
+      return { success: false, error: error.message };
+    }
+
+    const { data: urlData } = supabase.storage
+      .from("banners")
+      .getPublicUrl(fileName);
+
+    return { success: true, url: urlData.publicUrl };
+  } catch (error) {
+    console.error("Error in uploadBanner:", error);
+    return { success: false, error: "Failed to upload banner" };
   }
 }
 
@@ -74,6 +132,27 @@ export async function deleteAvatar(avatarUrl: string): Promise<boolean> {
     return true;
   } catch (error) {
     console.error("Error in deleteAvatar:", error);
+    return false;
+  }
+}
+
+export async function deleteBanner(bannerUrl: string): Promise<boolean> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return false;
+
+  try {
+    const urlParts = bannerUrl.split("/");
+    const fileName = urlParts[urlParts.length - 1];
+    const { error } = await supabase.storage.from("banners").remove([fileName]);
+
+    if (error) {
+      console.error("Error deleting banner:", error);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error("Error in deleteBanner:", error);
     return false;
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "next": "^15.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-image-crop": "^11.0.10",
     "tailwind-merge": "^2.0.0",
     "zod": "^4.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.1(react@19.1.1)
+      react-image-crop:
+        specifier: ^11.0.10
+        version: 11.0.10(react@19.1.1)
       tailwind-merge:
         specifier: ^2.0.0
         version: 2.6.0
@@ -2541,6 +2544,11 @@ packages:
     resolution: {integrity: sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==}
     peerDependencies:
       react: ^19.1.1
+
+  react-image-crop@11.0.10:
+    resolution: {integrity: sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5508,6 +5516,10 @@ snapshots:
     dependencies:
       react: 19.1.1
       scheduler: 0.26.0
+
+  react-image-crop@11.0.10(react@19.1.1):
+    dependencies:
+      react: 19.1.1
 
   react-is@16.13.1: {}
 

--- a/src/app/(app)/profile/edit/page.tsx
+++ b/src/app/(app)/profile/edit/page.tsx
@@ -1,15 +1,21 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { getProfileByUserId, updateProfile } from "@/lib/db";
+import { getProfileByUserId, updateProfile, getProfileByUsername } from "@/lib/db";
 import { Profile, ProfileFormData } from "@/lib/types";
+import { uploadAvatar, uploadBanner, deleteAvatar, deleteBanner } from "@/lib/storage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Dropzone } from "@/components/ui/dropzone";
+import { Progress } from "@/components/ui/Progress";
+import ReactCrop, { Crop, PixelCrop } from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
 import { ArrowLeft, Save, User, Calendar, MapPin, FileText } from "lucide-react";
 import Link from "next/link";
 
@@ -29,6 +35,24 @@ export default function ProfileEditPage() {
     city: "",
     bio: "",
   });
+
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [bannerFile, setBannerFile] = useState<File | null>(null);
+  const [bannerPreview, setBannerPreview] = useState<string | null>(null);
+  const [avatarProgress, setAvatarProgress] = useState(0);
+  const [bannerProgress, setBannerProgress] = useState(0);
+
+  const [isCropOpen, setIsCropOpen] = useState(false);
+  const [cropImageSrc, setCropImageSrc] = useState<string>("");
+  const [cropType, setCropType] = useState<"avatar" | "banner" | null>(null);
+  const [crop, setCrop] = useState<Crop>({ unit: "%", width: 100, aspect: 1 });
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop | null>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const originalFileRef = useRef<File | null>(null);
+
+  const [usernameAvailable, setUsernameAvailable] = useState<boolean | null>(null);
+  const [checkingUsername, setCheckingUsername] = useState(false);
 
   useEffect(() => {
     async function loadProfile() {
@@ -50,6 +74,8 @@ export default function ProfileEditPage() {
             city: userProfile.city || "",
             bio: userProfile.bio || "",
           });
+          setAvatarPreview(userProfile.avatar_url || null);
+          setBannerPreview(userProfile.banner_url || null);
         }
       } catch (err) {
         console.error("Error loading profile:", err);
@@ -62,6 +88,26 @@ export default function ProfileEditPage() {
     loadProfile();
   }, [session, router]);
 
+  useEffect(() => {
+    if (!formData.username) {
+      setUsernameAvailable(null);
+      return;
+    }
+
+    const handler = setTimeout(async () => {
+      setCheckingUsername(true);
+      const existing = await getProfileByUsername(formData.username);
+      if (!existing || existing.user_id === session?.user?.id) {
+        setUsernameAvailable(true);
+      } else {
+        setUsernameAvailable(false);
+      }
+      setCheckingUsername(false);
+    }, 500);
+
+    return () => clearTimeout(handler);
+  }, [formData.username, session?.user?.id]);
+
   const handleInputChange = (field: keyof ProfileFormData, value: string) => {
     setFormData(prev => ({
       ...prev,
@@ -69,11 +115,107 @@ export default function ProfileEditPage() {
     }));
   };
 
+  const startCrop = (file: File, type: "avatar" | "banner") => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      setCropImageSrc(event.target?.result as string);
+      setCropType(type);
+      setIsCropOpen(true);
+      originalFileRef.current = file;
+      setCrop({ unit: "%", width: 100, aspect: type === "avatar" ? 1 : 16 / 9 });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleAvatarSelect = (file: File) => {
+    startCrop(file, "avatar");
+  };
+
+  const handleBannerSelect = (file: File) => {
+    startCrop(file, "banner");
+  };
+
+  const onImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    imgRef.current = e.currentTarget;
+  };
+
+  const handleCropConfirm = async () => {
+    if (!imgRef.current || !completedCrop || !originalFileRef.current) return;
+
+    const canvas = document.createElement("canvas");
+    const scaleX = imgRef.current.naturalWidth / imgRef.current.width;
+    const scaleY = imgRef.current.naturalHeight / imgRef.current.height;
+    canvas.width = completedCrop.width * scaleX;
+    canvas.height = completedCrop.height * scaleY;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.drawImage(
+      imgRef.current,
+      completedCrop.x * scaleX,
+      completedCrop.y * scaleY,
+      completedCrop.width * scaleX,
+      completedCrop.height * scaleY,
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    );
+
+    const blob: Blob | null = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b), originalFileRef.current!.type)
+    );
+    if (!blob) return;
+    const croppedFile = new File([blob], originalFileRef.current!.name, {
+      type: originalFileRef.current!.type,
+    });
+    const previewUrl = URL.createObjectURL(blob);
+
+    if (cropType === "avatar") {
+      setAvatarFile(croppedFile);
+      setAvatarPreview(previewUrl);
+    } else {
+      setBannerFile(croppedFile);
+      setBannerPreview(previewUrl);
+    }
+
+    setIsCropOpen(false);
+    setCropImageSrc("");
+    setCompletedCrop(null);
+  };
+
+  const handleRemoveAvatar = async () => {
+    if (!session?.user?.id) return;
+    if (profile?.avatar_url) {
+      await deleteAvatar(profile.avatar_url);
+      await updateProfile(session.user.id, formData, null, undefined);
+      setProfile({ ...profile, avatar_url: null });
+    }
+    setAvatarFile(null);
+    setAvatarPreview(null);
+  };
+
+  const handleRemoveBanner = async () => {
+    if (!session?.user?.id) return;
+    if (profile?.banner_url) {
+      await deleteBanner(profile.banner_url);
+      await updateProfile(session.user.id, formData, undefined, null);
+      setProfile({ ...profile, banner_url: null });
+    }
+    setBannerFile(null);
+    setBannerPreview(null);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!session?.user?.id) {
       setError("Not authenticated");
+      return;
+    }
+
+    if (usernameAvailable === false) {
+      setError("Username is already taken");
       return;
     }
 
@@ -81,12 +223,48 @@ export default function ProfileEditPage() {
       setSaving(true);
       setError(null);
 
-      const result = await updateProfile(session.user.id, formData);
+      let avatarUrl: string | undefined;
+      let bannerUrl: string | undefined;
+
+      if (avatarFile) {
+        setAvatarProgress(0);
+        const uploadRes = await uploadAvatar(avatarFile, session.user.id, setAvatarProgress);
+        if (!uploadRes.success || !uploadRes.url) {
+          setError(uploadRes.error || "Failed to upload profile picture");
+          setSaving(false);
+          setAvatarProgress(0);
+          return;
+        }
+        avatarUrl = uploadRes.url;
+        setAvatarProgress(100);
+      }
+
+      if (bannerFile) {
+        setBannerProgress(0);
+        const uploadRes = await uploadBanner(bannerFile, session.user.id, setBannerProgress);
+        if (!uploadRes.success || !uploadRes.url) {
+          setError(uploadRes.error || "Failed to upload cover photo");
+          setSaving(false);
+          setBannerProgress(0);
+          return;
+        }
+        bannerUrl = uploadRes.url;
+        setBannerProgress(100);
+      }
+
+      const result = await updateProfile(
+        session.user.id,
+        formData,
+        avatarUrl,
+        bannerUrl
+      );
       
       if (result.success && result.profile) {
         setSuccess(true);
         setProfile(result.profile);
-        
+        setAvatarPreview(result.profile.avatar_url || null);
+        setBannerPreview(result.profile.banner_url || null);
+
         // Redirect to profile page after a short delay
         setTimeout(() => {
           router.push("/profile");
@@ -99,6 +277,8 @@ export default function ProfileEditPage() {
       setError("An unexpected error occurred");
     } finally {
       setSaving(false);
+      setAvatarProgress(0);
+      setBannerProgress(0);
     }
   };
 
@@ -171,6 +351,69 @@ export default function ProfileEditPage() {
             )}
 
             <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Cover Photo */}
+              <div className="space-y-2">
+                <Label>Cover Photo</Label>
+                <Dropzone
+                  onDrop={handleBannerSelect}
+                  accept="image/*"
+                  className="w-full h-40 bg-gray-100 rounded-lg overflow-hidden"
+                >
+                  {bannerPreview ? (
+                    <img
+                      src={bannerPreview}
+                      alt="Cover preview"
+                      className="object-cover w-full h-full"
+                    />
+                  ) : (
+                    <p className="text-gray-500 text-sm">Drag & drop or click</p>
+                  )}
+                </Dropzone>
+                {bannerPreview && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleRemoveBanner}
+                  >
+                    Remove
+                  </Button>
+                )}
+              </div>
+
+              {/* Profile Picture */}
+              <div className="space-y-2">
+                <Label>Profile Picture</Label>
+                <div className="flex items-center space-x-4">
+                  <Dropzone
+                    onDrop={handleAvatarSelect}
+                    accept="image/*"
+                    className="h-24 w-24 rounded-full overflow-hidden flex-shrink-0"
+                  >
+                    <Avatar className="h-24 w-24">
+                      {avatarPreview && (
+                        <AvatarImage src={avatarPreview} alt="Avatar preview" />
+                      )}
+                      <AvatarFallback>
+                        {formData.name
+                          ? formData.name.charAt(0)
+                          : formData.username.charAt(0)}
+                      </AvatarFallback>
+                    </Avatar>
+                  </Dropzone>
+                  {avatarPreview && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleRemoveAvatar}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </div>
+              </div>
+
               {/* Name */}
               <div className="space-y-2">
                 <Label htmlFor="name" className="flex items-center space-x-2">
@@ -204,6 +447,15 @@ export default function ProfileEditPage() {
                 <p className="text-sm text-gray-500">
                   This will be your unique identifier: @{formData.username || "username"}
                 </p>
+                {checkingUsername && (
+                  <p className="text-sm text-gray-500">Checking availability...</p>
+                )}
+                {usernameAvailable && formData.username && (
+                  <p className="text-sm text-green-600">Username available</p>
+                )}
+                {usernameAvailable === false && (
+                  <p className="text-sm text-red-600">Username already taken</p>
+                )}
               </div>
 
               {/* Bio */}
@@ -256,10 +508,22 @@ export default function ProfileEditPage() {
               </div>
 
               {/* Submit Button */}
-              <div className="pt-6">
+              <div className="pt-6 space-y-4">
+                {avatarProgress > 0 && avatarProgress < 100 && (
+                  <div>
+                    <p className="text-sm text-gray-700 mb-1">Uploading avatar: {avatarProgress}%</p>
+                    <Progress value={avatarProgress} />
+                  </div>
+                )}
+                {bannerProgress > 0 && bannerProgress < 100 && (
+                  <div>
+                    <p className="text-sm text-gray-700 mb-1">Uploading cover: {bannerProgress}%</p>
+                    <Progress value={bannerProgress} />
+                  </div>
+                )}
                 <Button
                   type="submit"
-                  disabled={saving}
+                  disabled={saving || usernameAvailable === false}
                   className="w-full h-14 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white text-lg font-semibold rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"
                 >
                   {saving ? (
@@ -279,6 +543,28 @@ export default function ProfileEditPage() {
           </CardContent>
         </Card>
       </div>
+      {isCropOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white p-4 rounded-lg max-w-lg w-full">
+            <ReactCrop
+              crop={crop}
+              onChange={(c) => setCrop(c)}
+              onComplete={(c) => setCompletedCrop(c)}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={cropImageSrc} onLoad={onImageLoad} alt="Crop" />
+            </ReactCrop>
+            <div className="flex justify-end space-x-2 mt-4">
+              <Button variant="ghost" type="button" onClick={() => setIsCropOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={handleCropConfirm}>
+                Crop
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable Dropzone component for drag-and-drop uploads
- support avatar and banner cropping, removal and upload progress
- validate username availability inline before saving

## Testing
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b1fb85ee9c832ca051769814acfee5