### PR TITLE
feat: add loading bar for goal dropdown

### DIFF
--- a/src/app/(app)/goals/components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/components/ProjectsDropdown.tsx
@@ -2,6 +2,7 @@
 
 import { ProjectRow } from "./ProjectRow";
 import type { Project } from "../types";
+import { Progress } from "@/components/ui/Progress";
 
 interface ProjectsDropdownProps {
   id: string;
@@ -33,11 +34,12 @@ export function ProjectsDropdown({
             Projects for {goalTitle}
           </h4>
           {loading ? (
-            <div className="space-y-2">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className="h-6 bg-gray-800 rounded animate-pulse" />
-              ))}
-            </div>
+            <Progress
+              value={100}
+              className="mb-2"
+              trackClass="bg-gray-700"
+              barClass="bg-blue-500 animate-pulse"
+            />
           ) : projects.length > 0 ? (
             <div className="space-y-2">
               {projects.map((p) => (


### PR DESCRIPTION
## Summary
- replace tall skeleton loaders with a compact progress bar in project dropdown

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b5d5ceff20832c87afbba2d0e1d8c1