### PR TITLE
Revamp goals page with interactive cards and dropdowns

### DIFF
--- a/src/app/(app)/goals/_components/CreateGoalDrawer.tsx
+++ b/src/app/(app)/goals/_components/CreateGoalDrawer.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Goal, GoalPriority } from "./types";
+
+interface CreateGoalDrawerProps {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  onCreate: (goal: Goal) => void;
+}
+
+export function CreateGoalDrawer({ open, setOpen, onCreate }: CreateGoalDrawerProps) {
+  const [title, setTitle] = useState("");
+  const [emoji, setEmoji] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [priority, setPriority] = useState<GoalPriority>("Low");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    const newGoal: Goal = {
+      id: Date.now().toString(),
+      title,
+      emoji,
+      dueDate,
+      priority,
+      progress: 0,
+      status: "Active",
+      updatedAt: new Date().toISOString(),
+      projects: [],
+    };
+    onCreate(newGoal);
+    setOpen(false);
+    setTitle("");
+    setEmoji("");
+    setDueDate("");
+    setPriority("Low");
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Create Goal</SheetTitle>
+        </SheetHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+          <Input
+            required
+            placeholder="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="bg-gray-800 border-gray-700"
+          />
+          <Input
+            placeholder="Emoji"
+            value={emoji}
+            onChange={(e) => setEmoji(e.target.value)}
+            className="bg-gray-800 border-gray-700"
+          />
+          <Input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+            className="bg-gray-800 border-gray-700"
+          />
+          <select
+            value={priority}
+            onChange={(e) => setPriority(e.target.value as GoalPriority)}
+            className="rounded-md bg-gray-800 border border-gray-700 px-3 py-2 text-sm"
+          >
+            <option value="Low">Low</option>
+            <option value="Medium">Medium</option>
+            <option value="High">High</option>
+          </select>
+          <SheetFooter>
+            <Button type="submit">Add Goal</Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/(app)/goals/_components/EmptyState.tsx
+++ b/src/app/(app)/goals/_components/EmptyState.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  onCreate: () => void;
+}
+
+export function EmptyState({ onCreate }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <p className="mb-4 text-gray-400">No goals yet</p>
+      <Button onClick={onCreate}>Create Goal</Button>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/_components/GoalCard.tsx
+++ b/src/app/(app)/goals/_components/GoalCard.tsx
@@ -47,7 +47,7 @@ export function GoalCard({ goal, isOpen, onToggle, loading }: GoalCardProps) {
             />
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-400">
-            <Progress value={goal.progress} className="w-20" />
+            <Progress value={goal.progress ?? 0} className="w-20" />
             {goal.dueDate && (
               <Badge variant="outline" className="text-xs">
                 {goal.dueDate}
@@ -58,7 +58,7 @@ export function GoalCard({ goal, isOpen, onToggle, loading }: GoalCardProps) {
                 {goal.priority}
               </Badge>
             )}
-            <span>{goal.projects.length} proj</span>
+            <span>{goal.projectCount ?? goal.projects.length} proj</span>
           </div>
         </button>
         <DropdownMenu>

--- a/src/app/(app)/goals/_components/GoalCard.tsx
+++ b/src/app/(app)/goals/_components/GoalCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Goal } from "./types";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/Progress";
+import { ProjectsDropdown } from "./ProjectsDropdown";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { ChevronDown, MoreVertical } from "lucide-react";
+
+interface GoalCardProps {
+  goal: Goal;
+  isOpen: boolean;
+  onToggle: () => void;
+  loading: boolean;
+}
+
+export function GoalCard({ goal, isOpen, onToggle, loading }: GoalCardProps) {
+  const priorityVariant =
+    goal.priority === "High"
+      ? "destructive"
+      : goal.priority === "Medium"
+      ? "default"
+      : "secondary";
+
+  return (
+    <div className="rounded-lg bg-gray-800 p-4 shadow-sm">
+      <div className="flex items-start justify-between">
+        <button
+          onClick={onToggle}
+          aria-expanded={isOpen}
+          aria-controls={`goal-${goal.id}`}
+          className="flex-1 text-left motion-safe:transition-transform active:scale-95"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 min-w-0">
+              {goal.emoji && <span className="text-xl">{goal.emoji}</span>}
+              <span className="truncate font-medium">{goal.title}</span>
+            </div>
+            <ChevronDown
+              className={`size-4 shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+            />
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-gray-400">
+            <Progress value={goal.progress} className="w-20" />
+            {goal.dueDate && (
+              <Badge variant="outline" className="text-xs">
+                {goal.dueDate}
+              </Badge>
+            )}
+            {goal.priority && (
+              <Badge variant={priorityVariant} className="text-xs capitalize">
+                {goal.priority}
+              </Badge>
+            )}
+            <span>{goal.projects.length} proj</span>
+          </div>
+        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="ml-2">
+              <MoreVertical className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+            <DropdownMenuItem>Mark Done</DropdownMenuItem>
+            <DropdownMenuItem>Delete</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <ProjectsDropdown goal={goal} isOpen={isOpen} loading={loading} />
+    </div>
+  );
+}

--- a/src/app/(app)/goals/_components/GoalsHeader.tsx
+++ b/src/app/(app)/goals/_components/GoalsHeader.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface GoalsHeaderProps {
+  onOpenCreate: () => void;
+}
+
+export function GoalsHeader({ onOpenCreate }: GoalsHeaderProps) {
+  return (
+    <header className="flex items-center justify-between py-4">
+      <div>
+        <h1 className="text-2xl font-semibold">Goals</h1>
+        <p className="text-sm text-gray-400">Track and manage your goals</p>
+      </div>
+      <Button onClick={onOpenCreate} className="shrink-0">
+        + Create Goal
+      </Button>
+    </header>
+  );
+}

--- a/src/app/(app)/goals/_components/GoalsUtilityBar.tsx
+++ b/src/app/(app)/goals/_components/GoalsUtilityBar.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { ListIcon, GridIcon } from "lucide-react";
+import { Dispatch, SetStateAction } from "react";
+
+export type FilterType = "All" | "Active" | "Completed" | "Overdue";
+export type SortType = "az" | "due" | "progress" | "updated";
+export type ViewType = "grid" | "list";
+
+interface GoalsUtilityBarProps {
+  search: string;
+  setSearch: Dispatch<SetStateAction<string>>;
+  filter: FilterType;
+  setFilter: Dispatch<SetStateAction<FilterType>>;
+  sort: SortType;
+  setSort: Dispatch<SetStateAction<SortType>>;
+  view: ViewType;
+  setView: Dispatch<SetStateAction<ViewType>>;
+}
+
+const filters: FilterType[] = ["All", "Active", "Completed", "Overdue"];
+
+export function GoalsUtilityBar({
+  search,
+  setSearch,
+  filter,
+  setFilter,
+  sort,
+  setSort,
+  view,
+  setView,
+}: GoalsUtilityBarProps) {
+  return (
+    <div className="sticky top-0 z-10 bg-gray-900 py-2 space-y-2">
+      <Input
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search goals"
+        className="w-full bg-gray-800 border-gray-700"
+      />
+      <div className="flex items-center gap-2 overflow-x-auto">
+        {filters.map((f) => (
+          <Button
+            key={f}
+            onClick={() => setFilter(f)}
+            variant={f === filter ? "default" : "outline"}
+            className="rounded-full px-3 py-1 text-sm"
+          >
+            {f}
+          </Button>
+        ))}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortType)}
+          className="ml-auto rounded-md bg-gray-800 text-sm px-2 py-1 border border-gray-700"
+        >
+          <option value="az">A→Z</option>
+          <option value="due">Due Soon</option>
+          <option value="progress">Progress</option>
+          <option value="updated">Recently Updated</option>
+        </select>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setView(view === "grid" ? "list" : "grid")}
+        >
+          {view === "grid" ? <ListIcon className="size-4" /> : <GridIcon className="size-4" />}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/_components/LoadingSkeleton.tsx
+++ b/src/app/(app)/goals/_components/LoadingSkeleton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function LoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between py-4">
+        <div>
+          <Skeleton className="mb-2 h-7 w-24" />
+          <Skeleton className="h-4 w-40" />
+        </div>
+        <Skeleton className="h-10 w-32" />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} className="h-36 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/_components/ProjectRow.tsx
+++ b/src/app/(app)/goals/_components/ProjectRow.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/Progress";
+import { Project } from "./types";
+
+interface ProjectRowProps {
+  project: Project;
+}
+
+export function ProjectRow({ project }: ProjectRowProps) {
+  return (
+    <div className="flex items-center justify-between py-2">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{project.name}</p>
+        <div className="mt-1 flex items-center gap-2">
+          <Badge variant="outline" className="text-xs capitalize">
+            {project.status}
+          </Badge>
+          <Progress value={project.progress} className="w-24" />
+          {project.dueDate && (
+            <span className="text-xs text-gray-400">{project.dueDate}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/_components/ProjectRow.tsx
+++ b/src/app/(app)/goals/_components/ProjectRow.tsx
@@ -14,10 +14,12 @@ export function ProjectRow({ project }: ProjectRowProps) {
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">{project.name}</p>
         <div className="mt-1 flex items-center gap-2">
-          <Badge variant="outline" className="text-xs capitalize">
-            {project.status}
-          </Badge>
-          <Progress value={project.progress} className="w-24" />
+          {project.status && (
+            <Badge variant="outline" className="text-xs capitalize">
+              {project.status}
+            </Badge>
+          )}
+          <Progress value={project.progress ?? 0} className="w-24" />
           {project.dueDate && (
             <span className="text-xs text-gray-400">{project.dueDate}</span>
           )}

--- a/src/app/(app)/goals/_components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/_components/ProjectsDropdown.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ProjectRow } from "./ProjectRow";
+import { Goal } from "./types";
+
+interface ProjectsDropdownProps {
+  goal: Goal;
+  isOpen: boolean;
+  loading: boolean;
+}
+
+export function ProjectsDropdown({ goal, isOpen, loading }: ProjectsDropdownProps) {
+  return (
+    <div
+      id={`goal-${goal.id}`}
+      role="region"
+      aria-label={`Projects for ${goal.title}`}
+      className={cn(
+        "overflow-hidden transition-all motion-safe:duration-300",
+        isOpen ? "max-h-screen opacity-100 pt-2" : "max-h-0 opacity-0"
+      )}
+    >
+      {loading ? (
+        <div className="space-y-2">
+          {[...Array(3)].map((_, i) => (
+            <Skeleton key={i} className="h-6 w-full" />
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-400">
+            Projects for {goal.title}
+          </p>
+          {goal.projects.length === 0 ? (
+            <div className="flex items-center gap-2 text-sm text-gray-400">
+              <span>No projects linked yet</span>
+              <Button variant="link" className="h-auto p-0 text-sm">
+                Add Project
+              </Button>
+            </div>
+          ) : (
+            goal.projects.map((p) => <ProjectRow key={p.id} project={p} />)
+          )}
+          <Button variant="link" className="h-auto p-0 text-xs">
+            View all projects
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/goals/_components/types.ts
+++ b/src/app/(app)/goals/_components/types.ts
@@ -3,8 +3,8 @@ export type ProjectStatus = "Todo" | "In-Progress" | "Done";
 export interface Project {
   id: string;
   name: string;
-  status: ProjectStatus;
-  progress: number;
+  status?: ProjectStatus;
+  progress?: number;
   dueDate?: string;
 }
 
@@ -17,8 +17,9 @@ export interface Goal {
   emoji?: string;
   dueDate?: string;
   priority?: GoalPriority;
-  progress: number;
-  status: GoalStatus;
-  updatedAt: string;
+  progress?: number;
+  status?: GoalStatus;
+  updatedAt?: string;
+  projectCount?: number;
   projects: Project[];
 }

--- a/src/app/(app)/goals/_components/types.ts
+++ b/src/app/(app)/goals/_components/types.ts
@@ -1,0 +1,24 @@
+export type ProjectStatus = "Todo" | "In-Progress" | "Done";
+
+export interface Project {
+  id: string;
+  name: string;
+  status: ProjectStatus;
+  progress: number;
+  dueDate?: string;
+}
+
+export type GoalStatus = "Active" | "Completed" | "Overdue";
+export type GoalPriority = "Low" | "Medium" | "High";
+
+export interface Goal {
+  id: string;
+  title: string;
+  emoji?: string;
+  dueDate?: string;
+  priority?: GoalPriority;
+  progress: number;
+  status: GoalStatus;
+  updatedAt: string;
+  projects: Project[];
+}

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -156,7 +156,7 @@ export default function GoalsPage() {
         case "due":
           return (a.dueDate || "").localeCompare(b.dueDate || "");
         case "progress":
-          return b.progress - a.progress;
+          return (b.progress ?? 0) - (a.progress ?? 0);
         case "updated":
           return (
             new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
-import { Goal, GoalPriority, ProjectStatus, GoalStatus } from "./_components/types";
+import { Goal } from "./_components/types";
 import { GoalsHeader } from "./_components/GoalsHeader";
 import {
   GoalsUtilityBar,
@@ -14,8 +14,85 @@ import { GoalCard } from "./_components/GoalCard";
 import { CreateGoalDrawer } from "./_components/CreateGoalDrawer";
 import { LoadingSkeleton } from "./_components/LoadingSkeleton";
 import { EmptyState } from "./_components/EmptyState";
-import { getSupabaseBrowser } from "@/lib/supabase";
-import { useAuth } from "@/components/auth/AuthProvider";
+
+const initialGoals: Goal[] = [
+  {
+    id: "1",
+    title: "Build portfolio",
+    emoji: "💼",
+    dueDate: "2025-03-01",
+    priority: "High",
+    progress: 30,
+    status: "Active",
+    updatedAt: "2025-01-05",
+    projectCount: 3,
+    projects: [
+      { id: "p1", name: "Design", status: "In-Progress", progress: 60 },
+      { id: "p2", name: "Develop", status: "Todo", progress: 0 },
+      { id: "p3", name: "Deploy", status: "Todo", progress: 0 },
+    ],
+  },
+  {
+    id: "2",
+    title: "Learn guitar",
+    emoji: "🎸",
+    dueDate: "2025-02-15",
+    priority: "Medium",
+    progress: 80,
+    status: "Completed",
+    updatedAt: "2025-02-10",
+    projectCount: 2,
+    projects: [
+      { id: "p4", name: "Chords practice", status: "Done", progress: 100 },
+      { id: "p5", name: "Song library", status: "Done", progress: 100 },
+    ],
+  },
+  {
+    id: "3",
+    title: "Plan vacation",
+    emoji: "🏖️",
+    dueDate: "2024-12-20",
+    priority: "Low",
+    progress: 20,
+    status: "Overdue",
+    updatedAt: "2024-12-25",
+    projectCount: 2,
+    projects: [
+      { id: "p6", name: "Book flights", status: "Todo", progress: 0 },
+      { id: "p7", name: "Reserve hotel", status: "Todo", progress: 0 },
+    ],
+  },
+  {
+    id: "4",
+    title: "Read books",
+    emoji: "📚",
+    dueDate: "2025-04-30",
+    priority: "Medium",
+    progress: 50,
+    status: "Active",
+    updatedAt: "2025-03-01",
+    projectCount: 2,
+    projects: [
+      { id: "p8", name: "Fiction", status: "In-Progress", progress: 40 },
+      { id: "p9", name: "Non-fiction", status: "Todo", progress: 0 },
+    ],
+  },
+  {
+    id: "5",
+    title: "Fitness routine",
+    emoji: "💪",
+    dueDate: "2025-05-20",
+    priority: "High",
+    progress: 10,
+    status: "Active",
+    updatedAt: "2025-03-05",
+    projectCount: 2,
+    projects: [
+      { id: "p10", name: "Cardio", status: "Todo", progress: 0 },
+      { id: "p11", name: "Strength", status: "Todo", progress: 0 },
+    ],
+  },
+];
 
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);
@@ -29,71 +106,13 @@ export default function GoalsPage() {
   const [loadingProjects, setLoadingProjects] = useState<Record<string, boolean>>({});
   const [drawerOpen, setDrawerOpen] = useState(false);
 
-  const { session } = useAuth();
-  const supabase = getSupabaseBrowser();
-
-  const mapPriority = (p?: string): GoalPriority | undefined => {
-    if (!p) return undefined;
-    const map: Record<string, GoalPriority> = {
-      LOW: "Low",
-      MEDIUM: "Medium",
-      HIGH: "High",
-    };
-    return map[p as keyof typeof map];
-  };
-
-  const mapStage = (s?: string): ProjectStatus => {
-    if (!s) return "Todo";
-    const stage = s.toLowerCase();
-    if (stage.includes("progress")) return "In-Progress";
-    if (stage.includes("done")) return "Done";
-    return "Todo";
-  };
-
   useEffect(() => {
-    const loadGoals = async () => {
-      if (!supabase || !session?.user) {
-        setLoading(false);
-        return;
-      }
-      try {
-        const { data, error } = await supabase
-          .from("goals")
-          .select(
-            "id, name, priority, updated_at, created_at, projects (id, name, stage, created_at)"
-          )
-          .eq("user_id", session.user.id)
-          .order("updated_at", { ascending: false });
-
-        if (error) throw error;
-
-        const mapped = (data || []).map((g) => ({
-          id: g.id,
-          title: g.name,
-          priority: mapPriority(g.priority),
-          progress: 0,
-          status: "Active" as GoalStatus,
-          updatedAt: g.updated_at || g.created_at,
-          projectCount: g.projects ? g.projects.length : 0,
-          projects: (g.projects || []).map(
-            (p: { id: string; name: string; stage: string }) => ({
-              id: p.id,
-              name: p.name,
-              status: mapStage(p.stage),
-              progress: 0,
-            })
-          ),
-        }));
-        setGoals(mapped);
-      } catch (e) {
-        console.error("Error loading goals", e);
-        setGoals([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-    loadGoals();
-  }, [supabase, session?.user]);
+    const t = setTimeout(() => {
+      setGoals(initialGoals);
+      setLoading(false);
+    }, 400);
+    return () => clearTimeout(t);
+  }, []);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 200);

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -1,20 +1,248 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
-import { PageHeader } from "@/components/ui";
-import { GoalList } from "@/components/ui/GoalList";
+import { Goal } from "./_components/types";
+import { GoalsHeader } from "./_components/GoalsHeader";
+import {
+  GoalsUtilityBar,
+  FilterType,
+  SortType,
+  ViewType,
+} from "./_components/GoalsUtilityBar";
+import { GoalCard } from "./_components/GoalCard";
+import { CreateGoalDrawer } from "./_components/CreateGoalDrawer";
+import { LoadingSkeleton } from "./_components/LoadingSkeleton";
+import { EmptyState } from "./_components/EmptyState";
+
+const initialGoals: Goal[] = [
+  {
+    id: "1",
+    title: "Learn Guitar",
+    emoji: "🎸",
+    dueDate: "2024-12-01",
+    priority: "High",
+    progress: 40,
+    status: "Active",
+    updatedAt: "2024-05-20",
+    projects: [
+      {
+        id: "p1",
+        name: "Practice chords",
+        status: "In-Progress",
+        progress: 60,
+        dueDate: "2024-06-10",
+      },
+      {
+        id: "p2",
+        name: "Learn song",
+        status: "Todo",
+        progress: 0,
+      },
+    ],
+  },
+  {
+    id: "2",
+    title: "Read 12 Books",
+    emoji: "📚",
+    dueDate: "2024-12-31",
+    priority: "Medium",
+    progress: 70,
+    status: "Active",
+    updatedAt: "2024-05-18",
+    projects: [
+      {
+        id: "p3",
+        name: "Finish Dune",
+        status: "Done",
+        progress: 100,
+      },
+      {
+        id: "p4",
+        name: "Start 1984",
+        status: "Todo",
+        progress: 0,
+      },
+    ],
+  },
+  {
+    id: "3",
+    title: "Build Portfolio",
+    emoji: "💻",
+    dueDate: "2024-07-01",
+    priority: "High",
+    progress: 90,
+    status: "Completed",
+    updatedAt: "2024-05-10",
+    projects: [
+      {
+        id: "p5",
+        name: "Design layout",
+        status: "Done",
+        progress: 100,
+      },
+      {
+        id: "p6",
+        name: "Deploy site",
+        status: "Done",
+        progress: 100,
+      },
+    ],
+  },
+  {
+    id: "4",
+    title: "Plan Vacation",
+    emoji: "🏖️",
+    dueDate: "2024-05-15",
+    priority: "Low",
+    progress: 20,
+    status: "Overdue",
+    updatedAt: "2024-04-30",
+    projects: [
+      {
+        id: "p7",
+        name: "Book flights",
+        status: "Todo",
+        progress: 0,
+      },
+      {
+        id: "p8",
+        name: "Reserve hotel",
+        status: "Todo",
+        progress: 0,
+      },
+    ],
+  },
+  {
+    id: "5",
+    title: "Meditation Habit",
+    emoji: "🧘",
+    priority: "Low",
+    progress: 10,
+    status: "Active",
+    updatedAt: "2024-05-25",
+    projects: [],
+  },
+];
 
 export default function GoalsPage() {
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [filter, setFilter] = useState<FilterType>("All");
+  const [sort, setSort] = useState<SortType>("az");
+  const [view, setView] = useState<ViewType>("grid");
+  const [openGoals, setOpenGoals] = useState<Set<string>>(new Set());
+  const [loadingProjects, setLoadingProjects] = useState<Record<string, boolean>>({});
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    setGoals(initialGoals);
+    const timer = setTimeout(() => setLoading(false), 500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 200);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const handleToggle = (id: string) => {
+    setOpenGoals((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+        setLoadingProjects((lp) => ({ ...lp, [id]: true }));
+        setTimeout(
+          () => setLoadingProjects((lp) => ({ ...lp, [id]: false })),
+          400
+        );
+      }
+      return next;
+    });
+  };
+
+  const filteredGoals = goals
+    .filter((goal) => {
+      const term = debouncedSearch.toLowerCase();
+      if (!term) return true;
+      const inGoal = goal.title.toLowerCase().includes(term);
+      const inProject = goal.projects.some((p) =>
+        p.name.toLowerCase().includes(term)
+      );
+      return inGoal || inProject;
+    })
+    .filter((goal) => (filter === "All" ? true : goal.status === filter))
+    .sort((a, b) => {
+      switch (sort) {
+        case "az":
+          return a.title.localeCompare(b.title);
+        case "due":
+          return (a.dueDate || "").localeCompare(b.dueDate || "");
+        case "progress":
+          return b.progress - a.progress;
+        case "updated":
+          return (
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+          );
+        default:
+          return 0;
+      }
+    });
+
+  const addGoal = (goal: Goal) => {
+    setGoals((prev) => [...prev, goal]);
+  };
+
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gray-900 text-white">
-        <div className="container mx-auto px-4 py-6">
-          <PageHeader
-            title="Goals"
-            description="Track and manage your personal goals"
-          />
-          <GoalList />
-        </div>
+      <div className="min-h-screen bg-gray-900 p-4 text-white">
+        {loading ? (
+          <LoadingSkeleton />
+        ) : (
+          <>
+            <GoalsHeader onOpenCreate={() => setDrawerOpen(true)} />
+            <GoalsUtilityBar
+              search={search}
+              setSearch={setSearch}
+              filter={filter}
+              setFilter={setFilter}
+              sort={sort}
+              setSort={setSort}
+              view={view}
+              setView={setView}
+            />
+            {filteredGoals.length === 0 ? (
+              <EmptyState onCreate={() => setDrawerOpen(true)} />
+            ) : (
+              <div
+                className={
+                  view === "grid"
+                    ? "mt-4 grid grid-cols-2 gap-4"
+                    : "mt-4 space-y-4"
+                }
+              >
+                {filteredGoals.map((goal) => (
+                  <GoalCard
+                    key={goal.id}
+                    goal={goal}
+                    isOpen={openGoals.has(goal.id)}
+                    onToggle={() => handleToggle(goal.id)}
+                    loading={!!loadingProjects[goal.id]}
+                  />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+        <CreateGoalDrawer
+          open={drawerOpen}
+          setOpen={setDrawerOpen}
+          onCreate={addGoal}
+        />
       </div>
     </ProtectedRoute>
   );


### PR DESCRIPTION
## Summary
- redesign goals page with mobile-first goal cards and project dropdowns
- add search, filter, and sort utility bar with grid/list toggle
- include create-goal drawer and loading/empty states using mock data

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b22bb82ad8832c95a778b6df6748e4