### PR TITLE
feat(schedule): add windows-based schedule UI

### DIFF
--- a/components/schedule/ConflictToast.tsx
+++ b/components/schedule/ConflictToast.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+interface Props {
+  message: string
+}
+
+export function ConflictToast({ message }: Props) {
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-red-600 text-white px-4 py-2 rounded shadow-lg">
+      {message}
+    </div>
+  )
+}

--- a/components/schedule/EmptyState.tsx
+++ b/components/schedule/EmptyState.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+export function EmptyState() {
+  return (
+    <div className="text-center text-[#A0A0A0] py-10">
+      No windows for this day
+    </div>
+  )
+}

--- a/components/schedule/InboxDrawer.tsx
+++ b/components/schedule/InboxDrawer.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { Task } from '@/lib/mock/schedule-ui'
+import { TaskChip } from './TaskChip'
+import { useState } from 'react'
+
+interface Props {
+  tasks: Task[]
+  open: boolean
+  onClose: () => void
+}
+
+export function InboxDrawer({ tasks, open, onClose }: Props) {
+  const [query, setQuery] = useState('')
+  const filtered = tasks.filter(t => t.title.toLowerCase().includes(query.toLowerCase()))
+
+  return (
+    <div
+      className={`fixed inset-x-0 bottom-0 bg-[#2B2B2B] border-t border-[#3C3C3C] transition-transform ${open ? 'translate-y-0' : 'translate-y-full'} p-4`}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="flex justify-between items-center mb-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search"
+          className="flex-1 mr-2 px-2 py-1 rounded bg-[#1E1E1E] text-[#E0E0E0] border border-[#3C3C3C]"
+        />
+        <button onClick={onClose} className="px-2 py-1 bg-[#1E1E1E] text-[#E0E0E0] rounded border border-[#3C3C3C]">Close</button>
+      </div>
+      <div className="flex flex-col gap-2 overflow-y-auto max-h-60">
+        {filtered.map(task => (
+          <TaskChip key={task.id} task={task} />
+        ))}
+        {filtered.length === 0 && <div className="text-center text-[#A0A0A0]">No tasks</div>}
+      </div>
+    </div>
+  )
+}

--- a/components/schedule/LoadingSkeleton.tsx
+++ b/components/schedule/LoadingSkeleton.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+export function LoadingSkeleton() {
+  return (
+    <div className="animate-pulse space-y-2">
+      <div className="h-6 bg-[#2B2B2B] rounded" />
+      <div className="h-6 bg-[#2B2B2B] rounded" />
+      <div className="h-6 bg-[#2B2B2B] rounded" />
+    </div>
+  )
+}

--- a/components/schedule/NowLine.tsx
+++ b/components/schedule/NowLine.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { Window } from '@/lib/mock/schedule-ui'
+
+interface Props {
+  window: Window
+  slotHeight: number
+}
+
+const timeToMinutes = (t: string) => {
+  const [h, m] = t.split(':').map(Number)
+  return h * 60 + m
+}
+
+export function NowLine({ window, slotHeight }: Props) {
+  const [now, setNow] = useState(new Date())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60000)
+    return () => clearInterval(id)
+  }, [])
+
+  const start = timeToMinutes(window.start)
+  const end = timeToMinutes(window.end)
+  const current = now.getHours() * 60 + now.getMinutes()
+  if (current < start || current > end) return null
+
+  const offset = ((current - start) / 5) * slotHeight
+
+  return (
+    <div
+      className="absolute left-0 right-0 h-0.5 bg-red-500"
+      style={{ top: offset }}
+    />
+  )
+}

