### PR TITLE
feat: add duration fields and windows management

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { useRef, useState } from 'react'
+import Link from 'next/link'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { DayTimeline } from '@/components/schedule/DayTimeline'
 import { MonthView } from '@/components/schedule/MonthView'
 import { WeekView } from '@/components/schedule/WeekView'
 import { FocusTimeline } from '@/components/schedule/FocusTimeline'
+import { Button } from '@/components/ui/button'
 
 export default function SchedulePage() {
   const [currentDate, setCurrentDate] = useState(new Date())
@@ -43,8 +45,16 @@ export default function SchedulePage() {
   return (
     <ProtectedRoute>
       <div className="space-y-6">
-        <div>
+        <div className="relative">
           <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
+          <Link href="/windows" className="absolute right-0 top-0">
+            <Button
+              size="sm"
+              className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+            >
+              Windows
+            </Button>
+          </Link>
           <p className="text-muted-foreground">
             Plan and manage your time
           </p>

--- a/src/app/(app)/windows/page.tsx
+++ b/src/app/(app)/windows/page.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PageHeader } from "@/components/ui";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { useToastHelpers } from "@/components/ui/toast";
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+interface WindowRow {
+  id: string;
+  label: string;
+  days_of_week: number[];
+  start_local: string;
+  end_local: string;
+  energy_cap: string | null;
+  tags: string[] | null;
+  max_consecutive_min: number | null;
+}
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+export default function WindowsPage() {
+  const supabase = getSupabaseBrowser();
+  const toast = useToastHelpers();
+  const [windows, setWindows] = useState<WindowRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<WindowRow | null>(null);
+
+  const [label, setLabel] = useState("");
+  const [days, setDays] = useState<number[]>([]);
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [energy, setEnergy] = useState("low");
+  const [tags, setTags] = useState("");
+  const [maxConsecutive, setMaxConsecutive] = useState<number | "">("");
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function load() {
+    if (!supabase) return;
+    setLoading(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setWindows([]);
+      setLoading(false);
+      return;
+    }
+    const { data, error } = await supabase
+      .from("windows")
+      .select(
+        "id,label,days_of_week,start_local,end_local,energy_cap,tags,max_consecutive_min"
+      )
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: true });
+    if (!error && data) {
+      setWindows(data as WindowRow[]);
+    }
+    setLoading(false);
+  }
+
+  function openNew() {
+    setEditing(null);
+    setLabel("");
+    setDays([]);
+    setStart("");
+    setEnd("");
+    setEnergy("low");
+    setTags("");
+    setMaxConsecutive("");
+    setShowForm(true);
+  }
+
+  function openEdit(w: WindowRow) {
+    setEditing(w);
+    setLabel(w.label);
+    setDays(w.days_of_week || []);
+    setStart(w.start_local || "");
+    setEnd(w.end_local || "");
+    setEnergy(w.energy_cap || "low");
+    setTags((w.tags || []).join(","));
+    setMaxConsecutive(w.max_consecutive_min ?? "");
+    setShowForm(true);
+  }
+
+  function toggleDay(i: number) {
+    setDays((prev) =>
+      prev.includes(i) ? prev.filter((d) => d !== i) : [...prev, i]
+    );
+  }
+
+  function formatDays(arr: number[]) {
+    return arr
+      .slice()
+      .sort()
+      .map((i) => DAY_LABELS[i])
+      .join(", ");
+  }
+
+  async function saveWindow(e: React.FormEvent) {
+    e.preventDefault();
+    if (!supabase) return;
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+    const payload = {
+      label,
+      days_of_week: days,
+      start_local: start,
+      end_local: end,
+      energy_cap: energy,
+      tags: tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0),
+      max_consecutive_min:
+        maxConsecutive === "" ? null : Number(maxConsecutive),
+      user_id: user.id,
+    };
+    let error;
+    if (editing) {
+      ({ error } = await supabase
+        .from("windows")
+        .update(payload)
+        .eq("id", editing.id)
+        .eq("user_id", user.id));
+    } else {
+      ({ error } = await supabase.from("windows").insert(payload));
+    }
+    if (error) {
+      toast.error("Error", "Failed to save window");
+    } else {
+      toast.success("Saved", "Window saved");
+      setShowForm(false);
+      load();
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!supabase) return;
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return;
+    if (!confirm("Delete window?")) return;
+    const { error } = await supabase
+      .from("windows")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", user.id);
+    if (error) {
+      toast.error("Error", "Failed to delete window");
+    } else {
+      toast.success("Deleted", "Window removed");
+      load();
+    }
+  }
+
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen bg-gray-900 text-white">
+        <div className="container mx-auto px-4 py-6">
+          <PageHeader
+            title="Windows"
+            description="Manage your scheduling windows"
+          >
+            <Button
+              onClick={openNew}
+              size="sm"
+              className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+            >
+              New Window
+            </Button>
+          </PageHeader>
+
+          {loading ? (
+            <p className="text-gray-400">Loading...</p>
+          ) : windows.length === 0 ? (
+            <p className="text-gray-400">No windows yet</p>
+          ) : (
+            <div className="space-y-4">
+              {windows.map((w) => (
+                <Card key={w.id} className="bg-gray-800">
+                  <CardContent className="flex justify-between p-4">
+                    <div>
+                      <div className="font-medium">{w.label}</div>
+                      <div className="text-sm text-gray-400">
+                        {formatDays(w.days_of_week)} {w.start_local} - {w.end_local}
+                      </div>
+                      <div className="text-sm text-gray-400">
+                        {w.energy_cap}
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-gray-300 hover:bg-gray-700"
+                        onClick={() => openEdit(w)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-gray-300 hover:bg-gray-700"
+                        onClick={() => handleDelete(w.id)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {showForm && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+            <form
+              onSubmit={saveWindow}
+              className="w-full max-w-md space-y-4 rounded-lg bg-gray-900 p-6"
+            >
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold">
+                  {editing ? "Edit Window" : "New Window"}
+                </h2>
+                <button
+                  type="button"
+                  className="text-gray-400"
+                  onClick={() => setShowForm(false)}
+                >
+                  ×
+                </button>
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="label">Label</Label>
+                <Input
+                  id="label"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  required
+                />
+              </div>
+
+              <div className="space-y-1">
+                <Label>Days of Week</Label>
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {DAY_LABELS.map((d, idx) => (
+                    <label key={idx} className="flex items-center gap-1 text-sm">
+                      <input
+                        type="checkbox"
+                        className="accent-gray-600"
+                        checked={days.includes(idx)}
+                        onChange={() => toggleDay(idx)}
+                      />
+                      {d}
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <div className="flex-1 space-y-1">
+                  <Label htmlFor="start">Start</Label>
+                  <Input
+                    id="start"
+                    type="time"
+                    value={start}
+                    onChange={(e) => setStart(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="flex-1 space-y-1">
+                  <Label htmlFor="end">End</Label>
+                  <Input
+                    id="end"
+                    type="time"
+                    value={end}
+                    onChange={(e) => setEnd(e.target.value)}
+                    required
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="energy">Energy Cap</Label>
+                <select
+                  id="energy"
+                  value={energy}
+                  onChange={(e) => setEnergy(e.target.value)}
+                  className="w-full rounded-md bg-gray-800 p-2 text-sm"
+                >
+                  <option value="low">low</option>
+                  <option value="med">med</option>
+                  <option value="high">high</option>
+                </select>
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="tags">Tags</Label>
+                <Input
+                  id="tags"
+                  value={tags}
+                  onChange={(e) => setTags(e.target.value)}
+                  placeholder="tag1, tag2"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="max">Max Consecutive (min)</Label>
+                <Input
+                  id="max"
+                  type="number"
+                  min="0"
+                  value={maxConsecutive}
+                  onChange={(e) =>
+                    setMaxConsecutive(
+                      e.target.value === "" ? "" : parseInt(e.target.value)
+                    )
+                  }
+                />
+              </div>
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="text-gray-300 hover:bg-gray-700"
+                  onClick={() => setShowForm(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+                >
+                  Save
+                </Button>
+              </div>
+            </form>
+          </div>
+        )}
+      </div>
+    </ProtectedRoute>
+  );
+}
+

--- a/src/app/(app)/windows/page.tsx
+++ b/src/app/(app)/windows/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const runtime = "nodejs";
+
 import { useEffect, useState } from "react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageHeader } from "@/components/ui";

--- a/src/lib/scheduler/windows.ts
+++ b/src/lib/scheduler/windows.ts
@@ -26,12 +26,9 @@ export interface Slot {
   maxConsecutiveMin: number | null;
 }
 
-export function genSlots(
-  date: Date,
-  windows: WindowRow[],
-  slotMinutes = 5
-): Slot[] {
+export function genSlots(date: Date, windows: WindowRow[]): Slot[] {
   const slots: Slot[] = [];
+  const slotMinutes = 5;
   for (const w of windows) {
     const [sh, sm] = (w.start_local || "0:0").split(":").map(Number);
     const [eh, em] = (w.end_local || "0:0").split(":").map(Number);

--- a/src/lib/scheduler/windows.ts
+++ b/src/lib/scheduler/windows.ts
@@ -1,0 +1,60 @@
+import { getSupabaseBrowser } from "../../../lib/supabase";
+import type { Database } from "../../../types/supabase";
+
+export type WindowRow = Database["public"]["Tables"]["windows"]["Row"];
+
+export async function getWindowsForDate(date: Date, userId: string) {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error("Supabase client not available");
+  const weekday = date.getDay();
+  const { data, error } = await supabase
+    .from("windows")
+    .select(
+      "id,label,days_of_week,start_local,end_local,energy_cap,tags,max_consecutive_min"
+    )
+    .eq("user_id", userId)
+    .contains("days_of_week", [weekday]);
+  if (error) throw error;
+  return (data ?? []) as WindowRow[];
+}
+
+export interface Slot {
+  windowId: string;
+  start: Date;
+  end: Date;
+  index: number;
+  maxConsecutiveMin: number | null;
+}
+
+export function genSlots(
+  date: Date,
+  windows: WindowRow[],
+  slotMinutes = 5
+): Slot[] {
+  const slots: Slot[] = [];
+  for (const w of windows) {
+    const [sh, sm] = (w.start_local || "0:0").split(":").map(Number);
+    const [eh, em] = (w.end_local || "0:0").split(":").map(Number);
+    const windowStart = new Date(date);
+    windowStart.setHours(sh, sm, 0, 0);
+    const windowEnd = new Date(date);
+    windowEnd.setHours(eh, em, 0, 0);
+    let index = 0;
+    let cursor = new Date(windowStart);
+    while (true) {
+      const end = new Date(cursor.getTime() + slotMinutes * 60000);
+      if (end > windowEnd) break;
+      slots.push({
+        windowId: w.id,
+        start: new Date(cursor),
+        end,
+        index,
+        maxConsecutiveMin: w.max_consecutive_min ?? null,
+      });
+      cursor = end;
+      index++;
+    }
+  }
+  return slots;
+}
+

--- a/test/lib/scheduler/windows.spec.ts
+++ b/test/lib/scheduler/windows.spec.ts
@@ -18,13 +18,15 @@ describe("genSlots", () => {
         max_consecutive_min: null,
       },
     ];
-    const slots = genSlots(date, windows, 15);
-    expect(slots).toHaveLength(4);
+    const slots = genSlots(date, windows);
+    expect(slots).toHaveLength(12);
     expect(slots[0].start.getHours()).toBe(6);
     expect(slots[0].start.getMinutes()).toBe(0);
-    expect(slots[3].end.getHours()).toBe(7);
-    expect(slots[3].end.getMinutes()).toBe(0);
-    expect(slots.map((s) => s.index)).toEqual([0, 1, 2, 3]);
+    expect(slots[11].end.getHours()).toBe(7);
+    expect(slots[11].end.getMinutes()).toBe(0);
+    expect(slots.map((s) => s.index)).toEqual(
+      Array.from({ length: 12 }, (_, i) => i)
+    );
   });
 });
 

--- a/test/lib/scheduler/windows.spec.ts
+++ b/test/lib/scheduler/windows.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { genSlots, type WindowRow } from "../../../src/lib/scheduler/windows";
+
+describe("genSlots", () => {
+  it("splits windows into expected slots", () => {
+    const date = new Date("2023-01-01T00:00:00");
+    const windows: WindowRow[] = [
+      {
+        id: "w1",
+        created_at: "",
+        user_id: "u1",
+        label: "Morning",
+        days_of_week: [0],
+        start_local: "06:00",
+        end_local: "07:00",
+        energy_cap: null,
+        tags: null,
+        max_consecutive_min: null,
+      },
+    ];
+    const slots = genSlots(date, windows, 15);
+    expect(slots).toHaveLength(4);
+    expect(slots[0].start.getHours()).toBe(6);
+    expect(slots[0].start.getMinutes()).toBe(0);
+    expect(slots[3].end.getHours()).toBe(7);
+    expect(slots[3].end.getMinutes()).toBe(0);
+    expect(slots.map((s) => s.index)).toEqual([0, 1, 2, 3]);
+  });
+});
+

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,523 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      goals: {
+        Row: {
+          id: string;
+          created_at: string;
+          is_current: boolean;
+          priority_id: number;
+          energy_id: number;
+          stage_id: number;
+          monument_id: string;
+          Title: string;
+          user_id: string;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          is_current?: boolean;
+          priority_id: number;
+          energy_id: number;
+          stage_id: number;
+          monument_id: string;
+          Title?: string;
+          user_id: string;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          is_current?: boolean;
+          priority_id?: number;
+          energy_id?: number;
+          stage_id?: number;
+          monument_id?: string;
+          Title?: string;
+          user_id?: string;
+        };
+      };
+      habits: {
+        Row: {
+          id: string;
+          created_at: string;
+          recurrence: number | null;
+          Title: string | null;
+          type_id: number;
+          user_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          recurrence?: number | null;
+          Title?: string | null;
+          type_id?: number;
+          user_id?: string | null;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          recurrence?: number | null;
+          Title?: string | null;
+          type_id?: number;
+          user_id?: string | null;
+        };
+      };
+      projects: {
+        Row: {
+          id: string;
+          created_at: string;
+          energy_id: number | null;
+          priority_id: number | null;
+          goal_id: string | null;
+          stage_id: number;
+          Title: string;
+          user_id: string | null;
+          duration_min: number | null;
+          effective_duration_min: number | null;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          energy_id?: number | null;
+          priority_id?: number | null;
+          goal_id?: string | null;
+          stage_id: number;
+          Title?: string;
+          user_id?: string | null;
+          duration_min?: number | null;
+          effective_duration_min?: number | null;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          energy_id?: number | null;
+          priority_id?: number | null;
+          goal_id?: string | null;
+          stage_id?: number;
+          Title?: string;
+          user_id?: string | null;
+          duration_min?: number | null;
+          effective_duration_min?: number | null;
+        };
+      };
+      tasks: {
+        Row: {
+          id: string;
+          created_at: string;
+          priority_id: number | null;
+          energy_id: number | null;
+          stage_id: number;
+          project_id: string;
+          Title: string;
+          user_id: string;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          priority_id?: number | null;
+          energy_id?: number | null;
+          stage_id?: number;
+          project_id: string;
+          Title?: string;
+          user_id: string;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          priority_id?: number | null;
+          energy_id?: number | null;
+          stage_id?: number;
+          project_id?: string;
+          Title?: string;
+          user_id?: string;
+        };
+      };
+      skills: {
+        Row: {
+          id: string;
+          created_at: string;
+          Title: string | null;
+          cat_id: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          Title?: string | null;
+          cat_id?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          Title?: string | null;
+          cat_id?: string | null;
+          user_id?: string | null;
+        };
+      };
+      monuments: {
+        Row: {
+          id: string;
+          created_at: string;
+          Title: string | null;
+          description: string | null;
+          user_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          Title?: string | null;
+          description?: string | null;
+          user_id?: string | null;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          Title?: string | null;
+          description?: string | null;
+          user_id?: string | null;
+        };
+      };
+      monument_skills: {
+        Row: {
+          user_id: string;
+          monument_id: string | null;
+          skill_id: string | null;
+        };
+        Insert: {
+          user_id: string;
+          monument_id?: string | null;
+          skill_id?: string | null;
+        };
+        Update: {
+          user_id?: string;
+          monument_id?: string | null;
+          skill_id?: string | null;
+        };
+      };
+      energy: {
+        Row: {
+          id: number;
+          name: string;
+          order_index: number;
+        };
+        Insert: {
+          id: number;
+          name: string;
+          order_index: number;
+        };
+        Update: {
+          id?: number;
+          name?: string;
+          order_index?: number;
+        };
+      };
+      goal_stage: {
+        Row: {
+          id: number;
+          name: string | null;
+          order_index: number | null;
+        };
+        Insert: {
+          id: number;
+          name?: string | null;
+          order_index?: number | null;
+        };
+        Update: {
+          id?: number;
+          name?: string | null;
+          order_index?: number | null;
+        };
+      };
+      habit_types: {
+        Row: {
+          id: number;
+          name: string | null;
+        };
+        Insert: {
+          id: number;
+          name?: string | null;
+        };
+        Update: {
+          id?: number;
+          name?: string | null;
+        };
+      };
+      priority: {
+        Row: {
+          id: number;
+          name: string;
+          order_index: number;
+        };
+        Insert: {
+          id: number;
+          name: string;
+          order_index: number;
+        };
+        Update: {
+          id?: number;
+          name?: string;
+          order_index?: number;
+        };
+      };
+      project_stage: {
+        Row: {
+          id: number;
+          name: string | null;
+          order_index: number | null;
+        };
+        Insert: {
+          id: number;
+          name?: string | null;
+          order_index?: number | null;
+        };
+        Update: {
+          id?: number;
+          name?: string | null;
+          order_index?: number | null;
+        };
+      };
+      task_stage: {
+        Row: {
+          id: number;
+          name: string | null;
+          order_index: number | null;
+        };
+        Insert: {
+          id: number;
+          name?: string | null;
+          order_index?: number | null;
+        };
+        Update: {
+          id?: number;
+          name?: string | null;
+          order_index?: number | null;
+        };
+      };
+      skill_categories: {
+        Row: {
+          id: number;
+          name: string | null;
+        };
+        Insert: {
+          id: number;
+          name?: string | null;
+        };
+        Update: {
+          id?: number;
+          name?: string | null;
+        };
+      };
+      profiles: {
+        Row: {
+          id: string;
+          created_at: string;
+          user_id: string | null;
+          username: string;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          user_id?: string | null;
+          username: string;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          user_id?: string | null;
+          username?: string;
+        };
+      };
+      linked_accounts: {
+        Row: {
+          id: string;
+          user_id: string;
+          platform: string;
+          url: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          platform: string;
+          url: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          platform?: string;
+          url?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
+      social_links: {
+        Row: {
+          id: string;
+          user_id: string;
+          platform: string;
+          url: string;
+          icon: string | null;
+          color: string | null;
+          position: number;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          platform: string;
+          url: string;
+          icon?: string | null;
+          color?: string | null;
+          position?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          platform?: string;
+          url?: string;
+          icon?: string | null;
+          color?: string | null;
+          position?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
+      content_cards: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          description: string | null;
+          url: string;
+          thumbnail_url: string | null;
+          category: string | null;
+          position: number;
+          is_active: boolean;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          description?: string | null;
+          url: string;
+          thumbnail_url?: string | null;
+          category?: string | null;
+          position?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          description?: string | null;
+          url?: string;
+          thumbnail_url?: string | null;
+          category?: string | null;
+          position?: number;
+          is_active?: boolean;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
+      profile_themes: {
+        Row: {
+          id: string;
+          name: string;
+          primary_color: string;
+          secondary_color: string;
+          accent_color: string;
+          background_gradient: string | null;
+          font_family: string;
+          is_premium: boolean;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          name: string;
+          primary_color: string;
+          secondary_color: string;
+          accent_color: string;
+          background_gradient?: string | null;
+          font_family: string;
+          is_premium?: boolean;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          name?: string;
+          primary_color?: string;
+          secondary_color?: string;
+          accent_color?: string;
+          background_gradient?: string | null;
+          font_family?: string;
+          is_premium?: boolean;
+          created_at?: string;
+        };
+      };
+      windows: {
+        Row: {
+          id: string;
+          created_at: string;
+          user_id: string;
+          label: string;
+          days_of_week: number[];
+          start_local: string;
+          end_local: string;
+          energy_cap: string | null;
+          tags: string[] | null;
+          max_consecutive_min: number | null;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          user_id: string;
+          label: string;
+          days_of_week?: number[];
+          start_local?: string;
+          end_local?: string;
+          energy_cap?: string | null;
+          tags?: string[] | null;
+          max_consecutive_min?: number | null;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          user_id?: string;
+          label?: string;
+          days_of_week?: number[];
+          start_local?: string;
+          end_local?: string;
+          energy_cap?: string | null;
+          tags?: string[] | null;
+          max_consecutive_min?: number | null;
+        };
+      };
+    };
+    Views: {};
+    Functions: {};
+    Enums: {};
+    CompositeTypes: {};
+  };
+}


### PR DESCRIPTION
## Summary
- add Supabase types for windows including scheduling fields
- add `/windows` page with create, edit, delete via modal
- link schedule page to windows manager

## Testing
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7363728832c81ba5e02b3b394f2