### PR TITLE
feat(scheduler): add supabase repo helpers

### DIFF
--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -25,6 +25,7 @@ export default function DraftSchedulerPage() {
     ReturnType<typeof placeByEnergyWeight>["unplaced"]
   >([]);
   const [debug, setDebug] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const windowsByEnergy = useMemo(() => {
     const map: Record<string, WindowLite[]> = {};
@@ -48,15 +49,25 @@ export default function DraftSchedulerPage() {
   }, [tasks]);
 
   async function handleLoad() {
-    const weekday = new Date().getDay();
-    const [ws, ts] = await Promise.all([
-      fetchWindowsForDate(weekday),
-      fetchReadyTasks(),
-    ]);
-    setWindows(ws);
-    setTasks(ts);
-    setPlacements([]);
-    setUnplaced([]);
+    try {
+      const weekday = new Date().getDay();
+      const [ws, ts] = await Promise.all([
+        fetchWindowsForDate(weekday),
+        fetchReadyTasks(),
+      ]);
+      setWindows(ws);
+      setTasks(ts);
+      setPlacements([]);
+      setUnplaced([]);
+      setError(null);
+    } catch (e) {
+      console.error(e);
+      setError(e instanceof Error ? e.message : String(e));
+      setWindows([]);
+      setTasks([]);
+      setPlacements([]);
+      setUnplaced([]);
+    }
   }
 
   function handleAutoPlace() {
@@ -83,6 +94,8 @@ export default function DraftSchedulerPage() {
           Auto-place
         </Button>
       </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
 
       {windows.length > 0 && (
         <section>

--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/scheduler/repo";
 import { placeByEnergyWeight } from "@/lib/scheduler/placer";
 import { TaskLite, taskWeight } from "@/lib/scheduler/weight";
+import { MOCK_TASKS, MOCK_WINDOWS } from "@/lib/scheduler/mock";
 
 function fmt(d: Date) {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -48,6 +49,14 @@ export default function DraftSchedulerPage() {
     return map;
   }, [tasks]);
 
+  function handleLoadMock() {
+    setWindows(MOCK_WINDOWS);
+    setTasks(MOCK_TASKS);
+    setPlacements([]);
+    setUnplaced([]);
+    setError(null);
+  }
+
   async function handleLoad() {
     try {
       const weekday = new Date().getDay();
@@ -85,6 +94,12 @@ export default function DraftSchedulerPage() {
           onClick={handleLoad}
         >
           Load Data
+        </Button>
+        <Button
+          className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"
+          onClick={handleLoadMock}
+        >
+          Load Mock
         </Button>
         <Button
           className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"

--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  fetchReadyTasks,
+  fetchWindowsForDate,
+  type WindowLite,
+} from "@/lib/scheduler/repo";
+import { placeByEnergyWeight } from "@/lib/scheduler/placer";
+import { TaskLite, taskWeight } from "@/lib/scheduler/weight";
+
+function fmt(d: Date) {
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export default function DraftSchedulerPage() {
+  const [tasks, setTasks] = useState<TaskLite[]>([]);
+  const [windows, setWindows] = useState<WindowLite[]>([]);
+  const [placements, setPlacements] = useState<
+    ReturnType<typeof placeByEnergyWeight>["placements"]
+  >([]);
+  const [unplaced, setUnplaced] = useState<
+    ReturnType<typeof placeByEnergyWeight>["unplaced"]
+  >([]);
+  const [debug, setDebug] = useState(false);
+
+  const windowsByEnergy = useMemo(() => {
+    const map: Record<string, WindowLite[]> = {};
+    for (const w of windows) {
+      if (!map[w.energy_cap]) map[w.energy_cap] = [];
+      map[w.energy_cap].push(w);
+    }
+    return map;
+  }, [windows]);
+
+  const windowMap = useMemo(() => {
+    const map: Record<string, WindowLite> = {};
+    for (const w of windows) map[w.id] = w;
+    return map;
+  }, [windows]);
+
+  const taskMap = useMemo(() => {
+    const map: Record<string, TaskLite> = {};
+    for (const t of tasks) map[t.id] = t;
+    return map;
+  }, [tasks]);
+
+  async function handleLoad() {
+    const weekday = new Date().getDay();
+    const [ws, ts] = await Promise.all([
+      fetchWindowsForDate(weekday),
+      fetchReadyTasks(),
+    ]);
+    setWindows(ws);
+    setTasks(ts);
+    setPlacements([]);
+    setUnplaced([]);
+  }
+
+  function handleAutoPlace() {
+    const date = new Date();
+    const result = placeByEnergyWeight(tasks, windows, date);
+    setPlacements(result.placements);
+    setUnplaced(result.unplaced);
+  }
+
+  return (
+    <div className="space-y-6 p-4 text-zinc-100">
+      <div className="flex gap-2">
+        <Button
+          className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"
+          onClick={handleLoad}
+        >
+          Load Data
+        </Button>
+        <Button
+          className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"
+          onClick={handleAutoPlace}
+          disabled={!tasks.length || !windows.length}
+        >
+          Auto-place
+        </Button>
+      </div>
+
+      {windows.length > 0 && (
+        <section>
+          <h2 className="mb-2 font-semibold">Windows</h2>
+          {Object.entries(windowsByEnergy).map(([energy, list]) => (
+            <div key={energy} className="mb-4">
+              <div className="mb-1 text-sm font-medium">{energy}</div>
+              <ul className="ml-4 list-disc text-xs text-zinc-400">
+                {list.map((w) => (
+                  <li key={w.id}>
+                    {w.label} {w.start_local}–{w.end_local}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {tasks.length > 0 && (
+        <section>
+          <h2 className="mb-2 font-semibold">Tasks</h2>
+          <ul className="space-y-2">
+            {tasks.map((t) => (
+              <li key={t.id} className="rounded-md border border-zinc-800 bg-zinc-900 p-2">
+                <div className="flex justify-between text-sm">
+                  <span>{t.id}</span>
+                  <div className="flex gap-1">
+                    {t.energy && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {t.energy}
+                      </Badge>
+                    )}
+                    <Badge variant="outline" className="text-[10px]">
+                      {taskWeight(t)}
+                    </Badge>
+                  </div>
+                </div>
+                <div className="text-xs text-zinc-400">
+                  {t.priority} / {t.stage} • {t.duration_min}m
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {placements.length > 0 && (
+        <section>
+          <h2 className="mb-2 font-semibold">Placements</h2>
+          <ul className="space-y-2">
+            {placements.map((p) => {
+              const w = windowMap[p.windowId];
+              return (
+                <li
+                  key={p.taskId}
+                  className="rounded-md border border-zinc-800 bg-zinc-900 p-2"
+                >
+                  <div className="flex justify-between text-sm">
+                    <span>{p.taskId}</span>
+                    <div className="flex gap-1">
+                      {w && (
+                        <Badge variant="outline" className="text-[10px]">
+                          {w.energy_cap}
+                        </Badge>
+                      )}
+                      <Badge variant="outline" className="text-[10px]">
+                        {p.weight}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div className="text-xs text-zinc-400">
+                    {w ? w.label : p.windowId} {fmt(p.start)}–{fmt(p.end)}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {unplaced.length > 0 && (
+        <section>
+          <h2 className="mb-2 font-semibold">Unplaced</h2>
+          <ul className="space-y-2">
+            {unplaced.map((u) => {
+              const t = taskMap[u.taskId];
+              return (
+                <li
+                  key={u.taskId}
+                  className="rounded-md border border-zinc-800 bg-zinc-900 p-2"
+                >
+                  <div className="flex justify-between text-sm">
+                    <span>{u.taskId}</span>
+                    <div className="flex gap-1">
+                      {t?.energy && (
+                        <Badge variant="outline" className="text-[10px]">
+                          {t.energy}
+                        </Badge>
+                      )}
+                      {t && (
+                        <Badge variant="outline" className="text-[10px]">
+                          {taskWeight(t)}
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-xs text-zinc-400">{u.reason}</div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-zinc-300"
+          onClick={() => setDebug((d) => !d)}
+        >
+          {debug ? "Hide" : "Show"} Debug
+        </Button>
+        {debug && (
+          <pre className="mt-2 max-h-60 overflow-auto rounded bg-zinc-900 p-2 text-[10px]">
+            {JSON.stringify({ tasks, windows, placements, unplaced }, null, 2)}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -137,7 +137,7 @@ export default function DraftSchedulerPage() {
             {tasks.map((t) => (
               <li key={t.id} className="rounded-md border border-zinc-800 bg-zinc-900 p-2">
                 <div className="flex justify-between text-sm">
-                  <span>{t.id}</span>
+                  <span>{t.name}</span>
                   <div className="flex gap-1">
                     {t.energy && (
                       <Badge variant="outline" className="text-[10px]">
@@ -170,7 +170,7 @@ export default function DraftSchedulerPage() {
                   className="rounded-md border border-zinc-800 bg-zinc-900 p-2"
                 >
                   <div className="flex justify-between text-sm">
-                    <span>{p.taskId}</span>
+                    <span>{taskMap[p.taskId]?.name ?? p.taskId}</span>
                     <div className="flex gap-1">
                       {w && (
                         <Badge variant="outline" className="text-[10px]">
@@ -204,7 +204,7 @@ export default function DraftSchedulerPage() {
                   className="rounded-md border border-zinc-800 bg-zinc-900 p-2"
                 >
                   <div className="flex justify-between text-sm">
-                    <span>{u.taskId}</span>
+                    <span>{t ? t.name : u.taskId}</span>
                     <div className="flex gap-1">
                       {t?.energy && (
                         <Badge variant="outline" className="text-[10px]">

--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -31,8 +31,8 @@ export default function DraftSchedulerPage() {
   const windowsByEnergy = useMemo(() => {
     const map: Record<string, WindowLite[]> = {};
     for (const w of windows) {
-      if (!map[w.energy_cap]) map[w.energy_cap] = [];
-      map[w.energy_cap].push(w);
+      if (!map[w.energy]) map[w.energy] = [];
+      map[w.energy].push(w);
     }
     return map;
   }, [windows]);
@@ -174,7 +174,7 @@ export default function DraftSchedulerPage() {
                     <div className="flex gap-1">
                       {w && (
                         <Badge variant="outline" className="text-[10px]">
-                          {w.energy_cap}
+                          {w.energy}
                         </Badge>
                       )}
                       <Badge variant="outline" className="text-[10px]">

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -47,14 +47,24 @@ export default function SchedulePage() {
       <div className="space-y-6">
         <div className="relative">
           <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
-          <Link href="/windows" className="absolute right-0 top-0">
-            <Button
-              size="sm"
-              className="bg-gray-800 text-gray-100 hover:bg-gray-700"
-            >
-              Windows
-            </Button>
-          </Link>
+          <div className="absolute right-0 top-0 flex gap-2">
+            <Link href="/schedule/draft">
+              <Button
+                size="sm"
+                className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+              >
+                Draft
+              </Button>
+            </Link>
+            <Link href="/windows">
+              <Button
+                size="sm"
+                className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+              >
+                Windows
+              </Button>
+            </Link>
+          </div>
           <p className="text-muted-foreground">
             Plan and manage your time
           </p>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -48,6 +48,14 @@ export default function SchedulePage() {
         <div className="relative">
           <h1 className="text-3xl font-bold tracking-tight">Schedule</h1>
           <div className="absolute right-0 top-0 flex gap-2">
+            <Link href="/tasks">
+              <Button
+                size="sm"
+                className="bg-gray-800 text-gray-100 hover:bg-gray-700"
+              >
+                Tasks
+              </Button>
+            </Link>
             <Link href="/schedule/draft">
               <Button
                 size="sm"

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -50,7 +50,7 @@ export default function TasksPage() {
               className="rounded-md border border-zinc-800 bg-zinc-900 p-2"
             >
               <div className="flex justify-between text-sm">
-                <span>{t.id}</span>
+                <span>{t.name}</span>
                 <div className="flex gap-1">
                   {t.energy && (
                     <Badge variant="outline" className="text-[10px]">

--- a/src/app/(app)/tasks/page.tsx
+++ b/src/app/(app)/tasks/page.tsx
@@ -1,19 +1,73 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import Link from "next/link";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
-import { PageHeader, TaskList } from "@/components/ui";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { fetchReadyTasks } from "@/lib/scheduler/repo";
+import { TaskLite, taskWeight } from "@/lib/scheduler/weight";
 
 export default function TasksPage() {
+  const [tasks, setTasks] = useState<TaskLite[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const ts = await fetchReadyTasks();
+        setTasks(ts);
+      } catch (e) {
+        console.error(e);
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    }
+    load();
+  }, []);
+
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gray-900 text-white">
-        <div className="container mx-auto px-4 py-6">
-          <PageHeader
-            title="Tasks"
-            description="Manage your tasks and track completion"
-          />
-          <TaskList />
+      <div className="space-y-6 p-4 text-zinc-100">
+        <div className="relative">
+          <h1 className="text-3xl font-bold tracking-tight">Tasks</h1>
+          <Link href="/schedule">
+            <Button
+              size="sm"
+              className="absolute right-0 top-0 bg-gray-800 text-gray-100 hover:bg-gray-700"
+            >
+              Back
+            </Button>
+          </Link>
+          <p className="text-muted-foreground">All tasks</p>
         </div>
+
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        <ul className="space-y-2">
+          {tasks.map((t) => (
+            <li
+              key={t.id}
+              className="rounded-md border border-zinc-800 bg-zinc-900 p-2"
+            >
+              <div className="flex justify-between text-sm">
+                <span>{t.id}</span>
+                <div className="flex gap-1">
+                  {t.energy && (
+                    <Badge variant="outline" className="text-[10px]">
+                      {t.energy}
+                    </Badge>
+                  )}
+                  <Badge variant="outline" className="text-[10px]">
+                    {taskWeight(t)}
+                  </Badge>
+                </div>
+              </div>
+              <div className="text-xs text-zinc-400">
+                {t.priority} / {t.stage} • {t.duration_min}m
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </ProtectedRoute>
   );

--- a/src/lib/scheduler/config.ts
+++ b/src/lib/scheduler/config.ts
@@ -1,0 +1,45 @@
+export const ENERGY = {
+  LIST: ["LOW", "MEDIUM", "HIGH"], // placeholder values
+} as const;
+
+export const TASK_PRIORITY_WEIGHT = {
+  NO: 0,
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+  Critical: 4,
+  "Ultra-Critical": 5,
+};
+
+export const TASK_STAGE_WEIGHT = {
+  Prepare: 30,
+  Produce: 20,
+  Perfect: 10,
+};
+
+export const PROJECT_PRIORITY_WEIGHT = {
+  NO: 0,
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+  Critical: 4,
+  "Ultra-Critical": 5,
+};
+
+export const PROJECT_STAGE_WEIGHT = {
+  RESEARCH: 50,
+  TEST: 40,
+  BUILD: 30,
+  REFINE: 20,
+  RELEASE: 10,
+};
+
+export const GOAL_PRIORITY_WEIGHT = {
+  NO: 0,
+  LOW: 10,
+  MEDIUM: 20,
+  HIGH: 30,
+  Critical: 40,
+  "Ultra-Critical": 50,
+};
+

--- a/src/lib/scheduler/config.ts
+++ b/src/lib/scheduler/config.ts
@@ -1,4 +1,5 @@
 export const ENERGY = {
+  // TODO: replace with full energy tiers
   LIST: ["LOW", "MEDIUM", "HIGH"], // placeholder values
 } as const;
 

--- a/src/lib/scheduler/mock.ts
+++ b/src/lib/scheduler/mock.ts
@@ -5,18 +5,18 @@ export const MOCK_WINDOWS: WindowLite[] = [
   {
     id: 'w1',
     label: 'Morning Focus',
-    energy_cap: 'LOW',
+    energy: 'LOW',
     start_local: '09:00',
     end_local: '11:00',
-    days_of_week: null,
+    days: null,
   },
   {
     id: 'w2',
     label: 'Afternoon Deep Work',
-    energy_cap: 'HIGH',
+    energy: 'HIGH',
     start_local: '13:00',
     end_local: '15:00',
-    days_of_week: null,
+    days: null,
   },
 ];
 

--- a/src/lib/scheduler/mock.ts
+++ b/src/lib/scheduler/mock.ts
@@ -1,0 +1,49 @@
+import type { TaskLite } from './weight';
+import type { WindowLite } from './repo';
+
+export const MOCK_WINDOWS: WindowLite[] = [
+  {
+    id: 'w1',
+    label: 'Morning Focus',
+    energy_cap: 'LOW',
+    start_local: '09:00',
+    end_local: '11:00',
+    days_of_week: null,
+  },
+  {
+    id: 'w2',
+    label: 'Afternoon Deep Work',
+    energy_cap: 'HIGH',
+    start_local: '13:00',
+    end_local: '15:00',
+    days_of_week: null,
+  },
+];
+
+export const MOCK_TASKS: TaskLite[] = [
+  {
+    id: 't1',
+    priority: 'HIGH',
+    stage: 'Prepare',
+    duration_min: 60,
+    energy: 'LOW',
+    project_id: null,
+  },
+  {
+    id: 't2',
+    priority: 'MEDIUM',
+    stage: 'Produce',
+    duration_min: 30,
+    energy: 'HIGH',
+    project_id: null,
+  },
+  {
+    id: 't3',
+    priority: 'LOW',
+    stage: 'Perfect',
+    duration_min: 45,
+    energy: 'LOW',
+    project_id: null,
+  },
+];
+

--- a/src/lib/scheduler/mock.ts
+++ b/src/lib/scheduler/mock.ts
@@ -23,6 +23,7 @@ export const MOCK_WINDOWS: WindowLite[] = [
 export const MOCK_TASKS: TaskLite[] = [
   {
     id: 't1',
+    name: 'Mock Task 1',
     priority: 'HIGH',
     stage: 'Prepare',
     duration_min: 60,
@@ -31,6 +32,7 @@ export const MOCK_TASKS: TaskLite[] = [
   },
   {
     id: 't2',
+    name: 'Mock Task 2',
     priority: 'MEDIUM',
     stage: 'Produce',
     duration_min: 30,
@@ -39,6 +41,7 @@ export const MOCK_TASKS: TaskLite[] = [
   },
   {
     id: 't3',
+    name: 'Mock Task 3',
     priority: 'LOW',
     stage: 'Perfect',
     duration_min: 45,

--- a/src/lib/scheduler/placer.ts
+++ b/src/lib/scheduler/placer.ts
@@ -4,7 +4,7 @@ import { ENERGY } from "./config";
 export type WindowLite = {
   id: string;
   label: string;
-  energy_cap: string;
+  energy: string;
   start_local: string;
   end_local: string;
 };
@@ -111,7 +111,7 @@ export function placeByEnergyWeight(
 
   for (const task of sortedTasks) {
     const candidates = windowsSorted.filter(
-      (w) => energyIndex(task.energy) <= energyIndex(w.energy_cap)
+      (w) => energyIndex(task.energy) <= energyIndex(w.energy)
     );
     if (candidates.length === 0) {
       unplaced.push({ taskId: task.id, reason: "no-window" });

--- a/src/lib/scheduler/placer.ts
+++ b/src/lib/scheduler/placer.ts
@@ -1,0 +1,133 @@
+import { TaskLite, taskWeight } from "./weight";
+
+export type WindowLite = {
+  id: string;
+  label: string;
+  energy_cap: string;
+  start_local: string;
+  end_local: string;
+};
+
+export type Slot = {
+  windowId: string;
+  start: Date;
+  end: Date;
+  freeMin: number;
+};
+
+export function addMin(date: Date, n: number): Date {
+  return new Date(date.getTime() + n * 60000);
+}
+
+function parseTime(date: Date, time: string): Date {
+  const [h = 0, m = 0] = time.split(":").map(Number);
+  const d = new Date(date);
+  d.setHours(h, m, 0, 0);
+  return d;
+}
+
+export function genSlotsForWindow(
+  win: WindowLite,
+  date: Date,
+  slotMinutes = 5
+): Slot[] {
+  const start = parseTime(date, win.start_local);
+  const end = parseTime(date, win.end_local);
+  const slots: Slot[] = [];
+  let cursor = new Date(start);
+  while (true) {
+    const next = addMin(cursor, slotMinutes);
+    if (next > end) break;
+    slots.push({
+      windowId: win.id,
+      start: new Date(cursor),
+      end: next,
+      freeMin: slotMinutes,
+    });
+    cursor = next;
+  }
+  return slots;
+}
+
+function findFirstFit(slots: Slot[], durationMin: number): number | null {
+  for (let i = 0; i < slots.length; i++) {
+    if (slots[i].freeMin <= 0) continue;
+    let remaining = durationMin;
+    for (let j = i; j < slots.length && remaining > 0; j++) {
+      if (slots[j].freeMin <= 0) break;
+      remaining -= slots[j].freeMin;
+    }
+    if (remaining <= 0) return i;
+  }
+  return null;
+}
+
+function consume(slots: Slot[], startIndex: number, durationMin: number) {
+  let remaining = durationMin;
+  for (let i = startIndex; i < slots.length && remaining > 0; i++) {
+    const slot = slots[i];
+    const take = Math.min(slot.freeMin, remaining);
+    slot.freeMin -= take;
+    remaining -= take;
+  }
+}
+
+export function placeByEnergyWeight(
+  tasks: TaskLite[],
+  windows: WindowLite[],
+  date: Date
+) {
+  const slotsByWindow: Record<string, Slot[]> = {};
+  for (const w of windows) {
+    slotsByWindow[w.id] = genSlotsForWindow(w, date);
+  }
+
+  const placements: {
+    taskId: string;
+    windowId: string;
+    start: Date;
+    end: Date;
+    weight: number;
+  }[] = [];
+  const unplaced: { taskId: string; reason: string }[] = [];
+
+  const sortedTasks = [...tasks].sort((a, b) => {
+    const diff = taskWeight(b) - taskWeight(a);
+    return diff !== 0 ? diff : a.id.localeCompare(b.id);
+  });
+
+  for (const task of sortedTasks) {
+    const candidates = windows.filter(
+      (w) => task.energy === w.energy_cap
+    );
+    if (candidates.length === 0) {
+      unplaced.push({ taskId: task.id, reason: "no-window" });
+      continue;
+    }
+    const weight = taskWeight(task);
+    let placed = false;
+    for (const w of candidates) {
+      const slots = slotsByWindow[w.id];
+      const idx = findFirstFit(slots, task.duration_min);
+      if (idx === null) continue;
+      const start = new Date(slots[idx].start);
+      const end = addMin(start, task.duration_min);
+      consume(slots, idx, task.duration_min);
+      placements.push({
+        taskId: task.id,
+        windowId: w.id,
+        start,
+        end,
+        weight,
+      });
+      placed = true;
+      break;
+    }
+    if (!placed) {
+      unplaced.push({ taskId: task.id, reason: "no-slot" });
+    }
+  }
+
+  return { placements, unplaced };
+}
+

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -4,9 +4,9 @@ import type { TaskLite, ProjectLite } from './weight';
 export type WindowLite = {
   id: string;
   label: string;
-  energy_cap: number;
-  start_local: string | null;
-  end_local: string | null;
+  energy_cap: string;
+  start_local: string;
+  end_local: string;
   days_of_week: number[] | null;
 };
 

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -14,20 +14,12 @@ export async function fetchReadyTasks(): Promise<TaskLite[]> {
   const supabase = getSupabaseBrowser();
   if (!supabase) throw new Error('Supabase client not available');
 
-  type TaskRow = TaskLite & { status: string };
   const { data, error } = await supabase
     .from('tasks')
-    .select(
-      'id, priority, stage, duration_min, energy, project_id, status'
-    )
-    .in('status', ['backlog', 'ready']);
+    .select('id, priority, stage, duration_min, energy, project_id');
 
   if (error) throw error;
-  return ((data ?? []) as TaskRow[]).map((row) => {
-    const { status, ...task } = row;
-    void status;
-    return task;
-  });
+  return (data ?? []) as TaskLite[];
 }
 
 export async function fetchWindowsForDate(

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -16,10 +16,20 @@ export async function fetchReadyTasks(): Promise<TaskLite[]> {
 
   const { data, error } = await supabase
     .from('tasks')
-    .select('id, priority, stage, duration_min, energy, project_id');
+    .select('id, name, priority, stage, duration_min, energy, project_id');
 
   if (error) throw error;
-  return (data ?? []) as TaskLite[];
+  return (data ?? []).map(
+    ({ id, name, priority, stage, duration_min, energy, project_id }) => ({
+      id,
+      name,
+      priority,
+      stage,
+      duration_min,
+      energy,
+      project_id,
+    })
+  );
 }
 
 export async function fetchWindowsForDate(

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -1,0 +1,67 @@
+import { getSupabaseBrowser } from '../../../lib/supabase';
+import type { TaskLite, ProjectLite } from './weight';
+
+export type WindowLite = {
+  id: string;
+  label: string;
+  energy_cap: number;
+  start_local: string | null;
+  end_local: string | null;
+  days_of_week: number[] | null;
+};
+
+export async function fetchReadyTasks(): Promise<TaskLite[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error('Supabase client not available');
+
+  type TaskRow = TaskLite & { status: string };
+  const { data, error } = await supabase
+    .from('tasks')
+    .select(
+      'id, priority, stage, duration_min, energy, project_id, status'
+    )
+    .in('status', ['backlog', 'ready']);
+
+  if (error) throw error;
+  return ((data ?? []) as TaskRow[]).map((row) => {
+    const { status, ...task } = row;
+    void status;
+    return task;
+  });
+}
+
+export async function fetchWindowsForDate(
+  weekday0to6: number
+): Promise<WindowLite[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error('Supabase client not available');
+
+  const { data, error } = await supabase
+    .from('windows')
+    .select(
+      'id, label, energy_cap, start_local, end_local, days_of_week'
+    )
+    .contains('days_of_week', [weekday0to6]);
+
+  if (error) throw error;
+  return (data ?? []) as WindowLite[];
+}
+
+export async function fetchProjectsMap(): Promise<
+  Record<string, ProjectLite>
+> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error('Supabase client not available');
+
+  const { data, error } = await supabase
+    .from('projects')
+    .select('id, priority, stage');
+
+  if (error) throw error;
+  const map: Record<string, ProjectLite> = {};
+  for (const p of data ?? []) {
+    map[p.id] = p as ProjectLite;
+  }
+  return map;
+}
+

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -4,10 +4,10 @@ import type { TaskLite, ProjectLite } from './weight';
 export type WindowLite = {
   id: string;
   label: string;
-  energy_cap: string;
+  energy: string;
   start_local: string;
   end_local: string;
-  days_of_week: number[] | null;
+  days: number[] | null;
 };
 
 export async function fetchReadyTasks(): Promise<TaskLite[]> {
@@ -30,10 +30,8 @@ export async function fetchWindowsForDate(
 
   const { data, error } = await supabase
     .from('windows')
-    .select(
-      'id, label, energy_cap, start_local, end_local, days_of_week'
-    )
-    .contains('days_of_week', [weekday0to6]);
+    .select('id, label, energy, start_local, end_local, days')
+    .contains('days', [weekday0to6]);
 
   if (error) throw error;
   return (data ?? []) as WindowLite[];

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -8,6 +8,7 @@ import {
 
 export type TaskLite = {
   id: string;
+  name: string;
   priority: string;
   stage: string;
   duration_min: number;

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -26,7 +26,7 @@ export type GoalLite = {
   priority: string;
 };
 
-function hasKey<T extends Record<string, number>>(obj: T, key: string): key is keyof T {
+function hasKey<T extends object>(obj: T, key: PropertyKey): key is keyof T {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
 

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -1,0 +1,55 @@
+import {
+  TASK_PRIORITY_WEIGHT,
+  TASK_STAGE_WEIGHT,
+  PROJECT_PRIORITY_WEIGHT,
+  PROJECT_STAGE_WEIGHT,
+  GOAL_PRIORITY_WEIGHT,
+} from "./config";
+
+export type TaskLite = {
+  id: string;
+  priority: string;
+  stage: string;
+  duration_min: number;
+  energy: string | null;
+  project_id?: string | null;
+};
+
+export type ProjectLite = {
+  id: string;
+  priority: string;
+  stage: string;
+};
+
+export type GoalLite = {
+  id: string;
+  priority: string;
+};
+
+function hasKey<T extends Record<string, number>>(obj: T, key: string): key is keyof T {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+export function taskWeight(t: TaskLite): number {
+  const priority = hasKey(TASK_PRIORITY_WEIGHT, t.priority)
+    ? TASK_PRIORITY_WEIGHT[t.priority]
+    : 0;
+  const stage = hasKey(TASK_STAGE_WEIGHT, t.stage) ? TASK_STAGE_WEIGHT[t.stage] : 0;
+  return priority + stage;
+}
+
+export function projectWeight(p: ProjectLite, relatedTaskWeightsSum: number): number {
+  const priority = hasKey(PROJECT_PRIORITY_WEIGHT, p.priority)
+    ? PROJECT_PRIORITY_WEIGHT[p.priority]
+    : 0;
+  const stage = hasKey(PROJECT_STAGE_WEIGHT, p.stage) ? PROJECT_STAGE_WEIGHT[p.stage] : 0;
+  return relatedTaskWeightsSum / 1000 + priority + stage;
+}
+
+export function goalWeight(g: GoalLite, relatedProjectWeightsSum: number): number {
+  const priority = hasKey(GOAL_PRIORITY_WEIGHT, g.priority)
+    ? GOAL_PRIORITY_WEIGHT[g.priority]
+    : 0;
+  return relatedProjectWeightsSum / 1000 + priority;
+}
+


### PR DESCRIPTION
## Summary
- add scheduler repository helpers to fetch tasks, windows, and projects via Supabase
- add slot-based placer to schedule tasks by energy and weight

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b61bc593a0832c93d722d139da679e