--- a/components/schedule/ScheduleHeader.tsx
+++ b/components/schedule/ScheduleHeader.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useState } from 'react'
+
+interface Props {
+  date: string
+  onDateChange: (d: string) => void
+  filters: {
+    energy?: string
+  }
+  onFilterChange: (f: { energy?: string }) => void
+  view: 'day' | 'compact'
+  onViewChange: (v: 'day' | 'compact') => void
+}
+
+export function ScheduleHeader({ date, onDateChange, filters, onFilterChange, view, onViewChange }: Props) {
+  return (
+    <div className="flex items-center gap-2 p-4 sticky top-0 z-10 bg-[#1E1E1E]">
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => onDateChange(e.target.value)}
+        className="bg-[#2B2B2B] text-[#E0E0E0] border border-[#3C3C3C] rounded px-2 py-1"
+      />
+      <button
+        onClick={() => onDateChange(new Date().toISOString().slice(0,10))}
+        className="px-3 py-1 rounded bg-[#2B2B2B] text-[#E0E0E0] border border-[#3C3C3C] hover:bg-[#353535]"
+      >Today</button>
+
+      <div className="flex gap-1 ml-auto">
+        {(['Low','Med','High'] as const).map((level) => (
+          <button
+            key={level}
+            onClick={() => onFilterChange({ energy: filters.energy === level ? undefined : level })}
+            className={`px-2 py-1 rounded text-sm border ${filters.energy===level? 'bg-[#353535]':'bg-[#2B2B2B]'} border-[#3C3C3C] text-[#E0E0E0]`}
+          >{level}</button>
+        ))}
+      </div>
+
+      <div className="flex gap-1 ml-2">
+        <button
+          onClick={() => onViewChange('day')}
+          className={`px-2 py-1 rounded text-sm border ${view==='day'?'bg-[#353535]':'bg-[#2B2B2B]'} border-[#3C3C3C] text-[#E0E0E0]`}
+        >Day</button>
+        <button
+          onClick={() => onViewChange('compact')}
+          className={`px-2 py-1 rounded text-sm border ${view==='compact'?'bg-[#353535]':'bg-[#2B2B2B]'} border-[#3C3C3C] text-[#E0E0E0]`}
+        >Compact</button>
+      </div>
+    </div>
+  )
+}

--- a/components/schedule/SlotGrid.tsx
+++ b/components/schedule/SlotGrid.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { Window, Task } from '@/lib/mock/schedule-ui'
+import { TaskChip } from './TaskChip'
+import { NowLine } from './NowLine'
+
+interface Props {
+  window: Window
+  assignments: Record<number, Task>
+  onDrop: (index: number, taskId: string) => void
+  onMove?: (from: number, to: number) => void
+  view: 'day' | 'compact'
+  filterEnergy?: string
+}
+
+const timeToMinutes = (t: string) => {
+  const [h, m] = t.split(':').map(Number)
+  return h * 60 + m
+}
+
+const minutesToTime = (m: number) => {
+  const h = Math.floor(m / 60)
+  const min = m % 60
+  return `${h.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`
+}
+
+export function SlotGrid({ window, assignments, onDrop, onMove, view, filterEnergy }: Props) {
+  const start = timeToMinutes(window.start)
+  const end = timeToMinutes(window.end)
+  const totalSlots = (end - start) / 5
+  const slotHeight = view === 'day' ? 24 : 16
+
+  return (
+    <div className="relative">
+      {Array.from({ length: totalSlots }).map((_, i) => {
+        const task = assignments[i]
+        const timeLabel = start + i * 5
+        const showLabel = view === 'day' && i % 3 === 0
+        const hidden = filterEnergy && task && task.energy !== filterEnergy
+        return (
+          <div
+            key={i}
+            className="border-b border-[#3C3C3C] relative"
+            style={{ height: slotHeight }}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              const id = e.dataTransfer.getData('text/plain')
+              onDrop(i, id)
+            }}
+          >
+            {showLabel && (
+              <span className="absolute -left-14 text-xs text-[#A0A0A0]">{minutesToTime(timeLabel)}</span>
+            )}
+            {task && (
+              <div
+                className={hidden ? 'opacity-30' : ''}
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (!onMove) return
+                  if (e.key === 'ArrowUp') {
+                    onMove(i, i - 1)
+                    e.preventDefault()
+                  }
+                  if (e.key === 'ArrowDown') {
+                    onMove(i, i + 1)
+                    e.preventDefault()
+                  }
+                }}
+              >
+                <TaskChip task={task} draggable={false} />
+              </div>
+            )}
+          </div>
+        )
+      })}
+      <NowLine window={window} slotHeight={slotHeight} />
+    </div>
+  )
+}

