### PR TITLE
feat: add windows table migration

### DIFF
--- a/src/app/(app)/windows/page.tsx
+++ b/src/app/(app)/windows/page.tsx
@@ -15,10 +15,10 @@ import { getSupabaseBrowser } from "@/lib/supabase";
 interface WindowRow {
   id: string;
   label: string;
-  days_of_week: number[];
+  days: number[];
   start_local: string;
   end_local: string;
-  energy_cap: EnergyCap | null;
+  energy: EnergyCap | null;
 }
 
 type EnergyCap =
@@ -31,10 +31,10 @@ type EnergyCap =
 
 interface WindowPayload {
   label: string;
-  days_of_week: number[];
+  days: number[];
   start_local: string;
   end_local: string;
-  energy_cap: EnergyCap | null;
+  energy: EnergyCap | null;
   user_id: string;
 }
 
@@ -90,9 +90,7 @@ export default function WindowsPage() {
     }
     const { data, error } = await supabase
       .from("windows")
-      .select(
-        "id,label,days_of_week,start_local,end_local,energy_cap"
-      )
+      .select("id,label,days,start_local,end_local,energy")
       .eq("user_id", user.id)
       .order("created_at", { ascending: true });
     if (!error && data) {
@@ -123,11 +121,11 @@ export default function WindowsPage() {
   function openEdit(w: WindowRow) {
     setEditing(w);
     setLabel(w.label);
-    setDayPreset(determinePreset(w.days_of_week || []));
-    setDays(w.days_of_week || []);
+    setDayPreset(determinePreset(w.days || []));
+    setDays(w.days || []);
     setStart(w.start_local || "");
     setEnd(w.end_local || "");
-    setEnergy(w.energy_cap || "NO");
+    setEnergy(w.energy || "NO");
     setShowForm(true);
   }
 
@@ -196,7 +194,7 @@ export default function WindowsPage() {
     const duplicate = windows.find(
       (w) =>
         w.id !== editing?.id &&
-        arraysEqual(w.days_of_week || [], days) &&
+        arraysEqual(w.days || [], days) &&
         w.start_local === start &&
         w.end_local === end
     );
@@ -209,16 +207,16 @@ export default function WindowsPage() {
 
     const conflict = windows.find((w) => {
       if (w.id === editing?.id) return false;
-      const overlapDay = w.days_of_week.some((d) => days.includes(d));
+      const overlapDay = w.days.some((d) => days.includes(d));
       if (!overlapDay) return false;
       return parseTime(start) < parseTime(w.end_local) && parseTime(end) > parseTime(w.start_local);
     });
     const payload: WindowPayload = {
       label,
-      days_of_week: days,
+      days,
       start_local: start,
       end_local: end,
-      energy_cap: energy,
+      energy,
       user_id: user.id,
     };
 
@@ -303,10 +301,10 @@ export default function WindowsPage() {
                     <div>
                       <div className="font-medium">{w.label}</div>
                       <div className="text-sm text-gray-400">
-                        {formatDays(w.days_of_week)} {w.start_local} - {w.end_local}
+                        {formatDays(w.days)} {w.start_local} - {w.end_local}
                       </div>
                       <div className="text-sm text-gray-400">
-                        {w.energy_cap}
+                        {w.energy}
                       </div>
                     </div>
                     <div className="flex flex-col gap-2">

--- a/src/app/(app)/windows/page.tsx
+++ b/src/app/(app)/windows/page.tsx
@@ -68,6 +68,7 @@ export default function WindowsPage() {
   const [pendingPayload, setPendingPayload] = useState<WindowPayload | null>(
     null
   );
+  const [saving, setSaving] = useState(false);
 
   const is24Hour = !new Intl.DateTimeFormat(undefined, {
     hour: "numeric",
@@ -231,6 +232,7 @@ export default function WindowsPage() {
 
   async function performSave(payload: WindowPayload, userId: string) {
     if (!supabase) return;
+    setSaving(true);
     let error;
     if (editing) {
       ({ error } = await supabase
@@ -241,8 +243,10 @@ export default function WindowsPage() {
     } else {
       ({ error } = await supabase.from("windows").insert(payload));
     }
+    setSaving(false);
     if (error) {
-      toast.error("Error", "Failed to save window");
+      console.error(error);
+      toast.error("Error", error.message || "Failed to save window");
     } else {
       toast.success("Saved", "Window saved");
       setShowForm(false);
@@ -493,8 +497,9 @@ export default function WindowsPage() {
                 <Button
                   type="submit"
                   className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+                  disabled={saving}
                 >
-                  Save
+                  {saving ? "Saving..." : "Save"}
                 </Button>
               </div>
             </form>
@@ -511,6 +516,7 @@ export default function WindowsPage() {
                 <Button
                   className="bg-gray-800 text-gray-100 hover:bg-gray-700"
                   onClick={() => performSave(pendingPayload, pendingPayload.user_id)}
+                  disabled={saving}
                 >
                   Keep both
                 </Button>
@@ -533,6 +539,7 @@ export default function WindowsPage() {
                     };
                     performSave(adjusted, pendingPayload.user_id);
                   }}
+                  disabled={saving}
                 >
                   Adjust end time
                 </Button>

--- a/src/lib/scheduler/windows.ts
+++ b/src/lib/scheduler/windows.ts
@@ -9,11 +9,9 @@ export async function getWindowsForDate(date: Date, userId: string) {
   const weekday = date.getDay();
   const { data, error } = await supabase
     .from("windows")
-    .select(
-      "id,label,days_of_week,start_local,end_local,energy_cap"
-    )
+    .select("id,label,days,start_local,end_local,energy")
     .eq("user_id", userId)
-    .contains("days_of_week", [weekday]);
+    .contains("days", [weekday]);
   if (error) throw error;
   return (data ?? []) as WindowRow[];
 }

--- a/supabase/migrations/20250827050225_create_windows_table.sql
+++ b/supabase/migrations/20250827050225_create_windows_table.sql
@@ -1,0 +1,36 @@
+-- Migration to create windows table with RLS policies
+CREATE TABLE IF NOT EXISTS public.windows (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+    label text NOT NULL,
+    days smallint[] NOT NULL,
+    start_local time without time zone NOT NULL,
+    end_local time without time zone NOT NULL,
+    energy text NOT NULL
+);
+
+-- Enable row level security
+ALTER TABLE public.windows ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist
+DROP POLICY IF EXISTS "windows_select_own" ON public.windows;
+DROP POLICY IF EXISTS "windows_insert_own" ON public.windows;
+DROP POLICY IF EXISTS "windows_update_own" ON public.windows;
+DROP POLICY IF EXISTS "windows_delete_own" ON public.windows;
+
+-- Allow users to manage their own windows
+CREATE POLICY "windows_select_own" ON public.windows
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "windows_insert_own" ON public.windows
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "windows_update_own" ON public.windows
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "windows_delete_own" ON public.windows
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Grant permissions to authenticated users
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.windows TO authenticated;

--- a/test/lib/scheduler/windows.spec.ts
+++ b/test/lib/scheduler/windows.spec.ts
@@ -10,10 +10,10 @@ describe("genSlots", () => {
         created_at: "",
         user_id: "u1",
         label: "Morning",
-        days_of_week: [0],
+        days: [0],
         start_local: "06:00",
         end_local: "07:00",
-        energy_cap: null,
+        energy: "NO",
       },
     ];
     const slots = genSlots(date, windows);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -482,30 +482,30 @@ export interface Database {
           created_at: string;
           user_id: string;
           label: string;
-          days_of_week: number[];
+          days: number[];
           start_local: string;
           end_local: string;
-          energy_cap: string | null;
+          energy: string;
         };
         Insert: {
           id?: string;
           created_at?: string;
           user_id: string;
           label: string;
-          days_of_week?: number[];
+          days?: number[];
           start_local?: string;
           end_local?: string;
-          energy_cap?: string | null;
+          energy?: string;
         };
         Update: {
           id?: string;
           created_at?: string;
           user_id?: string;
           label?: string;
-          days_of_week?: number[];
+          days?: number[];
           start_local?: string;
           end_local?: string;
-          energy_cap?: string | null;
+          energy?: string;
         };
       };
     };


### PR DESCRIPTION
## Summary
- add migration defining `windows` table with RLS policies
- update supabase types and windows code to use `days` and `energy` columns

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b56cbddcf0832c9d3c4e49611095df