### PR TITLE
feat: add swipeable FAB menu with note option

### DIFF
--- a/components/ui/ComingSoonModal.tsx
+++ b/components/ui/ComingSoonModal.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+interface ComingSoonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  label: string;
+}
+
+export function ComingSoonModal({ isOpen, onClose, label }: ComingSoonModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!isOpen || !mounted) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl w-[300px]">
+        <div className="flex items-center justify-between p-4 border-b border-gray-700">
+          <h2 className="text-lg font-semibold text-white">Add {label}</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-6 text-center text-white">{label} form coming soon!</div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -27,22 +27,22 @@ export function Fab({ className = "" }: FabProps) {
     {
       label: "GOAL",
       eventType: "GOAL" as const,
-      color: "bg-gray-700 hover:bg-gray-600",
+      color: "hover:bg-gray-800",
     },
     {
       label: "PROJECT",
       eventType: "PROJECT" as const,
-      color: "bg-gray-700 hover:bg-gray-600",
+      color: "hover:bg-gray-800",
     },
     {
       label: "TASK",
       eventType: "TASK" as const,
-      color: "bg-gray-700 hover:bg-gray-600",
+      color: "hover:bg-gray-800",
     },
     {
       label: "HABIT",
       eventType: "HABIT" as const,
-      color: "bg-gray-700 hover:bg-gray-600",
+      color: "hover:bg-gray-800",
     },
   ];
 