--- a/components/schedule/TaskChip.tsx
+++ b/components/schedule/TaskChip.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import clsx from 'clsx'
+import { Task } from '@/lib/mock/schedule-ui'
+
+interface Props {
+  task: Task
+  draggable?: boolean
+}
+
+export function TaskChip({ task, draggable = true }: Props) {
+  return (
+    <div
+      className={clsx(
+        'text-sm px-2 py-1 rounded-full select-none cursor-grab active:cursor-grabbing',
+        'bg-[#2B2B2B] text-[#E0E0E0] border border-[#3C3C3C]',
+        'hover:bg-[#353535] transition-colors'
+      )}
+      draggable={draggable}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/plain', task.id)
+      }}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (!draggable) return
+        if (e.key === 'Enter' || e.key === ' ') {
+          // allow keyboard pick up
+          e.currentTarget.dispatchEvent(new DragEvent('dragstart', { bubbles: true, dataTransfer: new DataTransfer() }))
+        }
+      }}
+      aria-grabbed="false"
+    >
+      {task.title}
+    </div>
+  )
+}

--- a/components/schedule/WindowCard.tsx
+++ b/components/schedule/WindowCard.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useState } from 'react'
+import { Window, Task } from '@/lib/mock/schedule-ui'
+import { SlotGrid } from './SlotGrid'
+
+interface Props {
+  window: Window
+  assignments: Record<number, Task>
+  onDropTask: (index: number, taskId: string) => void
+  onMoveTask: (from: number, to: number) => void
+  view: 'day' | 'compact'
+  filterEnergy?: string
+  conflict?: boolean
+}
+
+export function WindowCard({ window, assignments, onDropTask, onMoveTask, view, filterEnergy, conflict }: Props) {
+  const [open, setOpen] = useState(true)
+  return (
+    <div className="mb-4 border border-[#3C3C3C] rounded bg-[#2B2B2B]">
+      <button
+        className="w-full flex justify-between items-center px-4 py-2 text-left text-[#E0E0E0]"
+        onClick={() => setOpen(o => !o)}
+      >
+        <span>{window.name}</span>
+        <span className="text-sm text-[#A0A0A0]">{window.start} – {window.end}</span>
+      </button>
+      {open && (
+        <div className="p-2">
+          {conflict && <div className="text-red-400 text-sm mb-2">Conflict: Slot already filled</div>}
+          <SlotGrid
+            window={window}
+            assignments={assignments}
+            onDrop={onDropTask}
+            onMove={onMoveTask}
+            view={view}
+            filterEnergy={filterEnergy}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/mock/schedule-ui.ts
+++ b/lib/mock/schedule-ui.ts
@@ -1,0 +1,29 @@
+export type Window = {
+  id: string
+  name: string
+  start: string // HH:MM
+  end: string   // HH:MM
+}
+
+export type Task = {
+  id: string
+  title: string
+  duration: number // minutes
+  energy: 'Low' | 'Med' | 'High'
+  priority: 'P1' | 'P2' | 'P3'
+  project: string
+}
+
+export const mockWindows: Window[] = [
+  { id: 'morning', name: 'MORNING ROUTINE', start: '06:00', end: '08:00' },
+  { id: 'prework', name: 'PRE-WORK', start: '08:00', end: '09:00' },
+  { id: 'work1', name: 'WORK 1', start: '09:00', end: '12:00' },
+  { id: 'evening', name: 'EVENING SPRINT', start: '18:00', end: '20:00' }
+]
+
+export const mockTasks: Task[] = [
+  { id: 't1', title: 'Write intro', duration: 30, energy: 'High', priority: 'P1', project: 'Writing' },
+  { id: 't2', title: 'Email sweep', duration: 15, energy: 'Low', priority: 'P2', project: 'Comms' },
+  { id: 't3', title: 'Design sketch', duration: 45, energy: 'Med', priority: 'P2', project: 'Design' },
+  { id: 't4', title: 'Read book', duration: 20, energy: 'Low', priority: 'P3', project: 'Learning' }
+]

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1,23 +1,93 @@
 "use client"
 
+import { useState } from 'react'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+import { ScheduleHeader } from '@/components/schedule/ScheduleHeader'
+import { WindowCard } from '@/components/schedule/WindowCard'
+import { InboxDrawer } from '@/components/schedule/InboxDrawer'
+import { ConflictToast } from '@/components/schedule/ConflictToast'
+import { EmptyState } from '@/components/schedule/EmptyState'
+import { mockWindows, mockTasks, Task } from '@/lib/mock/schedule-ui'
 
 export default function SchedulePage() {
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
+  const [view, setView] = useState<'day' | 'compact'>('day')
+  const [filters, setFilters] = useState<{ energy?: string }>({})
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [unscheduled, setUnscheduled] = useState<Task[]>(mockTasks)
+  const [assignments, setAssignments] = useState<Record<string, Record<number, Task>>>({})
+  const [conflict, setConflict] = useState<string | null>(null)
+
+  const handleDrop = (windowId: string) => (index: number, taskId: string) => {
+    const task = unscheduled.find(t => t.id === taskId)
+    if (!task) return
+    const slots = task.duration / 5
+    const windowAssignments = assignments[windowId] || {}
+    for (let i = 0; i < slots; i++) {
+      if (windowAssignments[index + i]) {
+        setConflict(windowId)
+        return
+      }
+    }
+    setConflict(null)
+    const newAssignments = { ...assignments }
+    const newWindowAssign = { ...windowAssignments }
+    for (let i = 0; i < slots; i++) {
+      newWindowAssign[index + i] = task
+    }
+    newAssignments[windowId] = newWindowAssign
+    setAssignments(newAssignments)
+    setUnscheduled(unscheduled.filter(t => t.id !== taskId))
+  }
+
+  const handleMove = (windowId: string) => (from: number, to: number) => {
+    const windowAssignments = assignments[windowId]
+    if (!windowAssignments) return
+    if (to < 0) return
+    if (windowAssignments[to]) return // prevent conflict
+    const task = windowAssignments[from]
+    if (!task) return
+    const newWindow = { ...windowAssignments }
+    delete newWindow[from]
+    newWindow[to] = task
+    setAssignments({ ...assignments, [windowId]: newWindow })
+  }
+
   return (
     <ProtectedRoute>
-      <div className="space-y-6">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
-          <p className="text-muted-foreground">
-            Plan and manage your time
-          </p>
+      <div className="min-h-screen bg-[#1E1E1E] text-[#E0E0E0]">
+        <ScheduleHeader
+          date={date}
+          onDateChange={setDate}
+          filters={filters}
+          onFilterChange={setFilters}
+          view={view}
+          onViewChange={setView}
+        />
+        <div className="p-4 pb-24">
+          {mockWindows.length === 0 ? (
+            <EmptyState />
+          ) : (
+            mockWindows.map(w => (
+              <WindowCard
+                key={w.id}
+                window={w}
+                assignments={assignments[w.id] || {}}
+                onDropTask={handleDrop(w.id)}
+                onMoveTask={handleMove(w.id)}
+                view={view}
+                filterEnergy={filters.energy}
+                conflict={conflict === w.id}
+              />
+            ))
+          )}
         </div>
-        
-        {/* Schedule content will go here */}
-        <div className="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
-          <h3 className="font-semibold">Your Schedule</h3>
-          <p className="text-sm text-muted-foreground">Manage your schedule here</p>
-        </div>
+        <button
+          className="fixed bottom-4 right-4 px-4 py-2 rounded-full bg-[#2B2B2B] border border-[#3C3C3C] text-[#E0E0E0]"
+          onClick={() => setDrawerOpen(true)}
+        >Inbox</button>
+        <InboxDrawer tasks={unscheduled} open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+        {conflict && <ConflictToast message="Slot already filled" />}
       </div>
     </ProtectedRoute>
   )


### PR DESCRIPTION
## Summary
- build mock schedule data with windows and tasks
- implement schedule page components (header, slot grid, inbox, now-line)
- enable drag/drop with conflict detection and keyboard nudging

## Testing
- `pnpm test:run`
- `pnpm lint`
- `pnpm build > /tmp/build.log 2>&1 && tail -n 20 /tmp/build.log`

------
https://chatgpt.com/codex/tasks/task_e_68b3456e5e40832ca15f5e37e09e8257