### PR TITLE
feat(skills): add notes support with local storage

### DIFF
--- a/src/app/(app)/skills/[id]/notes/[noteId]/page.tsx
+++ b/src/app/(app)/skills/[id]/notes/[noteId]/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { getNotes, saveNotes } from "@/lib/notesStorage";
+import type { Note } from "@/lib/types/note";
+
+export default function NotePage() {
+  const params = useParams();
+  const router = useRouter();
+  const skillId = params.id as string;
+  const noteId = params.noteId as string;
+
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    const notes = getNotes(skillId);
+    const note = notes.find((n) => n.id === noteId);
+    if (note) {
+      setTitle(note.title);
+      setContent(note.content);
+    }
+  }, [skillId, noteId]);
+
+  const onSave = () => {
+    const notes = getNotes(skillId);
+    const existingIndex = notes.findIndex((n) => n.id === noteId);
+    const newId = existingIndex >= 0 ? noteId : Date.now().toString();
+    const newNote: Note = {
+      id: newId,
+      skillId,
+      title,
+      content,
+    };
+    if (existingIndex >= 0) {
+      notes[existingIndex] = newNote;
+    } else {
+      notes.push(newNote);
+    }
+    saveNotes(skillId, notes);
+    router.push(`/skills/${skillId}`);
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <Input
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="Note title"
+      />
+      <Textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Write your note..."
+        className="min-h-[300px]"
+      />
+      <Button onClick={onSave}>
+        Save
+      </Button>
+    </main>
+  );
+}

--- a/src/app/(app)/skills/[id]/page.tsx
+++ b/src/app/(app)/skills/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { FilteredGoalsGrid } from "@/components/goals/FilteredGoalsGrid";
 import { Skeleton } from "@/components/ui/skeleton";
+import { NotesGrid } from "@/components/notes/NotesGrid";
 
 interface Skill {
   id: string;
@@ -135,6 +136,12 @@ export default function SkillDetailPage() {
       <div className="space-y-4">
         <h2 className="text-xl font-semibold text-white">Related Goals</h2>
         <FilteredGoalsGrid entity="skill" id={id} />
+      </div>
+
+      {/* Notes Section */}
+      <div className="space-y-4">
+        <h2 className="text-xl font-semibold text-white">Notes</h2>
+        <NotesGrid skillId={id} />
       </div>
     </main>
   );

--- a/src/components/notes/NoteCard.tsx
+++ b/src/components/notes/NoteCard.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import type { Note } from "@/lib/types/note";
+
+interface NoteCardProps {
+  note: Note;
+  skillId: string;
+}
+
+export function NoteCard({ note, skillId }: NoteCardProps) {
+  return (
+    <Link href={`/skills/${skillId}/notes/${note.id}`}>
+      <Card className="h-full hover:bg-gray-800 transition-colors">
+        <CardContent className="p-4">
+          <h3 className="text-lg font-medium text-white truncate">
+            {note.title || "Untitled"}
+          </h3>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/notes/NotesGrid.tsx
+++ b/src/components/notes/NotesGrid.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { NoteCard } from "./NoteCard";
+import type { Note } from "@/lib/types/note";
+import { getNotes, saveNotes } from "@/lib/notesStorage";
+
+interface NotesGridProps {
+  skillId: string;
+}
+
+export function NotesGrid({ skillId }: NotesGridProps) {
+  const [notes, setNotes] = useState<Note[]>([]);
+
+  useEffect(() => {
+    setNotes(getNotes(skillId));
+  }, [skillId]);
+
+  useEffect(() => {
+    saveNotes(skillId, notes);
+  }, [skillId, notes]);
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      {notes.map((note) => (
+        <NoteCard key={note.id} note={note} skillId={skillId} />
+      ))}
+      <Link href={`/skills/${skillId}/notes/new`}>
+        <Card className="flex items-center justify-center h-full border-dashed hover:bg-gray-800 transition-colors">
+          <CardContent className="p-4 flex items-center justify-center">
+            <Plus className="w-5 h-5 text-gray-400" />
+          </CardContent>
+        </Card>
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/notesStorage.ts
+++ b/src/lib/notesStorage.ts
@@ -1,0 +1,25 @@
+import type { Note } from "@/lib/types/note";
+
+const KEY_PREFIX = "skill-notes-";
+
+export function getNotes(skillId: string): Note[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const data = window.localStorage.getItem(`${KEY_PREFIX}${skillId}`);
+    return data ? (JSON.parse(data) as Note[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveNotes(skillId: string, notes: Note[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      `${KEY_PREFIX}${skillId}`,
+      JSON.stringify(notes)
+    );
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/types/note.ts
+++ b/src/lib/types/note.ts
@@ -1,0 +1,6 @@
+export type Note = {
+  id: string;
+  skillId: string;
+  title: string;
+  content: string;
+};


### PR DESCRIPTION
## Summary
- add Note type and localStorage helpers for skill-specific notes
- create NoteCard and NotesGrid components for displaying notes
- add note editing page and integrate notes section into skill detail page

## Testing
- `pnpm test:run`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3814a91a4832cbd64b6ffb07b2875