### PR TITLE
feat: add goal card actions and dashboard active goals

### DIFF
--- a/lib/queries/goals.ts
+++ b/lib/queries/goals.ts
@@ -7,6 +7,8 @@ export interface Goal {
   energy: string;
   why?: string;
   created_at: string;
+  active: boolean;
+  status: string;
 }
 
 export async function getGoalsForUser(userId: string): Promise<Goal[]> {
@@ -17,7 +19,7 @@ export async function getGoalsForUser(userId: string): Promise<Goal[]> {
 
   const { data, error } = await supabase
     .from("goals")
-    .select("id, name, priority, energy, why, created_at")
+    .select("id, name, priority, energy, why, created_at, active, status")
     .eq("user_id", userId)
     .order("created_at", { ascending: false });
 
@@ -37,7 +39,7 @@ export async function getGoalById(goalId: string): Promise<Goal | null> {
 
   const { data, error } = await supabase
     .from("goals")
-    .select("id, name, priority, energy, why, created_at")
+    .select("id, name, priority, energy, why, created_at, active, status")
     .eq("id", goalId)
     .single();
 

--- a/lib/queries/projects.ts
+++ b/lib/queries/projects.ts
@@ -7,6 +7,7 @@ export interface Project {
   priority: string;
   energy: string;
   stage: string;
+  status?: string;
   why?: string;
   created_at: string;
 }
@@ -19,7 +20,7 @@ export async function getProjectsForGoal(goalId: string): Promise<Project[]> {
 
   const { data, error } = await supabase
     .from("projects")
-    .select("id, name, goal_id, priority, energy, stage, why, created_at")
+    .select("id, name, goal_id, priority, energy, stage, status, why, created_at")
     .eq("goal_id", goalId)
     .order("created_at", { ascending: false });
 
@@ -39,7 +40,7 @@ export async function getProjectsForUser(userId: string): Promise<Project[]> {
 
   const { data, error } = await supabase
     .from("projects")
-    .select("id, name, goal_id, priority, energy, stage, why, created_at")
+    .select("id, name, goal_id, priority, energy, stage, status, why, created_at")
     .eq("user_id", userId)
     .order("created_at", { ascending: false });
 
@@ -61,7 +62,7 @@ export async function getProjectById(
 
   const { data, error } = await supabase
     .from("projects")
-    .select("id, name, goal_id, priority, energy, stage, why, created_at")
+    .select("id, name, goal_id, priority, energy, stage, status, why, created_at")
     .eq("id", projectId)
     .single();
 

--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -4,11 +4,14 @@ import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { Section } from "@/components/ui/Section";
 import { LevelBanner } from "@/components/ui/LevelBanner";
-import { GoalCardGrid } from "@/components/ui/GoalCardGrid";
 import { MonumentContainer } from "@/components/ui/MonumentContainer";
 import CategorySection from "@/components/skills/CategorySection";
 import { SkillCardSkeleton } from "@/components/skills/SkillCardSkeleton";
-import type { GoalItem } from "@/types/dashboard";
+import { GoalCard } from "@/app/(app)/goals/components/GoalCard";
+import type { Goal, Project } from "@/app/(app)/goals/types";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import { getGoalsForUser } from "@/lib/queries/goals";
+import { getProjectsForUser } from "@/lib/queries/projects";
 
 interface Skill {
   skill_id: string;
@@ -26,9 +29,33 @@ interface Category {
   skills: Skill[];
 }
 
+function mapPriority(priority: string): Goal["priority"] {
+  switch (priority) {
+    case "HIGH":
+    case "CRITICAL":
+    case "ULTRA-CRITICAL":
+      return "High";
+    case "MEDIUM":
+      return "Medium";
+    default:
+      return "Low";
+  }
+}
+
+function projectStageToStatus(stage: string): string {
+  switch (stage) {
+    case "RESEARCH":
+      return "Todo";
+    case "RELEASE":
+      return "Completed";
+    default:
+      return "Active";
+  }
+}
+
 export default function DashboardClient() {
   const [categories, setCategories] = useState<Category[]>([]);
-  const [goals, setGoals] = useState<GoalItem[]>([]);
+  const [goals, setGoals] = useState<Goal[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -39,14 +66,85 @@ export default function DashboardClient() {
     try {
       const response = await fetch("/api/dashboard");
       const data = await response.json();
-      
-      // Debug logging
-      console.log("🔍 Dashboard API response:", data);
-      console.log("🔍 Categories data:", data.skillsAndGoals?.cats);
-      console.log("🔍 Goals data:", data.skillsAndGoals?.goals);
-      
+
       setCategories(data.skillsAndGoals?.cats || []);
-      setGoals(data.skillsAndGoals?.goals || []);
+
+      const supabase = getSupabaseBrowser();
+      if (supabase) {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user) {
+          const [goalsData, projectsData, tasksRes] = await Promise.all([
+            getGoalsForUser(user.id),
+            getProjectsForUser(user.id),
+            supabase
+              .from("tasks")
+              .select("id, project_id, stage")
+              .eq("user_id", user.id),
+          ]);
+
+          const tasksData = tasksRes.data || [];
+
+          const tasksByProject = tasksData.reduce(
+            (acc: Record<string, { stage: string }[]>, task) => {
+              if (!task.project_id) return acc;
+              acc[task.project_id] = acc[task.project_id] || [];
+              acc[task.project_id].push(task);
+              return acc;
+            },
+            {}
+          );
+
+          const projectsByGoal = new Map<string, Project[]>();
+          projectsData.forEach((p) => {
+            const tasks = tasksByProject[p.id] || [];
+            const total = tasks.length;
+            const done = tasks.filter((t) => t.stage === "PERFECT").length;
+            const progress = total ? Math.round((done / total) * 100) : 0;
+            const status = p.status || projectStageToStatus(p.stage);
+            const proj: Project = {
+              id: p.id,
+              name: p.name,
+              status,
+              progress,
+            };
+            const list = projectsByGoal.get(p.goal_id) || [];
+            list.push(proj);
+            projectsByGoal.set(p.goal_id, list);
+          });
+
+          const realGoals: Goal[] = goalsData.map((g) => {
+            const projList = projectsByGoal.get(g.id) || [];
+            const progress =
+              projList.length > 0
+                ? Math.round(
+                    projList.reduce((sum, p) => sum + p.progress, 0) /
+                      projList.length
+                  )
+                : 0;
+            return {
+              id: g.id,
+              title: g.name,
+              priority: mapPriority(g.priority),
+              progress,
+              status: progress >= 100 ? "Completed" : g.status || "Active",
+              active: g.active,
+              updatedAt: g.created_at,
+              projects: projList,
+            };
+          });
+
+          const activeGoals = realGoals
+            .filter((g) => g.active)
+            .map((g) => ({
+              ...g,
+              projects: g.projects.filter((p) => p.status === "Active"),
+            }));
+
+          setGoals(activeGoals);
+        }
+      }
     } catch (error) {
       console.error("Error fetching dashboard data:", error);
     } finally {
@@ -89,11 +187,23 @@ export default function DashboardClient() {
         title={<Link href="/goals">Current Goals</Link>}
         className="safe-bottom mt-2 px-4"
       >
-        <GoalCardGrid
-          goals={goals}
-          loading={loading}
-          showLinks={false} // Set to true if /goals/[id] route exists
-        />
+        {loading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="h-24 bg-gray-800 rounded" />
+            ))}
+          </div>
+        ) : goals.length > 0 ? (
+          <div className="space-y-4">
+            {goals.map((goal) => (
+              <GoalCard key={goal.id} goal={goal} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 text-gray-500">
+            No active goals
+          </div>
+        )}
       </Section>
     </main>
   );

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -4,15 +4,24 @@ import { useState } from "react";
 import { ChevronDown, MoreHorizontal } from "lucide-react";
 import type { Goal } from "../types";
 import { ProjectsDropdown } from "./ProjectsDropdown";
+import { GoalDrawer } from "./GoalDrawer";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface GoalCardProps {
   goal: Goal;
 }
 
 export function GoalCard({ goal }: GoalCardProps) {
+  const [currentGoal, setCurrentGoal] = useState(goal);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [drawer, setDrawer] = useState(false);
 
   const toggle = () => {
     setOpen((o) => !o);
@@ -23,9 +32,9 @@ export function GoalCard({ goal }: GoalCardProps) {
   };
 
   const priorityColor =
-    goal.priority === "High"
+    currentGoal.priority === "High"
       ? "bg-red-600"
-      : goal.priority === "Medium"
+      : currentGoal.priority === "Medium"
       ? "bg-yellow-600"
       : "bg-green-600";
 
@@ -35,33 +44,40 @@ export function GoalCard({ goal }: GoalCardProps) {
         <button
           onClick={toggle}
           aria-expanded={open}
-          aria-controls={`goal-${goal.id}`}
+          aria-controls={`goal-${currentGoal.id}`}
           className="w-full flex items-start justify-between p-4 active:scale-95 transition-transform motion-safe:duration-150 motion-reduce:transform-none"
         >
           <div className="flex-1">
             <div className="flex items-center gap-2">
-              {goal.emoji && <span className="text-xl" aria-hidden>{goal.emoji}</span>}
-              <span id={`goal-${goal.id}-label`} className="font-medium truncate">
-                {goal.title}
+              {currentGoal.emoji && (
+                <span className="text-xl" aria-hidden>
+                  {currentGoal.emoji}
+                </span>
+              )}
+              <span
+                id={`goal-${currentGoal.id}-label`}
+                className="font-medium truncate"
+              >
+                {currentGoal.title}
               </span>
             </div>
             <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-300">
               <div className="w-10 h-2 bg-gray-700 rounded-full overflow-hidden">
                 <div
                   className="h-full bg-blue-500"
-                  style={{ width: `${goal.progress}%` }}
+                  style={{ width: `${currentGoal.progress}%` }}
                 />
               </div>
-              {goal.dueDate && (
+              {currentGoal.dueDate && (
                 <span className="px-2 py-0.5 bg-gray-700 rounded-full">
-                  {new Date(goal.dueDate).toLocaleDateString()}
+                  {new Date(currentGoal.dueDate).toLocaleDateString()}
                 </span>
               )}
               <span className={`px-2 py-0.5 rounded-full ${priorityColor}`}>
-                {goal.priority}
+                {currentGoal.priority}
               </span>
               <span className="px-2 py-0.5 bg-gray-700 rounded-full">
-                {goal.projects.length} projects
+                {currentGoal.projects.length} projects
               </span>
             </div>
           </div>
@@ -70,32 +86,56 @@ export function GoalCard({ goal }: GoalCardProps) {
           />
         </button>
         <div className="absolute top-2 right-2">
-          <button
-            aria-label="Goal actions"
-            onClick={() => setMenuOpen((m) => !m)}
-            className="p-1 rounded bg-gray-700"
-          >
-            <MoreHorizontal className="w-4 h-4" />
-          </button>
-          {menuOpen && (
-            <ul className="absolute right-0 mt-1 bg-gray-700 rounded shadow-lg text-sm z-10">
-              {['Edit','Mark Done','Delete'].map((act) => (
-                <li key={act}>
-                  <button className="block w-full text-left px-3 py-1 hover:bg-gray-600">
-                    {act}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                aria-label="Goal actions"
+                className="p-1 rounded bg-gray-700"
+              >
+                <MoreHorizontal className="w-4 h-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => setDrawer(true)}>
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={async () => {
+                  const supabase = getSupabaseBrowser();
+                  if (!supabase) return;
+                  const newActive = !currentGoal.active;
+                  await supabase
+                    .from("goals")
+                    .update({
+                      active: newActive,
+                      status: newActive ? "Active" : "Inactive",
+                    })
+                    .eq("id", currentGoal.id);
+                  setCurrentGoal((g) => ({
+                    ...g,
+                    active: newActive,
+                    status: newActive ? "Active" : "Inactive",
+                  }));
+                }}
+              >
+                {currentGoal.active ? "Mark Inactive" : "Mark Active"}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
       <ProjectsDropdown
-        id={`goal-${goal.id}`}
-        goalTitle={goal.title}
-        projects={goal.projects}
+        id={`goal-${currentGoal.id}`}
+        goalTitle={currentGoal.title}
+        projects={currentGoal.projects}
         open={open}
         loading={loading}
+      />
+      <GoalDrawer
+        open={drawer}
+        onClose={() => setDrawer(false)}
+        goal={currentGoal}
+        onSave={(g) => setCurrentGoal(g)}
       />
     </div>
   );

--- a/src/app/(app)/goals/components/GoalDrawer.tsx
+++ b/src/app/(app)/goals/components/GoalDrawer.tsx
@@ -1,39 +1,88 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Goal } from "../types";
+import { getSupabaseBrowser } from "@/lib/supabase";
 
-interface CreateGoalDrawerProps {
+interface GoalDrawerProps {
   open: boolean;
   onClose(): void;
-  onAdd(goal: Goal): void;
+  goal?: Goal;
+  onSave(goal: Goal): void;
 }
 
-export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps) {
+export function GoalDrawer({ open, onClose, goal, onSave }: GoalDrawerProps) {
   const [title, setTitle] = useState("");
   const [emoji, setEmoji] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [priority, setPriority] = useState<Goal["priority"]>("Low");
 
-  const submit = (e: React.FormEvent) => {
+  useEffect(() => {
+    if (goal && open) {
+      setTitle(goal.title);
+      setEmoji(goal.emoji || "");
+      setDueDate(goal.dueDate || "");
+      setPriority(goal.priority);
+    }
+    if (!open && !goal) {
+      setTitle("");
+      setEmoji("");
+      setDueDate("");
+      setPriority("Low");
+    }
+  }, [goal, open]);
+
+  const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title) return;
-    const newGoal: Goal = {
-      id: Date.now().toString(),
-      title,
-      emoji,
-      dueDate: dueDate || undefined,
-      priority,
-      progress: 0,
-      status: "Active",
-      updatedAt: new Date().toISOString(),
-      projects: [],
-    };
-    onAdd(newGoal);
-    setTitle("");
-    setEmoji("");
-    setDueDate("");
-    setPriority("Low");
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return;
+
+    if (goal) {
+      await supabase
+        .from("goals")
+        .update({
+          name: title,
+          emoji,
+          due_date: dueDate || null,
+          priority,
+        })
+        .eq("id", goal.id);
+
+      onSave({ ...goal, title, emoji, dueDate: dueDate || undefined, priority });
+    } else {
+      const { data } = await supabase
+        .from("goals")
+        .insert({
+          name: title,
+          emoji,
+          due_date: dueDate || null,
+          priority,
+          active: true,
+          status: "Active",
+        })
+        .select("id, name, emoji, due_date, priority, active, status, created_at")
+        .single();
+
+      const newGoal: Goal = {
+        id: data.id,
+        title: data.name,
+        emoji: data.emoji || "",
+        dueDate: data.due_date || undefined,
+        priority: data.priority as Goal["priority"],
+        progress: 0,
+        status: data.status || "Active",
+        active: data.active ?? true,
+        updatedAt: data.created_at,
+        projects: [],
+      };
+      onSave(newGoal);
+      setTitle("");
+      setEmoji("");
+      setDueDate("");
+      setPriority("Low");
+    }
+
     onClose();
   };
 
@@ -43,7 +92,9 @@ export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
       <div className="absolute right-0 top-0 h-full w-80 bg-gray-800 p-4 overflow-y-auto">
-        <h2 className="text-lg font-semibold mb-4">Create Goal</h2>
+        <h2 className="text-lg font-semibold mb-4">
+          {goal ? "Edit Goal" : "Create Goal"}
+        </h2>
         <form onSubmit={submit} className="space-y-4">
           <div>
             <label className="block text-sm mb-1">Title *</label>
@@ -84,11 +135,15 @@ export function CreateGoalDrawer({ open, onClose, onAdd }: CreateGoalDrawerProps
             </select>
           </div>
           <div className="flex justify-end gap-2 pt-2">
-            <button type="button" onClick={onClose} className="px-3 py-2 rounded bg-gray-700">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-2 rounded bg-gray-700"
+            >
               Cancel
             </button>
             <button type="submit" className="px-3 py-2 rounded bg-blue-600">
-              Add
+              {goal ? "Save" : "Add"}
             </button>
           </div>
         </form>

--- a/src/app/(app)/goals/components/ProjectRow.tsx
+++ b/src/app/(app)/goals/components/ProjectRow.tsx
@@ -8,9 +8,9 @@ interface ProjectRowProps {
 
 export function ProjectRow({ project }: ProjectRowProps) {
   const statusColor =
-    project.status === "Done"
+    project.status === "Completed"
       ? "bg-green-600"
-      : project.status === "In-Progress"
+      : project.status === "Active"
       ? "bg-yellow-600"
       : "bg-gray-600";
 

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -11,7 +11,7 @@ import {
 import { GoalCard } from "./components/GoalCard";
 import { LoadingSkeleton } from "./components/LoadingSkeleton";
 import { EmptyState } from "./components/EmptyState";
-import { CreateGoalDrawer } from "./components/CreateGoalDrawer";
+import { GoalDrawer } from "./components/GoalDrawer";
 import type { Goal, Project } from "./types";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { getGoalsForUser } from "@/lib/queries/goals";
@@ -94,7 +94,7 @@ export default function GoalsPage() {
           const total = tasks.length;
           const done = tasks.filter((t) => t.stage === "PERFECT").length;
           const progress = total ? Math.round((done / total) * 100) : 0;
-          const status = projectStageToStatus(p.stage);
+          const status = p.status || projectStageToStatus(p.stage);
           const proj: Project = {
             id: p.id,
             name: p.name,
@@ -120,7 +120,8 @@ export default function GoalsPage() {
             title: g.name,
             priority: mapPriority(g.priority),
             progress,
-            status: progress >= 100 ? "Completed" : "Active",
+            status: progress >= 100 ? "Completed" : g.status || "Active",
+            active: g.active,
             updatedAt: g.created_at,
             projects: projList,
           };
@@ -206,10 +207,10 @@ export default function GoalsPage() {
             ))}
           </div>
         )}
-        <CreateGoalDrawer
+        <GoalDrawer
           open={drawer}
           onClose={() => setDrawer(false)}
-          onAdd={addGoal}
+          onSave={addGoal}
         />
       </div>
     </ProtectedRoute>

--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -1,7 +1,7 @@
 export interface Project {
   id: string;
   name: string;
-  status: "Todo" | "In-Progress" | "Done";
+  status: string;
   progress: number; // 0-100
   dueDate?: string;
 }
@@ -13,7 +13,8 @@ export interface Goal {
   dueDate?: string;
   priority: "Low" | "Medium" | "High";
   progress: number; // 0-100
-  status: "Active" | "Completed" | "Overdue";
+  status: "Active" | "Completed" | "Overdue" | "Inactive";
+  active: boolean;
   updatedAt: string;
   projects: Project[];
 }


### PR DESCRIPTION
## Summary
- add dropdown action menu to goal cards with edit and active toggle
- support editing goals in a reusable drawer
- display active goals on dashboard with active project filtering

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b30c03e04c832cb63e915329c46b80