### PR TITLE
feat: redesign goals page with interactive cards

### DIFF
--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -8,7 +8,12 @@ import { GoalCardGrid } from "@/components/ui/GoalCardGrid";
 import { MonumentContainer } from "@/components/ui/MonumentContainer";
 import CategorySection from "@/components/skills/CategorySection";
 import { SkillCardSkeleton } from "@/components/skills/SkillCardSkeleton";
-import type { GoalItem } from "@/types/dashboard";
+import { LoadingSkeleton } from "@/app/(app)/goals/components/LoadingSkeleton";
+import { EmptyState } from "@/app/(app)/goals/components/EmptyState";
+import type { Goal, Project, Task } from "@/app/(app)/goals/types";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import { getGoalsForUser } from "@/lib/queries/goals";
+import { getProjectsForUser } from "@/lib/queries/projects";
 
 interface Skill {
   skill_id: string;
@@ -28,7 +33,7 @@ interface Category {
 
 export default function DashboardClient() {
   const [categories, setCategories] = useState<Category[]>([]);
-  const [goals, setGoals] = useState<GoalItem[]>([]);
+  const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -37,22 +42,149 @@ export default function DashboardClient() {
 
   const fetchDashboardData = async () => {
     try {
-      const response = await fetch("/api/dashboard");
-      const data = await response.json();
-      
+      const dashboardFetch = fetch("/api/dashboard").then((res) => res.json());
+      const goalsList = loadGoals();
+
+      const [data, goalsData] = await Promise.all([dashboardFetch, goalsList]);
+
       // Debug logging
       console.log("🔍 Dashboard API response:", data);
       console.log("🔍 Categories data:", data.skillsAndGoals?.cats);
-      console.log("🔍 Goals data:", data.skillsAndGoals?.goals);
-      
+
       setCategories(data.skillsAndGoals?.cats || []);
-      setGoals(data.skillsAndGoals?.goals || []);
+      setGoals(goalsData);
     } catch (error) {
       console.error("Error fetching dashboard data:", error);
     } finally {
       setLoading(false);
     }
   };
+
+  const mapPriority = (priority: string): Goal["priority"] => {
+    switch (priority) {
+      case "HIGH":
+      case "CRITICAL":
+      case "ULTRA-CRITICAL":
+        return "High";
+      case "MEDIUM":
+        return "Medium";
+      default:
+        return "Low";
+    }
+  };
+
+  const projectStageToStatus = (stage: string): Project["status"] => {
+    switch (stage) {
+      case "RESEARCH":
+        return "Todo";
+      case "RELEASE":
+        return "Done";
+      default:
+        return "In-Progress";
+    }
+  };
+
+  const taskStageToStatus = (stage: string): Task["status"] => {
+    switch (stage) {
+      case "PERFECT":
+        return "Done";
+      case "PREPARE":
+        return "Todo";
+      default:
+        return "In-Progress";
+    }
+  };
+
+  const loadGoals = async (): Promise<Goal[]> => {
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return [];
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return [];
+
+    const [goalsData, projectsData, tasksRes] = await Promise.all([
+      getGoalsForUser(user.id),
+      getProjectsForUser(user.id),
+      supabase
+        .from("tasks")
+        .select("id, project_id, name, stage")
+        .eq("user_id", user.id),
+    ]);
+
+    const tasksData = tasksRes.data || [];
+    const tasksByProject = tasksData.reduce(
+      (acc: Record<string, Task[]>, task) => {
+        if (!task.project_id) return acc;
+        const t: Task = {
+          id: task.id,
+          name: task.name,
+          status: taskStageToStatus(task.stage),
+        };
+        acc[task.project_id] = acc[task.project_id] || [];
+        acc[task.project_id].push(t);
+        return acc;
+      },
+      {}
+    );
+
+    const projectsByGoal = new Map<string, Project[]>();
+    projectsData.forEach((p) => {
+      const tasks = tasksByProject[p.id] || [];
+      const total = tasks.length;
+      const done = tasks.filter((t) => t.status === "Done").length;
+      const progress = total ? Math.round((done / total) * 100) : 0;
+      const status = projectStageToStatus(p.stage);
+      const proj: Project = {
+        id: p.id,
+        name: p.name,
+        status,
+        progress,
+        tasks,
+      };
+      const list = projectsByGoal.get(p.goal_id) || [];
+      list.push(proj);
+      projectsByGoal.set(p.goal_id, list);
+    });
+
+    const realGoals: Goal[] = goalsData.map((g) => {
+      const projList = projectsByGoal.get(g.id) || [];
+      const activeProjects = projList.filter((p) => p.status !== "Done");
+      const progress =
+        projList.length > 0
+          ? Math.round(
+              projList.reduce((sum, p) => sum + p.progress, 0) /
+                projList.length
+            )
+          : 0;
+      return {
+        id: g.id,
+        title: g.name,
+        priority: mapPriority(g.priority),
+        progress,
+        status: progress >= 100 ? "Completed" : "Active",
+        updatedAt: g.created_at,
+        projects: activeProjects,
+        active: progress < 100,
+      };
+    });
+
+    return realGoals.filter((g) => g.active);
+  };
+
+  const toggleActive = (id: string) =>
+    setGoals((g) =>
+      g.map((goal) =>
+        goal.id === id
+          ? {
+              ...goal,
+              active: !goal.active,
+              status: !goal.active ? "Active" : goal.status,
+            }
+          : goal
+      )
+    );
 
   return (
     <main className="pb-20">
@@ -89,11 +221,17 @@ export default function DashboardClient() {
         title={<Link href="/goals">Current Goals</Link>}
         className="safe-bottom mt-2 px-4"
       >
-        <GoalCardGrid
-          goals={goals}
-          loading={loading}
-          showLinks={false} // Set to true if /goals/[id] route exists
-        />
+        {loading ? (
+          <LoadingSkeleton />
+        ) : goals.length === 0 ? (
+          <EmptyState onCreate={() => {}} />
+        ) : (
+          <GoalCardGrid
+            goals={goals}
+            onEdit={() => {}}
+            onToggleActive={toggleActive}
+          />
+        )}
       </Section>
     </main>
   );

--- a/src/app/(app)/goals/components/CreateGoalDrawer.tsx
+++ b/src/app/(app)/goals/components/CreateGoalDrawer.tsx
@@ -1,39 +1,51 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Goal } from "../types";
 
 interface CreateGoalDrawerProps {
   open: boolean;
   onClose(): void;
-  onAdd(goal: Goal): void;
+  onSave(goal: Goal): void;
+  goal?: Goal;
 }
 
-export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps) {
+export function CreateGoalDrawer({ open, onClose, onSave, goal }: CreateGoalDrawerProps) {
   const [title, setTitle] = useState("");
   const [emoji, setEmoji] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [priority, setPriority] = useState<Goal["priority"]>("Low");
 
+  useEffect(() => {
+    if (goal) {
+      setTitle(goal.title);
+      setEmoji(goal.emoji || "");
+      setDueDate(goal.dueDate || "");
+      setPriority(goal.priority);
+    } else {
+      setTitle("");
+      setEmoji("");
+      setDueDate("");
+      setPriority("Low");
+    }
+  }, [goal, open]);
+
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title) return;
     const newGoal: Goal = {
-      id: Date.now().toString(),
+      id: goal?.id || Date.now().toString(),
       title,
       emoji,
       dueDate: dueDate || undefined,
       priority,
-      progress: 0,
-      status: "Active",
+      progress: goal?.progress ?? 0,
+      status: goal?.status ?? "Active",
       updatedAt: new Date().toISOString(),
-      projects: [],
+      projects: goal?.projects ?? [],
+      active: goal?.active ?? true,
     };
-    onAdd(newGoal);
-    setTitle("");
-    setEmoji("");
-    setDueDate("");
-    setPriority("Low");
+    onSave(newGoal);
     onClose();
   };
 
@@ -43,7 +55,7 @@ export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
       <div className="absolute right-0 top-0 h-full w-80 bg-gray-800 p-4 overflow-y-auto">
-        <h2 className="text-lg font-semibold mb-4">Create Goal</h2>
+        <h2 className="text-lg font-semibold mb-4">{goal ? "Edit Goal" : "Create Goal"}</h2>
         <form onSubmit={submit} className="space-y-4">
           <div>
             <label className="block text-sm mb-1">Title *</label>
@@ -88,7 +100,7 @@ export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps
               Cancel
             </button>
             <button type="submit" className="px-3 py-2 rounded bg-blue-600">
-              Add
+              {goal ? "Save" : "Add"}
             </button>
           </div>
         </form>

--- a/src/app/(app)/goals/components/CreateGoalDrawer.tsx
+++ b/src/app/(app)/goals/components/CreateGoalDrawer.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import type { Goal } from "../types";
+
+interface CreateGoalDrawerProps {
+  open: boolean;
+  onClose(): void;
+  onAdd(goal: Goal): void;
+}
+
+export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps) {
+  const [title, setTitle] = useState("");
+  const [emoji, setEmoji] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [priority, setPriority] = useState<Goal["priority"]>("Low");
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title) return;
+    const newGoal: Goal = {
+      id: Date.now().toString(),
+      title,
+      emoji,
+      dueDate: dueDate || undefined,
+      priority,
+      progress: 0,
+      status: "Active",
+      updatedAt: new Date().toISOString(),
+      projects: [],
+    };
+    onAdd(newGoal);
+    setTitle("");
+    setEmoji("");
+    setDueDate("");
+    setPriority("Low");
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className="absolute right-0 top-0 h-full w-80 bg-gray-800 p-4 overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-4">Create Goal</h2>
+        <form onSubmit={submit} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Title *</label>
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Emoji</label>
+            <input
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Due Date</label>
+            <input
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Priority</label>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as Goal["priority"])}
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            >
+              <option value="Low">Low</option>
+              <option value="Medium">Medium</option>
+              <option value="High">High</option>
+            </select>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-3 py-2 rounded bg-gray-700">
+              Cancel
+            </button>
+            <button type="submit" className="px-3 py-2 rounded bg-blue-600">
+              Add
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/components/EmptyState.tsx
+++ b/src/app/(app)/goals/components/EmptyState.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+interface EmptyStateProps {
+  onCreate(): void;
+}
+
+export function EmptyState({ onCreate }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center space-y-4">
+      <div className="text-5xl" role="img" aria-label="target">
+        🎯
+      </div>
+      <p className="text-gray-400">No goals yet</p>
+      <button
+        onClick={onCreate}
+        className="bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded-md text-sm"
+      >
+        Create Goal
+      </button>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -7,9 +7,11 @@ import { ProjectsDropdown } from "./ProjectsDropdown";
 
 interface GoalCardProps {
   goal: Goal;
+  onEdit(goal: Goal): void;
+  onToggleActive(id: string): void;
 }
 
-export function GoalCard({ goal }: GoalCardProps) {
+export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -79,13 +81,28 @@ export function GoalCard({ goal }: GoalCardProps) {
           </button>
           {menuOpen && (
             <ul className="absolute right-0 mt-1 bg-gray-700 rounded shadow-lg text-sm z-10">
-              {['Edit','Mark Done','Delete'].map((act) => (
-                <li key={act}>
-                  <button className="block w-full text-left px-3 py-1 hover:bg-gray-600">
-                    {act}
-                  </button>
-                </li>
-              ))}
+              <li>
+                <button
+                  className="block w-full text-left px-3 py-1 hover:bg-gray-600"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onEdit(goal);
+                  }}
+                >
+                  Edit
+                </button>
+              </li>
+              <li>
+                <button
+                  className="block w-full text-left px-3 py-1 hover:bg-gray-600"
+                  onClick={() => {
+                    setMenuOpen(false);
+                    onToggleActive(goal.id);
+                  }}
+                >
+                  {goal.active ? "Mark Inactive" : "Mark Active"}
+                </button>
+              </li>
             </ul>
           )}
         </div>

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, MoreHorizontal } from "lucide-react";
+import type { Goal } from "../types";
+import { ProjectsDropdown } from "./ProjectsDropdown";
+
+interface GoalCardProps {
+  goal: Goal;
+}
+
+export function GoalCard({ goal }: GoalCardProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggle = () => {
+    setOpen((o) => !o);
+    if (!open) {
+      setLoading(true);
+      setTimeout(() => setLoading(false), 500);
+    }
+  };
+
+  const priorityColor =
+    goal.priority === "High"
+      ? "bg-red-600"
+      : goal.priority === "Medium"
+      ? "bg-yellow-600"
+      : "bg-green-600";
+
+  return (
+    <div className="bg-gray-800 rounded-lg shadow text-left">
+      <div className="relative">
+        <button
+          onClick={toggle}
+          aria-expanded={open}
+          aria-controls={`goal-${goal.id}`}
+          className="w-full flex items-start justify-between p-4 active:scale-95 transition-transform motion-safe:duration-150 motion-reduce:transform-none"
+        >
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              {goal.emoji && <span className="text-xl" aria-hidden>{goal.emoji}</span>}
+              <span id={`goal-${goal.id}-label`} className="font-medium truncate">
+                {goal.title}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-300">
+              <div className="w-10 h-2 bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-blue-500"
+                  style={{ width: `${goal.progress}%` }}
+                />
+              </div>
+              {goal.dueDate && (
+                <span className="px-2 py-0.5 bg-gray-700 rounded-full">
+                  {new Date(goal.dueDate).toLocaleDateString()}
+                </span>
+              )}
+              <span className={`px-2 py-0.5 rounded-full ${priorityColor}`}>
+                {goal.priority}
+              </span>
+              <span className="px-2 py-0.5 bg-gray-700 rounded-full">
+                {goal.projects.length} projects
+              </span>
+            </div>
+          </div>
+          <ChevronDown
+            className={`w-5 h-5 ml-2 transition-transform ${open ? "rotate-180" : ""}`}
+          />
+        </button>
+        <div className="absolute top-2 right-2">
+          <button
+            aria-label="Goal actions"
+            onClick={() => setMenuOpen((m) => !m)}
+            className="p-1 rounded bg-gray-700"
+          >
+            <MoreHorizontal className="w-4 h-4" />
+          </button>
+          {menuOpen && (
+            <ul className="absolute right-0 mt-1 bg-gray-700 rounded shadow-lg text-sm z-10">
+              {['Edit','Mark Done','Delete'].map((act) => (
+                <li key={act}>
+                  <button className="block w-full text-left px-3 py-1 hover:bg-gray-600">
+                    {act}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+      <ProjectsDropdown
+        id={`goal-${goal.id}`}
+        goalTitle={goal.title}
+        projects={goal.projects}
+        open={open}
+        loading={loading}
+      />
+    </div>
+  );
+}

--- a/src/app/(app)/goals/components/GoalsHeader.tsx
+++ b/src/app/(app)/goals/components/GoalsHeader.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { Plus } from "lucide-react";
+
+interface GoalsHeaderProps {
+  onCreate(): void;
+}
+
+export function GoalsHeader({ onCreate }: GoalsHeaderProps) {
+  return (
+    <header className="px-4 py-4 flex items-center justify-between bg-gray-900">
+      <div>
+        <h1 className="text-2xl font-bold">Goals</h1>
+        <p className="text-sm text-gray-400">Track and manage your goals</p>
+      </div>
+      <button
+        onClick={onCreate}
+        className="flex items-center gap-2 bg-blue-600 hover:bg-blue-500 active:bg-blue-700 px-3 py-2 rounded-md text-sm"
+      >
+        <Plus className="w-4 h-4" /> Create Goal
+      </button>
+    </header>
+  );
+}

--- a/src/app/(app)/goals/components/GoalsUtilityBar.tsx
+++ b/src/app/(app)/goals/components/GoalsUtilityBar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { List, LayoutGrid } from "lucide-react";
+
+export type FilterStatus = "All" | "Active" | "Completed" | "Overdue";
+export type SortOption = "A→Z" | "Due Soon" | "Progress" | "Recently Updated";
+
+interface GoalsUtilityBarProps {
+  search: string;
+  onSearch(term: string): void;
+  filter: FilterStatus;
+  onFilter(f: FilterStatus): void;
+  sort: SortOption;
+  onSort(s: SortOption): void;
+  view: "grid" | "list";
+  onViewChange(v: "grid" | "list"): void;
+}
+
+export function GoalsUtilityBar({
+  search,
+  onSearch,
+  filter,
+  onFilter,
+  sort,
+  onSort,
+  view,
+  onViewChange,
+}: GoalsUtilityBarProps) {
+  const [local, setLocal] = useState(search);
+
+  useEffect(() => {
+    const id = setTimeout(() => onSearch(local), 200);
+    return () => clearTimeout(id);
+  }, [local, onSearch]);
+
+  return (
+    <div className="sticky top-0 z-10 bg-gray-900 px-4 py-3 space-y-2">
+      <input
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        placeholder="Search goals"
+        className="w-full px-3 py-2 rounded-md bg-gray-800 text-sm focus:outline-none"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        {(["All", "Active", "Completed", "Overdue"] as FilterStatus[]).map((s) => (
+          <button
+            key={s}
+            onClick={() => onFilter(s)}
+            className={`px-3 py-1 rounded-full text-xs border border-gray-700 ${
+              filter === s ? "bg-blue-600" : "bg-gray-800"
+            }`}
+          >
+            {s}
+          </button>
+        ))}
+        <select
+          value={sort}
+          onChange={(e) => onSort(e.target.value as SortOption)}
+          className="ml-auto bg-gray-800 text-sm px-2 py-1 rounded-md"
+        >
+          <option value="A→Z">A→Z</option>
+          <option value="Due Soon">Due Soon</option>
+          <option value="Progress">Progress</option>
+          <option value="Recently Updated">Recently Updated</option>
+        </select>
+        <button
+          aria-label="Toggle view"
+          onClick={() => onViewChange(view === "grid" ? "list" : "grid")}
+          className="p-2 rounded-md bg-gray-800"
+        >
+          {view === "grid" ? <List className="w-4 h-4" /> : <LayoutGrid className="w-4 h-4" />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/components/LoadingSkeleton.tsx
+++ b/src/app/(app)/goals/components/LoadingSkeleton.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export function LoadingSkeleton() {
+  return (
+    <div className="p-4 space-y-4" data-testid="goals-loading">
+      <div className="h-8 w-32 bg-gray-800 rounded animate-pulse" />
+      <div className="grid grid-cols-2 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-32 rounded-lg bg-gray-800 animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/goals/components/ProjectRow.tsx
+++ b/src/app/(app)/goals/components/ProjectRow.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import type { Project } from "../types";
+import { TaskRow } from "./TaskRow";
+
+interface ProjectRowProps {
+  project: Project;
+}
+
+export function ProjectRow({ project }: ProjectRowProps) {
+  const [open, setOpen] = useState(false);
+  const statusColor =
+    project.status === "Done"
+      ? "bg-green-600"
+      : project.status === "In-Progress"
+      ? "bg-yellow-600"
+      : "bg-gray-600";
+
+  return (
+    <div className="border-b border-gray-700 last:border-b-0">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls={`project-${project.id}`}
+        className="w-full flex items-center justify-between py-1 active:scale-95 transition-transform motion-reduce:transform-none"
+      >
+        <div className="flex items-center gap-2">
+          <span id={`project-${project.id}-label`} className="text-sm">
+            {project.name}
+          </span>
+          <span className={`text-xs px-2 py-0.5 rounded-full ${statusColor}`}>
+            {project.status}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="w-16 h-2 bg-gray-700 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-blue-500"
+              style={{ width: `${project.progress}%` }}
+            />
+          </div>
+          {project.dueDate && (
+            <span className="text-xs text-gray-400">
+              {new Date(project.dueDate).toLocaleDateString()}
+            </span>
+          )}
+          <ChevronDown
+            className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+          />
+        </div>
+      </button>
+      <div
+        id={`project-${project.id}`}
+        role="region"
+        aria-labelledby={`project-${project.id}-label`}
+        className={`pl-4 transition-all overflow-hidden ${
+          open ? "max-h-64 opacity-100 py-2" : "max-h-0 opacity-0"
+        }`}
+      >
+        {open && (
+          project.tasks.length > 0 ? (
+            <div className="space-y-1">
+              {project.tasks.map((t) => (
+                <TaskRow key={t.id} task={t} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-sm text-gray-400">No tasks to show</div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(app)/goals/components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/components/ProjectsDropdown.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ProjectRow } from "./ProjectRow";
+import type { Project } from "../types";
+
+interface ProjectsDropdownProps {
+  id: string;
+  goalTitle: string;
+  projects: Project[];
+  open: boolean;
+  loading: boolean;
+}
+
+export function ProjectsDropdown({
+  id,
+  goalTitle,
+  projects,
+  open,
+  loading,
+}: ProjectsDropdownProps) {
+  return (
+    <div
+      id={id}
+      role="region"
+      aria-labelledby={`${id}-label`}
+      className={`px-4 transition-all overflow-hidden ${
+        open ? "max-h-96 opacity-100 py-4" : "max-h-0 opacity-0"
+      }`}
+    >
+      {open && (
+        <div>
+          <h4 className="text-sm font-medium mb-2">
+            Projects for {goalTitle}
+          </h4>
+          {loading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-6 bg-gray-800 rounded animate-pulse" />
+              ))}
+            </div>
+          ) : projects.length > 0 ? (
+            <div className="space-y-2">
+              {projects.map((p) => (
+                <ProjectRow key={p.id} project={p} />
+              ))}
+            </div>
+          ) : (
+            <div className="text-sm text-gray-400">
+              No projects linked yet
+              <button className="ml-2 text-blue-400">Add Project</button>
+            </div>
+          )}
+          <button className="mt-3 text-xs text-blue-400">View all projects</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/goals/components/TaskRow.tsx
+++ b/src/app/(app)/goals/components/TaskRow.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { Task } from "../types";
+
+interface TaskRowProps {
+  task: Task;
+}
+
+export function TaskRow({ task }: TaskRowProps) {
+  const statusColor =
+    task.status === "Done"
+      ? "bg-green-600"
+      : task.status === "In-Progress"
+      ? "bg-yellow-600"
+      : "bg-gray-600";
+
+  return (
+    <div className="flex items-center justify-between text-sm pl-2 pr-4">
+      <span>{task.name}</span>
+      <span className={`text-xs px-2 py-0.5 rounded-full ${statusColor}`}>
+        {task.status}
+      </span>
+    </div>
+  );
+}
+

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -210,7 +210,13 @@ export default function GoalsPage() {
   const toggleActive = (id: string) =>
     setGoals((g) =>
       g.map((goal) =>
-        goal.id === id ? { ...goal, active: !goal.active } : goal
+        goal.id === id
+          ? {
+              ...goal,
+              active: !goal.active,
+              status: !goal.active ? "Active" : goal.status,
+            }
+          : goal
       )
     );
 

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -1,20 +1,233 @@
 "use client";
 
+import { useState, useMemo, useEffect } from "react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
-import { PageHeader } from "@/components/ui";
-import { GoalList } from "@/components/ui/GoalList";
+import { GoalsHeader } from "./components/GoalsHeader";
+import {
+  GoalsUtilityBar,
+  FilterStatus,
+  SortOption,
+} from "./components/GoalsUtilityBar";
+import { GoalCard } from "./components/GoalCard";
+import { LoadingSkeleton } from "./components/LoadingSkeleton";
+import { EmptyState } from "./components/EmptyState";
+import { CreateGoalDrawer } from "./components/CreateGoalDrawer";
+import type { Goal, Project, Task } from "./types";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import { getGoalsForUser } from "@/lib/queries/goals";
+import { getProjectsForUser } from "@/lib/queries/projects";
+
+function mapPriority(priority: string): Goal["priority"] {
+  switch (priority) {
+    case "HIGH":
+    case "CRITICAL":
+    case "ULTRA-CRITICAL":
+      return "High";
+    case "MEDIUM":
+      return "Medium";
+    default:
+      return "Low";
+  }
+}
+
+function projectStageToStatus(stage: string): Project["status"] {
+  switch (stage) {
+    case "RESEARCH":
+      return "Todo";
+    case "RELEASE":
+      return "Done";
+    default:
+      return "In-Progress";
+  }
+}
+
+function taskStageToStatus(stage: string): Task["status"] {
+  switch (stage) {
+    case "PERFECT":
+      return "Done";
+    case "PREPARE":
+      return "Todo";
+    default:
+      return "In-Progress";
+  }
+}
 
 export default function GoalsPage() {
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [view, setView] = useState<"grid" | "list">("grid");
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<FilterStatus>("All");
+  const [sort, setSort] = useState<SortOption>("A→Z");
+  const [drawer, setDrawer] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = getSupabaseBrowser();
+      if (!supabase) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) {
+          setLoading(false);
+          return;
+        }
+
+        const [goalsData, projectsData, tasksRes] = await Promise.all([
+          getGoalsForUser(user.id),
+          getProjectsForUser(user.id),
+          supabase
+            .from("tasks")
+            .select("id, project_id, name, stage")
+            .eq("user_id", user.id),
+        ]);
+
+        const tasksData = tasksRes.data || [];
+
+        const tasksByProject = tasksData.reduce(
+          (acc: Record<string, Task[]>, task) => {
+            if (!task.project_id) return acc;
+            const t: Task = {
+              id: task.id,
+              name: task.name,
+              status: taskStageToStatus(task.stage),
+            };
+            acc[task.project_id] = acc[task.project_id] || [];
+            acc[task.project_id].push(t);
+            return acc;
+          },
+          {}
+        );
+
+        const projectsByGoal = new Map<string, Project[]>();
+        projectsData.forEach((p) => {
+          const tasks = tasksByProject[p.id] || [];
+          const total = tasks.length;
+          const done = tasks.filter((t) => t.status === "Done").length;
+          const progress = total ? Math.round((done / total) * 100) : 0;
+          const status = projectStageToStatus(p.stage);
+          const proj: Project = {
+            id: p.id,
+            name: p.name,
+            status,
+            progress,
+            tasks,
+          };
+          const list = projectsByGoal.get(p.goal_id) || [];
+          list.push(proj);
+          projectsByGoal.set(p.goal_id, list);
+        });
+
+        const realGoals: Goal[] = goalsData.map((g) => {
+          const projList = projectsByGoal.get(g.id) || [];
+          const progress =
+            projList.length > 0
+              ? Math.round(
+                  projList.reduce((sum, p) => sum + p.progress, 0) /
+                    projList.length
+                )
+              : 0;
+          return {
+            id: g.id,
+            title: g.name,
+            priority: mapPriority(g.priority),
+            progress,
+            status: progress >= 100 ? "Completed" : "Active",
+            updatedAt: g.created_at,
+            projects: projList,
+          };
+        });
+
+        setGoals(realGoals);
+      } catch (err) {
+        console.error("Error loading goals", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const filteredGoals = useMemo(() => {
+    let data = goals.filter((g) => {
+      const term = search.toLowerCase();
+      if (!term) return true;
+      const goalMatch = g.title.toLowerCase().includes(term);
+      const projectMatch = g.projects.some((p) =>
+        p.name.toLowerCase().includes(term)
+      );
+      return goalMatch || projectMatch;
+    });
+    if (filter !== "All") {
+      data = data.filter((g) => g.status === filter);
+    }
+    const sorted = [...data];
+    switch (sort) {
+      case "A→Z":
+        sorted.sort((a, b) => a.title.localeCompare(b.title));
+        break;
+      case "Due Soon":
+        sorted.sort((a, b) => {
+          const ad = a.dueDate ? Date.parse(a.dueDate) : Infinity;
+          const bd = b.dueDate ? Date.parse(b.dueDate) : Infinity;
+          return ad - bd;
+        });
+        break;
+      case "Progress":
+        sorted.sort((a, b) => b.progress - a.progress);
+        break;
+      case "Recently Updated":
+        sorted.sort(
+          (a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)
+        );
+        break;
+    }
+    return sorted;
+  }, [goals, search, filter, sort]);
+
+  const addGoal = (goal: Goal) => setGoals((g) => [goal, ...g]);
+
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gray-900 text-white">
-        <div className="container mx-auto px-4 py-6">
-          <PageHeader
-            title="Goals"
-            description="Track and manage your personal goals"
-          />
-          <GoalList />
-        </div>
+      <div className="min-h-screen bg-gray-900 text-white pb-24">
+        <GoalsHeader onCreate={() => setDrawer(true)} />
+        <GoalsUtilityBar
+          search={search}
+          onSearch={setSearch}
+          filter={filter}
+          onFilter={setFilter}
+          sort={sort}
+          onSort={setSort}
+          view={view}
+          onViewChange={setView}
+        />
+        {loading ? (
+          <LoadingSkeleton />
+        ) : filteredGoals.length === 0 ? (
+          <EmptyState onCreate={() => setDrawer(true)} />
+        ) : (
+          <div
+            className={
+              view === "grid"
+                ? "grid grid-cols-2 gap-4 p-4"
+                : "flex flex-col gap-4 p-4"
+            }
+          >
+            {filteredGoals.map((goal) => (
+              <GoalCard key={goal.id} goal={goal} />
+            ))}
+          </div>
+        )}
+        <CreateGoalDrawer
+          open={drawer}
+          onClose={() => setDrawer(false)}
+          onAdd={addGoal}
+        />
       </div>
     </ProtectedRoute>
   );

--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -1,0 +1,26 @@
+export interface Task {
+  id: string;
+  name: string;
+  status: "Todo" | "In-Progress" | "Done";
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  status: "Todo" | "In-Progress" | "Done";
+  progress: number; // 0-100
+  dueDate?: string;
+  tasks: Task[];
+}
+
+export interface Goal {
+  id: string;
+  title: string;
+  emoji?: string;
+  dueDate?: string;
+  priority: "Low" | "Medium" | "High";
+  progress: number; // 0-100
+  status: "Active" | "Completed" | "Overdue";
+  updatedAt: string;
+  projects: Project[];
+}

--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -23,4 +23,5 @@ export interface Goal {
   status: "Active" | "Completed" | "Overdue";
   updatedAt: string;
   projects: Project[];
+  active: boolean;
 }

--- a/src/components/ui/GoalCardGrid.tsx
+++ b/src/components/ui/GoalCardGrid.tsx
@@ -1,63 +1,26 @@
 "use client";
 
-import React from "react";
-import { GoalCard } from "./GoalCard";
-import { Card, CardContent } from "../../../components/ui/card";
-import { Target } from "lucide-react";
-import type { GoalItem } from "@/types/dashboard";
+import { GoalCard } from "@/app/(app)/goals/components/GoalCard";
+import type { Goal } from "@/app/(app)/goals/types";
 
 interface GoalCardGridProps {
-  goals: GoalItem[];
-  loading?: boolean;
-  showLinks?: boolean;
+  goals: Goal[];
+  onEdit(goal: Goal): void;
+  onToggleActive(id: string): void;
 }
 
-export function GoalCardGrid({
-  goals,
-  loading = false,
-  showLinks = false,
-}: GoalCardGridProps) {
-  if (loading) {
-    return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        {[...Array(6)].map((_, i) => (
-          <Card key={i} className="animate-pulse">
-            <CardContent className="p-4">
-              <div className="h-4 bg-gray-700 rounded w-3/4 mb-3"></div>
-              <div className="flex gap-2 mb-3">
-                <div className="h-6 bg-gray-700 rounded w-16"></div>
-                <div className="h-6 bg-gray-700 rounded w-16"></div>
-              </div>
-              <div className="h-3 bg-gray-700 rounded w-24"></div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-    );
-  }
-
-  if (goals.length === 0) {
-    return (
-      <Card className="mx-4">
-        <CardContent className="p-8 text-center">
-          <div className="text-gray-400 mb-2">
-            <Target className="w-8 h-8 mx-auto mb-3" />
-          </div>
-          <h3 className="text-lg font-medium text-white mb-2">No goals yet</h3>
-          <p className="text-sm text-gray-400 mb-4">
-            Start by creating your first goal to track your progress
-          </p>
-          {/* Check if we have a route to create goals - for now, omit CTA */}
-        </CardContent>
-      </Card>
-    );
-  }
-
+export function GoalCardGrid({ goals, onEdit, onToggleActive }: GoalCardGridProps) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
       {goals.map((goal) => (
-        <GoalCard key={goal.id} goal={goal} showLink={showLinks} />
+        <GoalCard
+          key={goal.id}
+          goal={goal}
+          onEdit={onEdit}
+          onToggleActive={onToggleActive}
+        />
       ))}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- load goals, projects, and tasks from Supabase instead of mock data
- compute project and goal progress and statuses from real task data
- map backend priority/stage enums to UI-friendly labels
- expand projects in goals view to reveal task lists and show "No tasks to show" when empty

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b23d30ea60832cb6553fc61844cc84