### PR TITLE
feat: add linked accounts to profiles

### DIFF
--- a/create_linked_accounts_table.sql
+++ b/create_linked_accounts_table.sql
@@ -1,0 +1,43 @@
+-- Create linked_accounts table for storing external social links
+CREATE TABLE IF NOT EXISTS public.linked_accounts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  platform text NOT NULL,
+  url text NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Ensure one link per user per platform
+CREATE UNIQUE INDEX IF NOT EXISTS linked_accounts_user_platform_idx
+  ON public.linked_accounts (user_id, platform);
+
+-- Trigger to update updated_at automatically
+DROP TRIGGER IF EXISTS linked_accounts_set_updated_at ON public.linked_accounts;
+CREATE TRIGGER linked_accounts_set_updated_at
+  BEFORE UPDATE ON public.linked_accounts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at();
+
+-- Enable RLS
+ALTER TABLE public.linked_accounts ENABLE ROW LEVEL SECURITY;
+
+-- Policies
+DROP POLICY IF EXISTS "linked_accounts read" ON public.linked_accounts;
+CREATE POLICY "linked_accounts read" ON public.linked_accounts
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "linked_accounts insert self" ON public.linked_accounts;
+CREATE POLICY "linked_accounts insert self" ON public.linked_accounts
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "linked_accounts update self" ON public.linked_accounts;
+CREATE POLICY "linked_accounts update self" ON public.linked_accounts
+  FOR UPDATE USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "linked_accounts delete self" ON public.linked_accounts;
+CREATE POLICY "linked_accounts delete self" ON public.linked_accounts
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Permissions
+GRANT ALL ON public.linked_accounts TO authenticated;

