### PR TITLE
feat: link monuments and skills in creation modal

### DIFF
--- a/lib/queries/monuments.ts
+++ b/lib/queries/monuments.ts
@@ -1,0 +1,28 @@
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+export interface Monument {
+  id: string;
+  title: string;
+}
+
+export async function getMonumentsForUser(
+  userId: string
+): Promise<Monument[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    throw new Error("Supabase client not available");
+  }
+
+  const { data, error } = await supabase
+    .from("monuments")
+    .select("id, title")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching monuments:", error);
+    throw error;
+  }
+
+  return data || [];
+}

--- a/lib/queries/skills.ts
+++ b/lib/queries/skills.ts
@@ -1,0 +1,26 @@
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+export interface Skill {
+  id: string;
+  name: string;
+}
+
+export async function getSkillsForUser(userId: string): Promise<Skill[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    throw new Error("Supabase client not available");
+  }
+
+  const { data, error } = await supabase
+    .from("skills")
+    .select("id, name")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching skills:", error);
+    throw error;
+  }
+
+  return data || [];
+}


### PR DESCRIPTION
## Summary
- add query helpers for monuments and skills
- allow selecting monuments for goals and skills for projects and tasks in EventModal
- persist selected skills via project_skills mapping

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68b5d954c678832caab9458d0db598a0