@@ -141,7 +141,7 @@ export function Fab({ className = "" }: FabProps) {
                 <button
                   key={event.label}
                   onClick={() => handleEventClick(event.eventType)}
-                  className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap ${event.color}`}
+                  className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
                   style={{
                     animationDelay: `${index * 50}ms`,
                     transform: `translateY(${isOpen ? "0" : "20px"})`,
@@ -157,7 +157,7 @@ export function Fab({ className = "" }: FabProps) {
                 <button
                   key={event.label}
                   onClick={() => handleExtraClick(event.label)}
-                  className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap bg-gray-700 hover:bg-gray-600"
+                  className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap"
                   style={{
                     animationDelay: `${index * 50}ms`,
                     transform: `translateY(${isOpen ? "0" : "20px"})`,

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -187,7 +187,7 @@ export function Fab({ className = "" }: FabProps) {
                     key={event.label}
                     variants={itemVariants}
                     onClick={() => handleEventClick(event.eventType)}
-                    className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
+                    className={`w-full px-6 py-3 text-left text-white font-medium transition-colors duration-200 border-b border-gray-700 last:border-b-0 whitespace-nowrap ${event.color}`}
                   >
                     <span className="text-sm opacity-80">add</span>{" "}
                     <span className="text-lg font-bold">{event.label}</span>
@@ -198,7 +198,7 @@ export function Fab({ className = "" }: FabProps) {
                     key={event.label}
                     variants={itemVariants}
                     onClick={() => handleExtraClick(event.label)}
-                    className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap"
+                    className="w-full px-6 py-3 text-left text-white font-medium transition-colors duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 whitespace-nowrap"
                   >
                     <span className="text-sm opacity-80">add</span>{" "}
                     <span className="text-lg font-bold">{event.label}</span>

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -67,20 +67,18 @@ export function Fab({ className = "" }: FabProps) {
   const menuVariants = {
     closed: {
       opacity: 0,
-      scale: 0.8,
-      y: 20,
-      transition: { type: "tween", ease: "easeIn", duration: 0.1 },
+      clipPath: "inset(100% 0% 0% 0%)",
+      transition: { type: "tween", ease: "easeInOut", duration: 0.2 },
     },
     open: {
       opacity: 1,
-      scale: 1,
-      y: 0,
+      clipPath: "inset(0% 0% 0% 0%)",
       transition: {
         type: "tween",
         ease: "easeOut",
-        duration: 0.2,
+        duration: 0.25,
         staggerChildren: 0.05,
-        delayChildren: 0.05,
+        delayChildren: 0.1,
       },
     },
   } as const;
@@ -88,7 +86,7 @@ export function Fab({ className = "" }: FabProps) {
   const itemVariants = {
     closed: {
       opacity: 0,
-      y: 20,
+      y: 10,
       transition: { type: "tween", ease: "easeIn", duration: 0.15 },
     },
     open: {

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -65,15 +65,20 @@ export function Fab({ className = "" }: FabProps) {
   ];
 
   const menuVariants = {
-    closed: { opacity: 0, scale: 0.8, y: 20 },
+    closed: {
+      opacity: 0,
+      scale: 0.8,
+      y: 20,
+      transition: { type: "tween", ease: "easeIn", duration: 0.1 },
+    },
     open: {
       opacity: 1,
       scale: 1,
       y: 0,
       transition: {
-        type: "spring",
-        stiffness: 260,
-        damping: 20,
+        type: "tween",
+        ease: "easeOut",
+        duration: 0.2,
         staggerChildren: 0.05,
         delayChildren: 0.05,
       },
@@ -81,8 +86,16 @@ export function Fab({ className = "" }: FabProps) {
   } as const;
 
   const itemVariants = {
-    closed: { opacity: 0, y: 20 },
-    open: { opacity: 1, y: 0 },
+    closed: {
+      opacity: 0,
+      y: 20,
+      transition: { type: "tween", ease: "easeIn", duration: 0.15 },
+    },
+    open: {
+      opacity: 1,
+      y: 0,
+      transition: { type: "tween", ease: "easeOut", duration: 0.15 },
+    },
   } as const;
 
   const handleEventClick = (

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -19,6 +19,7 @@ export function Fab({ className = "" }: FabProps) {
   const [comingSoon, setComingSoon] = useState<string | null>(null);
   const [menuPage, setMenuPage] = useState(0);
   const [touchStartX, setTouchStartX] = useState(0);
+  const [swipeProgress, setSwipeProgress] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -74,12 +75,26 @@ export function Fab({ className = "" }: FabProps) {
 
   const handleTouchStart = (e: React.TouchEvent) => {
     setTouchStartX(e.touches[0].clientX);
+    setSwipeProgress(0);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const currentX = e.touches[0].clientX;
+    const diff = currentX - touchStartX;
+    if (menuPage === 0 && diff < 0) {
+      setSwipeProgress(Math.min(-diff / 100, 1));
+    } else if (menuPage === 1 && diff > 0) {
+      setSwipeProgress(Math.min(diff / 100, 1));
+    } else {
+      setSwipeProgress(0);
+    }
   };
 
   const handleTouchEnd = (e: React.TouchEvent) => {
     const diff = e.changedTouches[0].clientX - touchStartX;
     if (diff < -50) setMenuPage(1);
     if (diff > 50) setMenuPage(0);
+    setSwipeProgress(0);
   };
 
   // Close menu when clicking outside
@@ -109,10 +124,17 @@ export function Fab({ className = "" }: FabProps) {
         <div
           ref={menuRef}
           onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
-          className={`absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px] ${
-            menuPage === 1 ? "bg-gray-900/60" : "bg-gray-900/40"
-          }`}
+          className="absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px]"
+          style={{
+            backgroundColor: `rgba(17, 24, 39, ${
+              menuPage === 1
+                ? 0.6 - 0.2 * swipeProgress
+                : 0.4 + 0.2 * swipeProgress
+            })`,
+            transition: "background-color 0.1s linear",
+          }}
         >
           {menuPage === 0
             ? addEvents.map((event, index) => (

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -64,6 +64,27 @@ export function Fab({ className = "" }: FabProps) {
     { label: "NOTE" },
   ];
 
+  const menuVariants = {
+    closed: { opacity: 0, scale: 0.8, y: 20 },
+    open: {
+      opacity: 1,
+      scale: 1,
+      y: 0,
+      transition: {
+        type: "spring",
+        stiffness: 260,
+        damping: 20,
+        staggerChildren: 0.05,
+        delayChildren: 0.05,
+      },
+    },
+  } as const;
+
+  const itemVariants = {
+    closed: { opacity: 0, y: 20 },
+    open: { opacity: 1, y: 0 },
+  } as const;
+
   const handleEventClick = (
     eventType: "GOAL" | "PROJECT" | "TASK" | "HABIT"
   ) => {
@@ -144,43 +165,33 @@ export function Fab({ className = "" }: FabProps) {
               transition: "background-color 0.1s linear",
               transformOrigin: "bottom center",
             }}
-            initial={{ opacity: 0, scale: 0.8, y: 20 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.8, y: 20 }}
-            transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            variants={menuVariants}
+            initial="closed"
+            animate="open"
+            exit="closed"
           >
             {menuPage === 0
-              ? addEvents.map((event, index) => (
-                  <button
+              ? addEvents.map((event) => (
+                  <motion.button
                     key={event.label}
+                    variants={itemVariants}
                     onClick={() => handleEventClick(event.eventType)}
                     className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
-                    style={{
-                      animationDelay: `${index * 50}ms`,
-                      transform: `translateY(${isOpen ? "0" : "20px"})`,
-                      opacity: isOpen ? 1 : 0,
-                      transition: `all 0.2s ease ${index * 50}ms`,
-                    }}
                   >
                     <span className="text-sm opacity-80">add</span>{" "}
                     <span className="text-lg font-bold">{event.label}</span>
-                  </button>
+                  </motion.button>
                 ))
-              : extraEvents.map((event, index) => (
-                  <button
+              : extraEvents.map((event) => (
+                  <motion.button
                     key={event.label}
+                    variants={itemVariants}
                     onClick={() => handleExtraClick(event.label)}
                     className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap"
-                    style={{
-                      animationDelay: `${index * 50}ms`,
-                      transform: `translateY(${isOpen ? "0" : "20px"})`,
-                      opacity: isOpen ? 1 : 0,
-                      transition: `all 0.2s ease ${index * 50}ms`,
-                    }}
                   >
                     <span className="text-sm opacity-80">add</span>{" "}
                     <span className="text-lg font-bold">{event.label}</span>
-                  </button>
+                  </motion.button>
                 ))}
           </motion.div>
         )}

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -25,8 +25,8 @@ export function Fab({ className = "" }: FabProps) {
 
   const getMenuBackground = () => {
     const progress = menuPage === 1 ? 1 - swipeProgress : swipeProgress;
-    const start = [229, 231, 235]; // gray-200
-    const end = [31, 41, 55]; // gray-800
+    const start = [55, 65, 81]; // gray-700
+    const end = [0, 0, 0]; // black
     const r = start[0] + (end[0] - start[0]) * progress;
     const g = start[1] + (end[1] - start[1]) * progress;
     const b = start[2] + (end[2] - start[2]) * progress;
@@ -37,22 +37,22 @@ export function Fab({ className = "" }: FabProps) {
     {
       label: "GOAL",
       eventType: "GOAL" as const,
-      color: "hover:bg-gray-300",
+      color: "hover:bg-gray-600",
     },
     {
       label: "PROJECT",
       eventType: "PROJECT" as const,
-      color: "hover:bg-gray-300",
+      color: "hover:bg-gray-600",
     },
     {
       label: "TASK",
       eventType: "TASK" as const,
-      color: "hover:bg-gray-300",
+      color: "hover:bg-gray-600",
     },
     {
       label: "HABIT",
       eventType: "HABIT" as const,
-      color: "hover:bg-gray-300",
+      color: "hover:bg-gray-600",
     },
   ];
 
@@ -147,7 +147,7 @@ export function Fab({ className = "" }: FabProps) {
                 <button
                   key={event.label}
                   onClick={() => handleEventClick(event.eventType)}
-                  className={`w-full px-6 py-3 text-left text-gray-900 font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
+                  className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
                   style={{
                     animationDelay: `${index * 50}ms`,
                     transform: `translateY(${isOpen ? "0" : "20px"})`,

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef } from "react";
 import { Plus, X } from "lucide-react";
 import { EventModal } from "./EventModal";
+import { NoteModal } from "./NoteModal";
+import { ComingSoonModal } from "./ComingSoonModal";
 
 interface FabProps {
   className?: string;
@@ -13,6 +15,10 @@ export function Fab({ className = "" }: FabProps) {
   const [modalEventType, setModalEventType] = useState<
     "GOAL" | "PROJECT" | "TASK" | "HABIT" | null
   >(null);
+  const [showNote, setShowNote] = useState(false);
+  const [comingSoon, setComingSoon] = useState<string | null>(null);
+  const [menuPage, setMenuPage] = useState(0);
+  const [touchStartX, setTouchStartX] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -39,6 +45,13 @@ export function Fab({ className = "" }: FabProps) {
     },
   ];
 
+  const extraEvents = [
+    { label: "SERVICE" },
+    { label: "PRODUCT" },
+    { label: "REQUEST" },
+    { label: "NOTE" },
+  ];
+
   const handleEventClick = (
     eventType: "GOAL" | "PROJECT" | "TASK" | "HABIT"
   ) => {
@@ -46,8 +59,27 @@ export function Fab({ className = "" }: FabProps) {
     setModalEventType(eventType);
   };
 
+  const handleExtraClick = (label: string) => {
+    setIsOpen(false);
+    if (label === "NOTE") {
+      setShowNote(true);
+    } else {
+      setComingSoon(label);
+    }
+  };
+
   const toggleMenu = () => {
     setIsOpen(!isOpen);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setTouchStartX(e.touches[0].clientX);
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const diff = e.changedTouches[0].clientX - touchStartX;
+    if (diff < -50) setMenuPage(1);
+    if (diff > 50) setMenuPage(0);
   };
 
   // Close menu when clicking outside
@@ -76,24 +108,45 @@ export function Fab({ className = "" }: FabProps) {
       {isOpen && (
         <div
           ref={menuRef}
-          className="absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 bg-gray-900/40 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px]"
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+          className={`absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px] ${
+            menuPage === 1 ? "bg-gray-900/60" : "bg-gray-900/40"
+          }`}
         >
-          {addEvents.map((event, index) => (
-            <button
-              key={event.label}
-              onClick={() => handleEventClick(event.eventType)}
-              className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap ${event.color}`}
-              style={{
-                animationDelay: `${index * 50}ms`,
-                transform: `translateY(${isOpen ? "0" : "20px"})`,
-                opacity: isOpen ? 1 : 0,
-                transition: `all 0.2s ease ${index * 50}ms`,
-              }}
-            >
-              <span className="text-sm opacity-80">add</span>{" "}
-              <span className="text-lg font-bold">{event.label}</span>
-            </button>
-          ))}
+          {menuPage === 0
+            ? addEvents.map((event, index) => (
+                <button
+                  key={event.label}
+                  onClick={() => handleEventClick(event.eventType)}
+                  className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap ${event.color}`}
+                  style={{
+                    animationDelay: `${index * 50}ms`,
+                    transform: `translateY(${isOpen ? "0" : "20px"})`,
+                    opacity: isOpen ? 1 : 0,
+                    transition: `all 0.2s ease ${index * 50}ms`,
+                  }}
+                >
+                  <span className="text-sm opacity-80">add</span>{" "}
+                  <span className="text-lg font-bold">{event.label}</span>
+                </button>
+              ))
+            : extraEvents.map((event, index) => (
+                <button
+                  key={event.label}
+                  onClick={() => handleExtraClick(event.label)}
+                  className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap bg-gray-700 hover:bg-gray-600"
+                  style={{
+                    animationDelay: `${index * 50}ms`,
+                    transform: `translateY(${isOpen ? "0" : "20px"})`,
+                    opacity: isOpen ? 1 : 0,
+                    transition: `all 0.2s ease ${index * 50}ms`,
+                  }}
+                >
+                  <span className="text-sm opacity-80">add</span>{" "}
+                  <span className="text-lg font-bold">{event.label}</span>
+                </button>
+              ))}
         </div>
       )}
 
@@ -118,6 +171,12 @@ export function Fab({ className = "" }: FabProps) {
         isOpen={modalEventType !== null}
         onClose={() => setModalEventType(null)}
         eventType={modalEventType!}
+      />
+      <NoteModal isOpen={showNote} onClose={() => setShowNote(false)} />
+      <ComingSoonModal
+        isOpen={comingSoon !== null}
+        onClose={() => setComingSoon(null)}
+        label={comingSoon || ""}
       />
     </div>
   );

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Plus, X } from "lucide-react";
 import { EventModal } from "./EventModal";
 import { NoteModal } from "./NoteModal";
@@ -130,53 +131,60 @@ export function Fab({ className = "" }: FabProps) {
   return (
     <div className={className}>
       {/* AddEvents Menu */}
-      {isOpen && (
-        <div
-          ref={menuRef}
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
-          className="absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px]"
-          style={{
-            backgroundColor: getMenuBackground(),
-            transition: "background-color 0.1s linear",
-          }}
-        >
-          {menuPage === 0
-            ? addEvents.map((event, index) => (
-                <button
-                  key={event.label}
-                  onClick={() => handleEventClick(event.eventType)}
-                  className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
-                  style={{
-                    animationDelay: `${index * 50}ms`,
-                    transform: `translateY(${isOpen ? "0" : "20px"})`,
-                    opacity: isOpen ? 1 : 0,
-                    transition: `all 0.2s ease ${index * 50}ms`,
-                  }}
-                >
-                  <span className="text-sm opacity-80">add</span>{" "}
-                  <span className="text-lg font-bold">{event.label}</span>
-                </button>
-              ))
-            : extraEvents.map((event, index) => (
-                <button
-                  key={event.label}
-                  onClick={() => handleExtraClick(event.label)}
-                  className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap"
-                  style={{
-                    animationDelay: `${index * 50}ms`,
-                    transform: `translateY(${isOpen ? "0" : "20px"})`,
-                    opacity: isOpen ? 1 : 0,
-                    transition: `all 0.2s ease ${index * 50}ms`,
-                  }}
-                >
-                  <span className="text-sm opacity-80">add</span>{" "}
-                  <span className="text-lg font-bold">{event.label}</span>
-                </button>
-              ))}
-        </div>
-      )}
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            ref={menuRef}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            className="absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px]"
+            style={{
+              backgroundColor: getMenuBackground(),
+              transition: "background-color 0.1s linear",
+              transformOrigin: "bottom center",
+            }}
+            initial={{ opacity: 0, scale: 0.8, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.8, y: 20 }}
+            transition={{ type: "spring", stiffness: 260, damping: 20 }}
+          >
+            {menuPage === 0
+              ? addEvents.map((event, index) => (
+                  <button
+                    key={event.label}
+                    onClick={() => handleEventClick(event.eventType)}
+                    className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
+                    style={{
+                      animationDelay: `${index * 50}ms`,
+                      transform: `translateY(${isOpen ? "0" : "20px"})`,
+                      opacity: isOpen ? 1 : 0,
+                      transition: `all 0.2s ease ${index * 50}ms`,
+                    }}
+                  >
+                    <span className="text-sm opacity-80">add</span>{" "}
+                    <span className="text-lg font-bold">{event.label}</span>
+                  </button>
+                ))
+              : extraEvents.map((event, index) => (
+                  <button
+                    key={event.label}
+                    onClick={() => handleExtraClick(event.label)}
+                    className="w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:bg-gray-800 hover:scale-105 whitespace-nowrap"
+                    style={{
+                      animationDelay: `${index * 50}ms`,
+                      transform: `translateY(${isOpen ? "0" : "20px"})`,
+                      opacity: isOpen ? 1 : 0,
+                      transition: `all 0.2s ease ${index * 50}ms`,
+                    }}
+                  >
+                    <span className="text-sm opacity-80">add</span>{" "}
+                    <span className="text-lg font-bold">{event.label}</span>
+                  </button>
+                ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* FAB Button - Restored to your original styling */}
       <button

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -23,26 +23,36 @@ export function Fab({ className = "" }: FabProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
+  const getMenuBackground = () => {
+    const progress = menuPage === 1 ? 1 - swipeProgress : swipeProgress;
+    const start = [229, 231, 235]; // gray-200
+    const end = [31, 41, 55]; // gray-800
+    const r = start[0] + (end[0] - start[0]) * progress;
+    const g = start[1] + (end[1] - start[1]) * progress;
+    const b = start[2] + (end[2] - start[2]) * progress;
+    return `rgb(${r}, ${g}, ${b})`;
+  };
+
   const addEvents = [
     {
       label: "GOAL",
       eventType: "GOAL" as const,
-      color: "hover:bg-gray-800",
+      color: "hover:bg-gray-300",
     },
     {
       label: "PROJECT",
       eventType: "PROJECT" as const,
-      color: "hover:bg-gray-800",
+      color: "hover:bg-gray-300",
     },
     {
       label: "TASK",
       eventType: "TASK" as const,
-      color: "hover:bg-gray-800",
+      color: "hover:bg-gray-300",
     },
     {
       label: "HABIT",
       eventType: "HABIT" as const,
-      color: "hover:bg-gray-800",
+      color: "hover:bg-gray-300",
     },
   ];
 
@@ -128,11 +138,7 @@ export function Fab({ className = "" }: FabProps) {
           onTouchEnd={handleTouchEnd}
           className="absolute bottom-20 left-1/2 -translate-x-1/2 mb-2 z-50 border border-gray-700 rounded-lg shadow-2xl overflow-hidden min-w-[200px]"
           style={{
-            backgroundColor: `rgba(17, 24, 39, ${
-              menuPage === 1
-                ? 0.6 - 0.2 * swipeProgress
-                : 0.4 + 0.2 * swipeProgress
-            })`,
+            backgroundColor: getMenuBackground(),
             transition: "background-color 0.1s linear",
           }}
         >
@@ -141,7 +147,7 @@ export function Fab({ className = "" }: FabProps) {
                 <button
                   key={event.label}
                   onClick={() => handleEventClick(event.eventType)}
-                  className={`w-full px-6 py-3 text-left text-white font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
+                  className={`w-full px-6 py-3 text-left text-gray-900 font-medium transition-all duration-200 border-b border-gray-700 last:border-b-0 hover:scale-105 whitespace-nowrap ${event.color}`}
                   style={{
                     animationDelay: `${index * 50}ms`,
                     transform: `translateY(${isOpen ? "0" : "20px"})`,

--- a/components/ui/NoteModal.tsx
+++ b/components/ui/NoteModal.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Input } from "./input";
+import { Textarea } from "./textarea";
+import { Label } from "./label";
+import { Button } from "./button";
+import { Select, SelectContent, SelectItem } from "./select";
+import { useToastHelpers } from "./toast";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import { getSkillsForUser, type Skill } from "@/lib/queries/skills";
+import { getNotes, saveNotes } from "@/lib/notesStorage";
+
+interface NoteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function NoteModal({ isOpen, onClose }: NoteModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const toast = useToastHelpers();
+  const [skills, setSkills] = useState<Skill[]>([]);
+  const [formData, setFormData] = useState({
+    skillId: "",
+    title: "",
+    content: "",
+  });
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    const loadSkills = async () => {
+      const supabase = getSupabaseBrowser();
+      if (!supabase) return;
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+      const skillsData = await getSkillsForUser(user.id);
+      setSkills(skillsData);
+    };
+    if (isOpen && mounted) {
+      loadSkills();
+    }
+  }, [isOpen, mounted]);
+
+  if (!isOpen || !mounted) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formData.skillId) {
+      alert("Please select a skill");
+      return;
+    }
+    const notes = getNotes(formData.skillId);
+    notes.push({
+      id: Date.now().toString(),
+      skillId: formData.skillId,
+      title: formData.title,
+      content: formData.content,
+    });
+    saveNotes(formData.skillId, notes);
+    toast.success("Note saved");
+    setFormData({ skillId: "", title: "", content: "" });
+    onClose();
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-900 border border-gray-700 rounded-lg shadow-2xl w-[400px] max-h-[80vh] overflow-y-auto">
+        <div className="flex items-center justify-between p-6 border-b border-gray-700">
+          <h2 className="text-xl font-semibold text-white">Add Note</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-6 space-y-4">
+          <div className="space-y-2">
+            <Label className="text-white text-sm font-medium">Skill</Label>
+            <Select
+              value={formData.skillId}
+              onValueChange={(value) =>
+                setFormData({ ...formData, skillId: value })
+              }
+            >
+              <SelectContent>
+                {skills.map((skill) => (
+                  <SelectItem key={skill.id} value={skill.id}>
+                    {skill.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label className="text-white text-sm font-medium">Title</Label>
+            <Input
+              value={formData.title}
+              onChange={(e) =>
+                setFormData({ ...formData, title: e.target.value })
+              }
+              placeholder="Note title"
+              className="bg-gray-800 border-gray-600 text-white h-10 text-sm"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label className="text-white text-sm font-medium">Content</Label>
+            <Textarea
+              value={formData.content}
+              onChange={(e) =>
+                setFormData({ ...formData, content: e.target.value })
+              }
+              placeholder="Write your note..."
+              className="bg-gray-800 border-gray-600 text-white text-base"
+              rows={4}
+            />
+          </div>
+          <Button type="submit" className="w-full">
+            Save Note
+          </Button>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -7,6 +7,8 @@ export { GoalList } from "./GoalList";
 export { ProjectList } from "./ProjectList";
 export { TaskList } from "./TaskList";
 export { EventModal } from "./EventModal";
+export { NoteModal } from "./NoteModal";
+export { ComingSoonModal } from "./ComingSoonModal";
 export { Select, SelectContent, SelectItem } from "./select";
 export { CatCard } from "./CatCard";
 export { SkillRow } from "./SkillRow";


### PR DESCRIPTION
## Summary
- add swipe gesture to FAB menu for extra actions
- include note creation modal and placeholders for service/product/request

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b62a28bfe8832c8e7f73e3b996a24e