### PR TITLE
Scaffold schedule timeline UI with gem-purple now line

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+import { DayTimeline } from '@/components/schedule/DayTimeline'
 
 export default function SchedulePage() {
   return (
@@ -12,11 +13,9 @@ export default function SchedulePage() {
             Plan and manage your time
           </p>
         </div>
-        
-        {/* Schedule content will go here */}
-        <div className="rounded-lg border bg-card text-card-foreground shadow-sm p-6">
-          <h3 className="font-semibold">Your Schedule</h3>
-          <p className="text-sm text-muted-foreground">Manage your schedule here</p>
+
+        <div className="relative h-[600px] overflow-y-auto rounded-lg border bg-neutral-950">
+          <DayTimeline />
         </div>
       </div>
     </ProtectedRoute>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -31,6 +31,15 @@ export default function SchedulePage() {
     touchStartX.current = null
   }
 
+  function formatFullDate(d: Date) {
+    return d.toLocaleDateString(undefined, {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })
+  }
+
   return (
     <ProtectedRoute>
       <div className="space-y-6">
@@ -51,6 +60,10 @@ export default function SchedulePage() {
               {v}
             </button>
           ))}
+        </div>
+
+        <div className="text-center text-sm text-gray-200">
+          {formatFullDate(view === 'focus' ? new Date() : currentDate)}
         </div>
 
         <div

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -3,9 +3,13 @@
 import { useRef, useState } from 'react'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { DayTimeline } from '@/components/schedule/DayTimeline'
+import { MonthView } from '@/components/schedule/MonthView'
+import { WeekView } from '@/components/schedule/WeekView'
+import { FocusTimeline } from '@/components/schedule/FocusTimeline'
 
 export default function SchedulePage() {
   const [currentDate, setCurrentDate] = useState(new Date())
+  const [view, setView] = useState<'month' | 'week' | 'day' | 'focus'>('day')
   const touchStartX = useRef<number | null>(null)
 
   function handleTouchStart(e: React.TouchEvent) {
@@ -13,6 +17,7 @@ export default function SchedulePage() {
   }
 
   function handleTouchEnd(e: React.TouchEvent) {
+    if (view !== 'day') return
     if (touchStartX.current === null) return
     const diff = e.changedTouches[0].clientX - touchStartX.current
     const threshold = 50
@@ -36,12 +41,27 @@ export default function SchedulePage() {
           </p>
         </div>
 
+        <div className="flex gap-2">
+          {(['month','week','day','focus'] as const).map(v => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`flex-1 rounded-md py-1 text-sm capitalize ${view===v ? 'bg-zinc-800 text-white' : 'bg-zinc-900 text-zinc-400'}`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+
         <div
           className="relative h-[600px] overflow-y-auto rounded-lg border bg-neutral-950"
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
         >
-          <DayTimeline date={currentDate} />
+          {view === 'month' && <MonthView date={currentDate} />}
+          {view === 'week' && <WeekView date={currentDate} />}
+          {view === 'day' && <DayTimeline date={currentDate} />}
+          {view === 'focus' && <FocusTimeline />}
         </div>
       </div>
     </ProtectedRoute>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1,9 +1,31 @@
 "use client"
 
+import { useRef, useState } from 'react'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { DayTimeline } from '@/components/schedule/DayTimeline'
 
 export default function SchedulePage() {
+  const [currentDate, setCurrentDate] = useState(new Date())
+  const touchStartX = useRef<number | null>(null)
+
+  function handleTouchStart(e: React.TouchEvent) {
+    touchStartX.current = e.touches[0].clientX
+  }
+
+  function handleTouchEnd(e: React.TouchEvent) {
+    if (touchStartX.current === null) return
+    const diff = e.changedTouches[0].clientX - touchStartX.current
+    const threshold = 50
+    if (Math.abs(diff) > threshold) {
+      setCurrentDate(prev => {
+        const d = new Date(prev)
+        d.setDate(prev.getDate() + (diff < 0 ? 1 : -1))
+        return d
+      })
+    }
+    touchStartX.current = null
+  }
+
   return (
     <ProtectedRoute>
       <div className="space-y-6">
@@ -14,8 +36,12 @@ export default function SchedulePage() {
           </p>
         </div>
 
-        <div className="relative h-[600px] overflow-y-auto rounded-lg border bg-neutral-950">
-          <DayTimeline />
+        <div
+          className="relative h-[600px] overflow-y-auto rounded-lg border bg-neutral-950"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
+          <DayTimeline date={currentDate} />
         </div>
       </div>
     </ProtectedRoute>

--- a/src/components/schedule/DayTimeline.tsx
+++ b/src/components/schedule/DayTimeline.tsx
@@ -11,7 +11,7 @@ interface DayTimelineProps {
 }
 
 export function DayTimeline({
-  startHour = 5,
+  startHour = 0,
   endHour = 24,
   pxPerMin = 2,
 }: DayTimelineProps) {
@@ -68,21 +68,38 @@ export function DayTimeline({
       })}
 
       {showNowLine && (
-        <div
-          className="absolute left-0 right-0"
-          style={{
-            top: nowTop,
-            borderTop: `2px solid ${GEM_PURPLE}`,
-            boxShadow: `0 0 6px ${GEM_PURPLE}`,
-          }}
-        />
+        <>
+          <div
+            className="absolute left-0 right-0"
+            style={{
+              top: nowTop,
+              borderTop: `2px solid ${GEM_PURPLE}`,
+              boxShadow: `0 0 6px ${GEM_PURPLE}`,
+            }}
+          />
+          <div
+            className="absolute right-0 text-xs text-white pr-2"
+            style={{ top: nowTop - 8 }}
+          >
+            {formatTime(nowMinutes! + startHour * 60)}
+          </div>
+        </>
       )}
     </div>
   );
 }
 
 function formatHour(h: number) {
-  const suffix = h >= 12 ? "PM" : "AM";
-  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  const normalized = h % 24;
+  const suffix = normalized >= 12 ? "PM" : "AM";
+  const hour12 = normalized % 12 === 0 ? 12 : normalized % 12;
   return `${hour12} ${suffix}`;
+}
+
+function formatTime(totalMinutes: number) {
+  const hours = Math.floor(totalMinutes / 60) % 24;
+  const minutes = totalMinutes % 60;
+  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+  const minuteStr = minutes.toString().padStart(2, "0");
+  return `${hour12}:${minuteStr}`;
 }

--- a/src/components/schedule/DayTimeline.tsx
+++ b/src/components/schedule/DayTimeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Clock } from "lucide-react";
 
 export const GEM_PURPLE = "#9966CC";
 
@@ -8,18 +9,25 @@ interface DayTimelineProps {
   startHour?: number;
   endHour?: number;
   pxPerMin?: number;
+  date?: Date;
 }
 
 export function DayTimeline({
   startHour = 0,
   endHour = 24,
   pxPerMin = 2,
+  date = new Date(),
 }: DayTimelineProps) {
   const totalMinutes = (endHour - startHour) * 60;
   const timelineHeight = totalMinutes * pxPerMin;
   const [nowMinutes, setNowMinutes] = useState<number | null>(null);
 
   useEffect(() => {
+    if (!isSameDay(date, new Date())) {
+      setNowMinutes(null);
+      return;
+    }
+
     function update() {
       const d = new Date();
       const minutes = d.getHours() * 60 + d.getMinutes();
@@ -28,7 +36,7 @@ export function DayTimeline({
     update();
     const id = setInterval(update, 30_000);
     return () => clearInterval(id);
-  }, [startHour]);
+  }, [startHour, date]);
 
   const showNowLine =
     nowMinutes !== null && nowMinutes >= 0 && nowMinutes <= totalMinutes;
@@ -70,13 +78,29 @@ export function DayTimeline({
       {showNowLine && (
         <>
           <div
+            className="absolute left-0 right-0 pointer-events-none"
+            style={{
+              top: nowTop - 10,
+              height: 20,
+              background: `linear-gradient(to bottom, rgba(153, 102, 204, 0) 0%, rgba(153, 102, 204, 0.4) 50%, rgba(153, 102, 204, 0) 100%)`,
+            }}
+          />
+          <div
             className="absolute left-0 right-0"
             style={{
               top: nowTop,
-              borderTop: `2px solid ${GEM_PURPLE}`,
-              boxShadow: `0 0 6px ${GEM_PURPLE}`,
+              height: 2,
+              backgroundColor: GEM_PURPLE,
+              boxShadow: `0 0 8px ${GEM_PURPLE}`,
             }}
           />
+          <div
+            className="absolute flex items-center gap-1 text-xs text-white"
+            style={{ top: nowTop - 8, left: 4 }}
+          >
+            <Clock className="h-3 w-3" />
+            <span>Now</span>
+          </div>
           <div
             className="absolute right-0 text-xs text-white pr-2"
             style={{ top: nowTop - 8 }}
@@ -102,4 +126,12 @@ function formatTime(totalMinutes: number) {
   const hour12 = hours % 12 === 0 ? 12 : hours % 12;
   const minuteStr = minutes.toString().padStart(2, "0");
   return `${hour12}:${minuteStr}`;
+}
+
+function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
 }

--- a/src/components/schedule/DayTimeline.tsx
+++ b/src/components/schedule/DayTimeline.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const GEM_PURPLE = "#9966CC";
+
+interface DayTimelineProps {
+  startHour?: number;
+  endHour?: number;
+  pxPerMin?: number;
+}
+
+export function DayTimeline({
+  startHour = 5,
+  endHour = 24,
+  pxPerMin = 2,
+}: DayTimelineProps) {
+  const totalMinutes = (endHour - startHour) * 60;
+  const timelineHeight = totalMinutes * pxPerMin;
+  const [nowMinutes, setNowMinutes] = useState<number | null>(null);
+
+  useEffect(() => {
+    function update() {
+      const d = new Date();
+      const minutes = d.getHours() * 60 + d.getMinutes();
+      setNowMinutes(minutes - startHour * 60);
+    }
+    update();
+    const id = setInterval(update, 30_000);
+    return () => clearInterval(id);
+  }, [startHour]);
+
+  const showNowLine =
+    nowMinutes !== null && nowMinutes >= 0 && nowMinutes <= totalMinutes;
+  const nowTop = (nowMinutes ?? 0) * pxPerMin;
+
+  const hours: number[] = [];
+  for (let h = startHour; h < endHour; h++) {
+    hours.push(h);
+  }
+
+  return (
+    <div
+      className="relative w-full pl-16"
+      style={{ height: `${timelineHeight}px` }}
+    >
+      <div
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          backgroundImage: `
+            repeating-linear-gradient(to bottom, rgba(255,255,255,0.05) 0px, rgba(255,255,255,0.05) 1px, transparent 1px, transparent ${5 * pxPerMin}px),
+            repeating-linear-gradient(to bottom, rgba(255,255,255,0.1) 0px, rgba(255,255,255,0.1) 2px, transparent 2px, transparent ${60 * pxPerMin}px)
+          `,
+        }}
+      />
+
+      {hours.map((h) => {
+        const top = (h - startHour) * 60 * pxPerMin;
+        return (
+          <div
+            key={h}
+            className="absolute left-0 w-16 pr-2 text-right text-xs text-gray-400"
+            style={{ top }}
+          >
+            {formatHour(h)}
+          </div>
+        );
+      })}
+
+      {showNowLine && (
+        <div
+          className="absolute left-0 right-0"
+          style={{
+            top: nowTop,
+            borderTop: `2px solid ${GEM_PURPLE}`,
+            boxShadow: `0 0 6px ${GEM_PURPLE}`,
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function formatHour(h: number) {
+  const suffix = h >= 12 ? "PM" : "AM";
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return `${hour12} ${suffix}`;
+}

--- a/src/components/schedule/DayTimeline.tsx
+++ b/src/components/schedule/DayTimeline.tsx
@@ -21,6 +21,7 @@ export function DayTimeline({
   const totalMinutes = (endHour - startHour) * 60;
   const timelineHeight = totalMinutes * pxPerMin;
   const [nowMinutes, setNowMinutes] = useState<number | null>(null);
+  const startMinuteOffset = (startHour - Math.floor(startHour)) * 60;
 
   useEffect(() => {
     if (!isSameDay(date, new Date())) {
@@ -43,7 +44,7 @@ export function DayTimeline({
   const nowTop = (nowMinutes ?? 0) * pxPerMin;
 
   const hours: number[] = [];
-  for (let h = startHour; h < endHour; h++) {
+  for (let h = Math.ceil(startHour); h < endHour; h++) {
     hours.push(h);
   }
 
@@ -59,6 +60,7 @@ export function DayTimeline({
             repeating-linear-gradient(to bottom, rgba(255,255,255,0.05) 0px, rgba(255,255,255,0.05) 1px, transparent 1px, transparent ${5 * pxPerMin}px),
             repeating-linear-gradient(to bottom, rgba(255,255,255,0.1) 0px, rgba(255,255,255,0.1) 2px, transparent 2px, transparent ${60 * pxPerMin}px)
           `,
+          backgroundPositionY: `-${startMinuteOffset * pxPerMin}px`,
         }}
       />
 

--- a/src/components/schedule/FocusTimeline.tsx
+++ b/src/components/schedule/FocusTimeline.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { DayTimeline } from "./DayTimeline";
+
+export function FocusTimeline() {
+  const now = new Date();
+  const startHour = now.getHours() + now.getMinutes() / 60;
+  const endHour = startHour + 3;
+  return <DayTimeline startHour={startHour} endHour={endHour} date={now} />;
+}

--- a/src/components/schedule/MonthView.tsx
+++ b/src/components/schedule/MonthView.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+interface MonthViewProps {
+  date?: Date;
+}
+
+export function MonthView({ date = new Date() }: MonthViewProps) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const first = new Date(year, month, 1);
+  const startWeekday = first.getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < startWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  return (
+    <div className="text-xs text-gray-300">
+      <div className="grid grid-cols-7 text-center">
+        {dayNames.map((d) => (
+          <div key={d} className="p-1 font-medium">
+            {d}
+          </div>
+        ))}
+        {cells.map((day, i) => (
+          <div key={i} className="h-10 border border-gray-800/40 p-1 text-center">
+            {day}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/schedule/MonthView.tsx
+++ b/src/components/schedule/MonthView.tsx
@@ -12,6 +12,10 @@ export function MonthView({ date = new Date() }: MonthViewProps) {
   const first = new Date(year, month, 1);
   const startWeekday = first.getDay();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const label = date.toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
 
   const cells: (number | null)[] = [];
   for (let i = 0; i < startWeekday; i++) cells.push(null);
@@ -20,6 +24,7 @@ export function MonthView({ date = new Date() }: MonthViewProps) {
 
   return (
     <div className="text-xs text-gray-300">
+      <div className="mb-2 text-center text-sm text-gray-200">{label}</div>
       <div className="grid grid-cols-7 text-center">
         {dayNames.map((d) => (
           <div key={d} className="p-1 font-medium">

--- a/src/components/schedule/WeekView.tsx
+++ b/src/components/schedule/WeekView.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+interface WeekViewProps {
+  date?: Date;
+}
+
+export function WeekView({ date = new Date() }: WeekViewProps) {
+  const start = new Date(date);
+  const day = start.getDay();
+  start.setDate(start.getDate() - day);
+  const days: Date[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    days.push(d);
+  }
+
+  return (
+    <div className="grid grid-cols-7 text-center text-xs text-gray-300">
+      {days.map((d) => (
+        <div key={d.toISOString()} className="p-2 border border-gray-800/40">
+          <div className="font-medium">{dayNames[d.getDay()]}</div>
+          <div>{d.getDate()}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/schedule/WeekView.tsx
+++ b/src/components/schedule/WeekView.tsx
@@ -10,6 +10,8 @@ export function WeekView({ date = new Date() }: WeekViewProps) {
   const start = new Date(date);
   const day = start.getDay();
   start.setDate(start.getDate() - day);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
   const days: Date[] = [];
   for (let i = 0; i < 7; i++) {
     const d = new Date(start);
@@ -18,13 +20,31 @@ export function WeekView({ date = new Date() }: WeekViewProps) {
   }
 
   return (
-    <div className="grid grid-cols-7 text-center text-xs text-gray-300">
-      {days.map((d) => (
-        <div key={d.toISOString()} className="p-2 border border-gray-800/40">
-          <div className="font-medium">{dayNames[d.getDay()]}</div>
-          <div>{d.getDate()}</div>
-        </div>
-      ))}
+    <div className="text-xs text-gray-300">
+      <div className="mb-2 text-center text-sm text-gray-200">
+        {formatRange(start, end)}
+      </div>
+      <div className="grid grid-cols-7 text-center">
+        {days.map((d) => (
+          <div key={d.toISOString()} className="p-2 border border-gray-800/40">
+            <div className="font-medium">{dayNames[d.getDay()]}</div>
+            <div>{d.getDate()}</div>
+          </div>
+        ))}
+      </div>
     </div>
   );
+}
+
+function formatRange(start: Date, end: Date) {
+  const startStr = start.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  const endStr = end.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+  const yearStr = end.getFullYear();
+  return `${startStr} – ${endStr}, ${yearStr}`;
 }


### PR DESCRIPTION
## Summary
- add `DayTimeline` component rendering scrollable day grid with hour labels and gem-purple now line
- display timeline on /schedule page within dark scrollable container

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b492f4c038832c81b90a74d43aeb90