### PR TITLE
Remove grid view toggle on goals page

### DIFF
--- a/src/app/(app)/goals/components/GoalsUtilityBar.tsx
+++ b/src/app/(app)/goals/components/GoalsUtilityBar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { List, LayoutGrid } from "lucide-react";
 
 export type FilterStatus = "All" | "Active" | "Completed" | "Overdue";
 export type SortOption = "A→Z" | "Due Soon" | "Progress" | "Recently Updated";
@@ -13,8 +12,6 @@ interface GoalsUtilityBarProps {
   onFilter(f: FilterStatus): void;
   sort: SortOption;
   onSort(s: SortOption): void;
-  view: "grid" | "list";
-  onViewChange(v: "grid" | "list"): void;
 }
 
 export function GoalsUtilityBar({
@@ -24,8 +21,6 @@ export function GoalsUtilityBar({
   onFilter,
   sort,
   onSort,
-  view,
-  onViewChange,
 }: GoalsUtilityBarProps) {
   const [local, setLocal] = useState(search);
 
@@ -64,13 +59,6 @@ export function GoalsUtilityBar({
           <option value="Progress">Progress</option>
           <option value="Recently Updated">Recently Updated</option>
         </select>
-        <button
-          aria-label="Toggle view"
-          onClick={() => onViewChange(view === "grid" ? "list" : "grid")}
-          className="p-2 rounded-md bg-gray-800"
-        >
-          {view === "grid" ? <List className="w-4 h-4" /> : <LayoutGrid className="w-4 h-4" />}
-        </button>
       </div>
     </div>
   );

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -64,7 +64,6 @@ function goalStatusToStatus(status?: string | null): Goal["status"] {
 
 export default function GoalsPage() {
   const [goals, setGoals] = useState<Goal[]>([]);
-  const [view, setView] = useState<"grid" | "list">("grid");
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<FilterStatus>("All");
   const [sort, setSort] = useState<SortOption>("A→Z");
@@ -264,21 +263,13 @@ export default function GoalsPage() {
           onFilter={setFilter}
           sort={sort}
           onSort={setSort}
-          view={view}
-          onViewChange={setView}
         />
         {loading ? (
           <LoadingSkeleton />
         ) : filteredGoals.length === 0 ? (
           <EmptyState onCreate={() => setDrawer(true)} />
         ) : (
-          <div
-            className={
-              view === "grid"
-                ? "grid grid-cols-2 gap-4 p-4"
-                : "flex flex-col gap-4 p-4"
-            }
-          >
+          <div className="flex flex-col gap-4 p-4">
             {filteredGoals.map((goal) => (
               <GoalCard
                 key={goal.id}


### PR DESCRIPTION
## Summary
- Remove row/grid view toggle from goals utility bar
- Always render goal list in rows

## Testing
- `pnpm lint`
- `pnpm test:run --reporter=basic`


------
https://chatgpt.com/codex/tasks/task_e_68b51d5256c0832ca089385812d123fe