### PR TITLE
feat: add skill drawer component

### DIFF
--- a/src/app/(app)/skills/components/SkillDrawer.tsx
+++ b/src/app/(app)/skills/components/SkillDrawer.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export interface Skill {
+  id: string;
+  name: string;
+  icon: string;
+  level: number;
+  progress: number;
+  cat_id: string | null;
+  created_at?: string | null;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+}
+
+interface SkillDrawerProps {
+  open: boolean;
+  onClose(): void;
+  onAdd(skill: Skill): void;
+  categories: Category[];
+  onAddCategory(cat: Category): void;
+  initialSkill?: Skill | null;
+  onUpdate?(skill: Skill): void;
+}
+
+export function SkillDrawer({
+  open,
+  onClose,
+  onAdd,
+  categories,
+  onAddCategory,
+  initialSkill,
+  onUpdate,
+}: SkillDrawerProps) {
+  const [name, setName] = useState("");
+  const [emoji, setEmoji] = useState("💡");
+  const [cat, setCat] = useState("");
+  const [newCat, setNewCat] = useState("");
+
+  const editing = Boolean(initialSkill);
+
+  useEffect(() => {
+    if (initialSkill) {
+      setName(initialSkill.name);
+      setEmoji(initialSkill.icon || "💡");
+      setCat(initialSkill.cat_id || "");
+    } else {
+      setName("");
+      setEmoji("💡");
+      setCat("");
+      setNewCat("");
+    }
+  }, [initialSkill, open]);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    let catId = cat;
+    if (cat === "new" && newCat.trim()) {
+      const created = { id: "local-" + Date.now(), name: newCat.trim() };
+      catId = created.id;
+      onAddCategory(created);
+    }
+
+    const base: Skill = {
+      id: initialSkill?.id || "local-" + Date.now(),
+      name: trimmed,
+      icon: emoji,
+      level: initialSkill?.level ?? 1,
+      progress: initialSkill?.progress ?? 0,
+      cat_id: catId || null,
+      created_at: initialSkill?.created_at ?? new Date().toISOString(),
+    };
+
+    if (editing && onUpdate) {
+      onUpdate(base);
+    } else {
+      onAdd(base);
+    }
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className="absolute right-0 top-0 h-full w-80 bg-gray-800 p-4 overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-4">{editing ? "Edit Skill" : "Add Skill"}</h2>
+        <form onSubmit={submit} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">Name *</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Emoji</label>
+            <input
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            />
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Category</label>
+            <select
+              value={cat}
+              onChange={(e) => setCat(e.target.value)}
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            >
+              <option value="">Select...</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+              <option value="new">+ New Category</option>
+            </select>
+            {cat === "new" && (
+              <input
+                value={newCat}
+                onChange={(e) => setNewCat(e.target.value)}
+                placeholder="New category"
+                className="w-full px-3 py-2 rounded bg-gray-700 mt-2"
+              />
+            )}
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-2 rounded bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button type="submit" className="px-3 py-2 rounded bg-blue-600">
+              {editing ? "Save" : "Add"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(app)/skills/page.tsx
+++ b/src/app/(app)/skills/page.tsx
@@ -5,13 +5,7 @@ import Link from "next/link";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetFooter,
-} from "@/components/ui/sheet";
+import { SkillDrawer, type Category, type Skill } from "./components/SkillDrawer";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -76,21 +70,6 @@ function CircularProgress({ value }: { value: number }) {
   );
 }
 
-interface Skill {
-  id: string;
-  name: string;
-  icon: string;
-  level: number;
-  progress: number;
-  cat_id: string | null;
-  created_at?: string | null;
-}
-
-interface Category {
-  id: string;
-  name: string;
-}
-
 function SkillsPageContent() {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -102,12 +81,6 @@ function SkillsPageContent() {
   const [view, setView] = useState<"grid" | "list">("grid");
   const [sort, setSort] = useState("name");
   const [open, setOpen] = useState(false);
-
-  // create drawer fields
-  const [formName, setFormName] = useState("");
-  const [formEmoji, setFormEmoji] = useState("💡");
-  const [formCat, setFormCat] = useState("");
-  const [formNewCat, setFormNewCat] = useState("");
 
   const supabase = getSupabaseBrowser();
 
@@ -205,31 +178,9 @@ function SkillsPageContent() {
     ];
   }, [categories, counts]);
 
-  const handleAddSkill = () => {
-    const name = formName.trim();
-    if (!name) return;
-    let catId = formCat;
-    const catName = formNewCat.trim();
-    if (formCat === "new" && catName) {
-      catId = "local-" + Date.now();
-      setCategories((prev) => [...prev, { id: catId, name: catName }]);
-    }
-    const newSkill: Skill = {
-      id: "local-" + Date.now(),
-      name,
-      icon: formEmoji,
-      level: 1,
-      progress: 0,
-      cat_id: catId || null,
-      created_at: new Date().toISOString(),
-    };
-    setSkills((prev) => [...prev, newSkill]);
-    setOpen(false);
-    setFormName("");
-    setFormEmoji("💡");
-    setFormCat("");
-    setFormNewCat("");
-  };
+  const addSkill = (skill: Skill) => setSkills((prev) => [...prev, skill]);
+  const addCategory = (cat: Category) =>
+    setCategories((prev) => [...prev, cat]);
 
   const handleRemoveSkill = (id: string) => {
     setSkills((prev) => prev.filter((s) => s.id !== id));
@@ -385,69 +336,13 @@ function SkillsPageContent() {
         </div>
       )}
 
-      {/* Create Drawer */}
-      <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent
-          side="bottom"
-          className="bg-[#1E1E1E] text-white max-h-[80vh]"
-        >
-          <SheetHeader>
-            <SheetTitle>Add Skill</SheetTitle>
-          </SheetHeader>
-          <div className="flex-1 overflow-y-auto p-4 space-y-4">
-            <div>
-              <label className="block text-sm mb-1">Name</label>
-              <Input
-                value={formName}
-                onChange={(e) => setFormName(e.target.value)}
-                className="h-11"
-              />
-            </div>
-            <div>
-              <label className="block text-sm mb-1">Emoji</label>
-              <Input
-                value={formEmoji}
-                onChange={(e) => setFormEmoji(e.target.value)}
-                className="h-11"
-                placeholder="🎯"
-              />
-            </div>
-            <div>
-              <label className="block text-sm mb-1">Category</label>
-              <select
-                value={formCat}
-                onChange={(e) => setFormCat(e.target.value)}
-                className="h-11 w-full bg-[#2C2C2C] border border-[#333] rounded-md px-3"
-              >
-                <option value="">Select...</option>
-                {categories.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-                <option value="new">+ New Category</option>
-              </select>
-              {formCat === "new" && (
-                <Input
-                  placeholder="New category"
-                  value={formNewCat}
-                  onChange={(e) => setFormNewCat(e.target.value)}
-                  className="h-11 mt-2"
-                />
-              )}
-            </div>
-          </div>
-          <SheetFooter>
-            <Button
-              className="w-full bg-gray-200 text-black hover:bg-gray-300"
-              onClick={handleAddSkill}
-              disabled={!formName}
-            >
-              Add
-            </Button>
-          </SheetFooter>
-        </SheetContent>
-      </Sheet>
+      <SkillDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        onAdd={addSkill}
+        categories={categories}
+        onAddCategory={addCategory}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable SkillDrawer for creating or editing skills
- integrate SkillDrawer into skills page

## Testing
- `pnpm test:run`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b51d9ef640832c8ba8f3aa57e04cd5