--- a/lib/db/linked-accounts.ts
+++ b/lib/db/linked-accounts.ts
@@ -1,0 +1,113 @@
+import { getSupabaseBrowser } from "../supabase";
+import { LinkedAccount } from "../types";
+
+export type SupportedPlatform =
+  | "instagram"
+  | "tiktok"
+  | "youtube"
+  | "spotify"
+  | "snapchat"
+  | "facebook"
+  | "twitter";
+
+export const PLATFORM_CONFIG: Record<
+  SupportedPlatform,
+  { label: string; domain: string; color: string }
+> = {
+  instagram: {
+    label: "Instagram",
+    domain: "instagram.com",
+    color: "#E1306C",
+  },
+  tiktok: { label: "TikTok", domain: "tiktok.com", color: "#010101" },
+  youtube: { label: "YouTube", domain: "youtube.com", color: "#FF0000" },
+  spotify: { label: "Spotify", domain: "spotify.com", color: "#1DB954" },
+  snapchat: { label: "Snapchat", domain: "snapchat.com", color: "#FFFC00" },
+  facebook: { label: "Facebook", domain: "facebook.com", color: "#1877F2" },
+  twitter: { label: "X/Twitter", domain: "twitter.com", color: "#000000" },
+};
+
+export async function getLinkedAccounts(
+  userId: string
+): Promise<LinkedAccount[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return [];
+
+  const { data, error } = await supabase
+    .from("linked_accounts")
+    .select("*")
+    .eq("user_id", userId);
+
+  if (error) {
+    console.error("Error fetching linked accounts:", error);
+    return [];
+  }
+
+  return data as LinkedAccount[];
+}
+
+export async function upsertLinkedAccount(
+  userId: string,
+  platform: SupportedPlatform,
+  url: string
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    return { success: false, error: "Supabase client not initialized" };
+  }
+
+  const { error } = await supabase
+    .from("linked_accounts")
+    .upsert(
+      { user_id: userId, platform, url },
+      { onConflict: "user_id,platform" }
+    );
+
+  if (error) {
+    console.error("Error upserting linked account:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function deleteLinkedAccount(
+  userId: string,
+  platform: SupportedPlatform
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    return { success: false, error: "Supabase client not initialized" };
+  }
+
+  const { error } = await supabase
+    .from("linked_accounts")
+    .delete()
+    .eq("user_id", userId)
+    .eq("platform", platform);
+
+  if (error) {
+    console.error("Error deleting linked account:", error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+export function validateLinkedAccountUrl(
+  platform: SupportedPlatform,
+  url: string
+): { valid: boolean; cleaned?: string; error?: string } {
+  try {
+    const config = PLATFORM_CONFIG[platform];
+    const parsed = new URL(url.startsWith("http") ? url : `https://${url}`);
+    if (!parsed.hostname.includes(config.domain)) {
+      return { valid: false, error: `URL must be on ${config.domain}` };
+    }
+    parsed.search = ""; // remove query params
+    const cleaned = `${parsed.protocol}//${parsed.hostname}${parsed.pathname}`;
+    return { valid: true, cleaned };
+  } catch {
+    return { valid: false, error: "Invalid URL" };
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -116,6 +116,15 @@ export interface Profile {
 }
 
 // Social Links
+export interface LinkedAccount {
+  id: string;
+  user_id: string;
+  platform: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface SocialLink {
   id: string;
   user_id: string;
@@ -171,6 +180,12 @@ export interface ProfileFormData {
   accent_color?: string;
 }
 
+// Linked Account Form Data
+export interface LinkedAccountFormData {
+  platform: string;
+  url: string;
+}
+
 // Social Link Form Data
 export interface SocialLinkFormData {
   platform: string;
@@ -195,6 +210,13 @@ export interface ProfileUpdateResult {
   success: boolean;
   error?: string;
   profile?: Profile;
+}
+
+// Linked Account Update Result
+export interface LinkedAccountUpdateResult {
+  success: boolean;
+  error?: string;
+  account?: LinkedAccount;
 }
 
 // Social Link Update Result
@@ -289,6 +311,11 @@ export interface Database {
         Row: Profile;
         Insert: Omit<Profile, "id" | "created_at" | "updated_at">;
         Update: Partial<Omit<Profile, "id" | "created_at" | "updated_at">>;
+      };
+      linked_accounts: {
+        Row: LinkedAccount;
+        Insert: Omit<LinkedAccount, "id" | "created_at" | "updated_at">;
+        Update: Partial<Omit<LinkedAccount, "id" | "created_at" | "updated_at">>;
       };
       social_links: {
         Row: SocialLink;

--- a/src/app/(app)/profile/ProfileContent.tsx
+++ b/src/app/(app)/profile/ProfileContent.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, MapPin, User, Edit3 } from "lucide-react";
+import LinkedAccountsBar from "@/components/profile/LinkedAccountsBar";
 
 interface Profile {
   user_id: string;
@@ -50,12 +53,17 @@ export default function ProfileContent({
     <div className="container mx-auto px-4 py-6 max-w-2xl">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">Profile</h1>
-        <Link href="/profile/edit">
-          <Button variant="outline" size="sm">
-            <Edit3 className="h-4 w-4 mr-2" />
-            Edit
-          </Button>
-        </Link>
+        <div className="space-x-2">
+          <Link href="/profile/linked-accounts">
+            <Button variant="outline" size="sm">Links</Button>
+          </Link>
+          <Link href="/profile/edit">
+            <Button variant="outline" size="sm">
+              <Edit3 className="h-4 w-4 mr-2" />
+              Edit
+            </Button>
+          </Link>
+        </div>
       </div>
 
       <Card>
@@ -74,6 +82,7 @@ export default function ProfileContent({
             {profile.name || "No name set"}
           </CardTitle>
           <p className="text-gray-600 text-lg">@{profile.username}</p>
+          <LinkedAccountsBar userId={profile.user_id} />
         </CardHeader>
 
         <CardContent className="space-y-4">

--- a/src/app/(app)/profile/edit/page.tsx
+++ b/src/app/(app)/profile/edit/page.tsx
@@ -197,13 +197,18 @@ export default function ProfileEditPage() {
       {/* Header */}
       <div className="bg-[#15161A] border-b border-white/5">
         <div className="max-w-2xl mx-auto px-4 py-4">
-          <div className="flex items-center space-x-4">
-            <Link href="/profile">
-              <Button variant="ghost" size="sm" className="p-2">
-                <ArrowLeft className="h-5 w-5" />
-              </Button>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-4">
+              <Link href="/profile">
+                <Button variant="ghost" size="sm" className="p-2">
+                  <ArrowLeft className="h-5 w-5" />
+                </Button>
+              </Link>
+              <h1 className="text-2xl font-bold text-zinc-100">Edit Profile</h1>
+            </div>
+            <Link href="/profile/linked-accounts">
+              <Button variant="outline" size="sm">Linked Accounts</Button>
             </Link>
-            <h1 className="text-2xl font-bold text-zinc-100">Edit Profile</h1>
           </div>
         </div>
       </div>

--- a/src/app/(app)/profile/linked-accounts/LinkedAccountsForm.tsx
+++ b/src/app/(app)/profile/linked-accounts/LinkedAccountsForm.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  PLATFORM_CONFIG,
+  SupportedPlatform,
+  getLinkedAccounts,
+  upsertLinkedAccount,
+  deleteLinkedAccount,
+  validateLinkedAccountUrl,
+} from "@/lib/db/linked-accounts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Instagram,
+  Youtube,
+  Twitter,
+  Music,
+  Music2,
+  Ghost,
+  Facebook,
+  LucideIcon,
+} from "lucide-react";
+
+const ICON_MAP: Record<SupportedPlatform, LucideIcon> = {
+  instagram: Instagram,
+  tiktok: Music2,
+  youtube: Youtube,
+  spotify: Music,
+  snapchat: Ghost,
+  facebook: Facebook,
+  twitter: Twitter,
+};
+
+interface AccountState {
+  id?: string;
+  url: string;
+}
+
+export default function LinkedAccountsForm() {
+  const { session } = useAuth();
+  const userId = session?.user?.id;
+  const [accounts, setAccounts] = useState<Record<SupportedPlatform, AccountState>>({
+    instagram: { url: "" },
+    tiktok: { url: "" },
+    youtube: { url: "" },
+    spotify: { url: "" },
+    snapchat: { url: "" },
+    facebook: { url: "" },
+    twitter: { url: "" },
+  });
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!userId) return;
+      const data = await getLinkedAccounts(userId);
+      setAccounts((prev) => {
+        const copy = { ...prev };
+        data.forEach((acc) => {
+          const platform = acc.platform as SupportedPlatform;
+          copy[platform] = { id: acc.id, url: acc.url };
+        });
+        return copy;
+      });
+    }
+    load();
+  }, [userId]);
+
+  const handleSave = async (platform: SupportedPlatform) => {
+    if (!userId) return;
+    setError(null);
+    const url = accounts[platform].url.trim();
+    const { valid, cleaned, error } = validateLinkedAccountUrl(platform, url);
+    if (!valid || !cleaned) {
+      setError(error || "Invalid URL");
+      return;
+    }
+    setSaving(platform);
+    const { success, error: saveError } = await upsertLinkedAccount(
+      userId,
+      platform,
+      cleaned
+    );
+    setSaving(null);
+    if (success) {
+      setSuccess(`${PLATFORM_CONFIG[platform].label} link saved`);
+    } else {
+      setError(saveError || "Failed to save link");
+    }
+  };
+
+  const handleRemove = async (platform: SupportedPlatform) => {
+    if (!userId) return;
+    setSaving(platform);
+    const { success, error: delError } = await deleteLinkedAccount(userId, platform);
+    setSaving(null);
+    if (success) {
+      setAccounts((prev) => ({ ...prev, [platform]: { url: "" } }));
+      setSuccess(`${PLATFORM_CONFIG[platform].label} link removed`);
+    } else {
+      setError(delError || "Failed to remove link");
+    }
+  };
+
+  const renderRow = (platform: SupportedPlatform) => {
+    const Icon = ICON_MAP[platform];
+    const config = PLATFORM_CONFIG[platform];
+    const value = accounts[platform]?.url || "";
+    return (
+      <div key={platform} className="flex items-center space-x-3 py-2">
+        <Icon className="h-5 w-5" style={{ color: config.color }} />
+        <Input
+          value={value}
+          onChange={(e) =>
+            setAccounts((prev) => ({
+              ...prev,
+              [platform]: { ...prev[platform], url: e.target.value },
+            }))
+          }
+          placeholder={`https://${config.domain}/username`}
+          className="flex-1"
+        />
+        <Button
+          onClick={() => handleSave(platform)}
+          disabled={saving === platform}
+          size="sm"
+        >
+          Save
+        </Button>
+        {value && (
+          <Button
+            variant="outline"
+            onClick={() => handleRemove(platform)}
+            disabled={saving === platform}
+            size="sm"
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    );
+  };
+
+  const platformKeys: SupportedPlatform[] = [
+    "instagram",
+    "tiktok",
+    "youtube",
+    "spotify",
+    "snapchat",
+    "facebook",
+    "twitter",
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Linked Accounts</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {error && <p className="text-sm text-red-500 mb-2">{error}</p>}
+        {success && <p className="text-sm text-green-500 mb-2">{success}</p>}
+        {platformKeys.map((p) => renderRow(p))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(app)/profile/linked-accounts/page.tsx
+++ b/src/app/(app)/profile/linked-accounts/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import LinkedAccountsForm from "./LinkedAccountsForm";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function LinkedAccountsPage() {
+  return (
+    <div className="container mx-auto px-4 py-6 max-w-2xl">
+      <div className="flex items-center space-x-4 mb-6">
+        <Link href="/profile">
+          <Button variant="ghost" size="sm" className="p-2">
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+        </Link>
+        <h1 className="text-2xl font-bold">Linked Accounts</h1>
+      </div>
+      <LinkedAccountsForm />
+    </div>
+  );
+}

--- a/src/app/(app)/u/[username]/PublicProfileContent.tsx
+++ b/src/app/(app)/u/[username]/PublicProfileContent.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Calendar, MapPin, User } from "lucide-react";
 import { getProfileByUsername } from "@/lib/db";
 import { Profile } from "@/lib/types";
+import LinkedAccountsBar from "@/components/profile/LinkedAccountsBar";
 
 interface PublicProfileContentProps {
   username: string;
@@ -94,6 +95,7 @@ export default function PublicProfileContent({
                 <Badge variant="secondary">@{profile.username}</Badge>
               </div>
               {profile.bio && <p className="text-gray-600">{profile.bio}</p>}
+              <LinkedAccountsBar userId={profile.user_id} />
             </div>
           </div>
         </CardContent>

--- a/src/components/profile/LinkedAccountsBar.tsx
+++ b/src/components/profile/LinkedAccountsBar.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getLinkedAccounts,
+  PLATFORM_CONFIG,
+  SupportedPlatform,
+} from "@/lib/db/linked-accounts";
+import { LinkedAccount } from "@/lib/types";
+import {
+  Instagram,
+  Youtube,
+  Twitter,
+  Music,
+  Music2,
+  Ghost,
+  Facebook,
+  LucideIcon,
+} from "lucide-react";
+
+const ICON_MAP: Record<SupportedPlatform, LucideIcon> = {
+  instagram: Instagram,
+  tiktok: Music2,
+  youtube: Youtube,
+  spotify: Music,
+  snapchat: Ghost,
+  facebook: Facebook,
+  twitter: Twitter,
+};
+
+interface Props {
+  userId: string;
+}
+
+export default function LinkedAccountsBar({ userId }: Props) {
+  const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const data = await getLinkedAccounts(userId);
+      setAccounts(data);
+    }
+    load();
+  }, [userId]);
+
+  if (accounts.length === 0) return null;
+
+  return (
+    <div className="flex space-x-3 justify-center mt-4">
+      {accounts.map((acc) => {
+        const platform = acc.platform as SupportedPlatform;
+        const Icon = ICON_MAP[platform];
+        const color = PLATFORM_CONFIG[platform].color;
+        return (
+          <a
+            key={acc.platform}
+            href={acc.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2 rounded-full bg-gray-100 hover:bg-gray-200"
+            style={{ color }}
+          >
+            {Icon && <Icon className="h-5 w-5" />}
+          </a>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `linked_accounts` table with RLS policies
- allow users to manage external profile links
- show linked account icons on profile pages

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b22bf92c10832cab7ef51a0c3abdda