### PR TITLE
Ensure bottom nav padding respects safe area and fix lint types

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -6,7 +6,7 @@ import { Fab } from "@/components/ui/Fab";
 
 export default function BottomNav() {
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 text-gray-400 flex justify-around items-center py-2">
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-gray-900 text-gray-400 flex justify-around items-center h-16">
       <Link
         href="/"
         className="flex flex-col items-center gap-1 hover:text-blue-400"

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -8,7 +8,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
     <ToastProvider>
       <ProfileProvider>
         <TopNav />
-        <main className="flex-1">{children}</main>
+        <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))]">
+          {children}
+        </main>
         <BottomNav />
       </ProfileProvider>
     </ToastProvider>

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -515,9 +515,9 @@ export interface Database {
         };
       };
     };
-    Views: {};
-    Functions: {};
-    Enums: {};
-    CompositeTypes: {};
+    Views: Record<string, unknown>;
+    Functions: Record<string, unknown>;
+    Enums: Record<string, unknown>;
+    CompositeTypes: Record<string, unknown>;
   };
 }


### PR DESCRIPTION
## Summary
- account for BottomNav height and safe-area inset with calc-based padding
- replace empty object placeholders in generated Supabase types to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b50ea2266c832c96649e8f5cc3890b