### PR TITLE
Require monument selection for new skills

### DIFF
--- a/src/app/(app)/skills/components/SkillDrawer.tsx
+++ b/src/app/(app)/skills/components/SkillDrawer.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import type { Monument } from "@/lib/queries/monuments";
+
+export type { Monument };
 
 export interface Skill {
   id: string;
@@ -9,6 +12,7 @@ export interface Skill {
   level: number;
   progress: number;
   cat_id: string | null;
+  monument_id: string;
   created_at?: string | null;
 }
 
@@ -20,11 +24,12 @@ export interface Category {
 interface SkillDrawerProps {
   open: boolean;
   onClose(): void;
-  onAdd(skill: Skill): void;
+  onAdd(skill: Skill): Promise<void> | void;
   categories: Category[];
+  monuments: Monument[];
   onAddCategory(cat: Category): void;
   initialSkill?: Skill | null;
-  onUpdate?(skill: Skill): void;
+  onUpdate?(skill: Skill): Promise<void> | void;
 }
 
 export function SkillDrawer({
@@ -40,6 +45,7 @@ export function SkillDrawer({
   const [emoji, setEmoji] = useState("💡");
   const [cat, setCat] = useState("");
   const [newCat, setNewCat] = useState("");
+  const [monument, setMonument] = useState("");
 
   const editing = Boolean(initialSkill);
 
@@ -48,18 +54,20 @@ export function SkillDrawer({
       setName(initialSkill.name);
       setEmoji(initialSkill.icon || "💡");
       setCat(initialSkill.cat_id || "");
+      setMonument(initialSkill.monument_id || "");
     } else {
       setName("");
       setEmoji("💡");
       setCat("");
       setNewCat("");
+      setMonument("");
     }
   }, [initialSkill, open]);
 
-  const submit = (e: React.FormEvent) => {
+  const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = name.trim();
-    if (!trimmed) return;
+    if (!trimmed || !monument) return;
 
     let catId = cat;
     if (cat === "new" && newCat.trim()) {
@@ -75,13 +83,14 @@ export function SkillDrawer({
       level: initialSkill?.level ?? 1,
       progress: initialSkill?.progress ?? 0,
       cat_id: catId || null,
+      monument_id: monument,
       created_at: initialSkill?.created_at ?? new Date().toISOString(),
     };
 
     if (editing && onUpdate) {
-      onUpdate(base);
+      await onUpdate(base);
     } else {
-      onAdd(base);
+      await onAdd(base);
     }
     onClose();
   };
@@ -134,6 +143,22 @@ export function SkillDrawer({
                 className="w-full px-3 py-2 rounded bg-gray-700 mt-2"
               />
             )}
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Monument *</label>
+            <select
+              value={monument}
+              onChange={(e) => setMonument(e.target.value)}
+              required
+              className="w-full px-3 py-2 rounded bg-gray-700"
+            >
+              <option value="">Select...</option>
+              {monuments.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.title}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="flex justify-end gap-2 pt-2">
             <button

--- a/src/lib/data/skills.ts
+++ b/src/lib/data/skills.ts
@@ -32,3 +32,40 @@ export async function getSkillsForUser(userId: string) {
   if (error) throw error;
   return (data ?? []) as SkillRow[];
 }
+
+export async function createSkill(
+  userId: string,
+  skill: { name: string; icon: string; cat_id: string | null; monument_id: string; level?: number }
+) {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("Supabase client not available");
+
+  const { data, error } = await sb
+    .from("skills")
+    .insert({
+      user_id: userId,
+      name: skill.name,
+      icon: skill.icon,
+      cat_id: skill.cat_id,
+      monument_id: skill.monument_id,
+      level: skill.level ?? 1,
+    })
+    .select("id,name,icon,cat_id,level,monument_id,created_at,updated_at")
+    .single();
+
+  if (error) throw error;
+  return data as SkillRow;
+}
+
+export async function deleteSkill(userId: string, id: string) {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("Supabase client not available");
+
+  const { error } = await sb
+    .from("skills")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", userId);
+
+  if (error) throw error;
+}


### PR DESCRIPTION
## Summary
- enforce monument selection in skill drawer
- store and remove skills through Supabase with monument relation
- add createSkill and deleteSkill helpers

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b64d7fbebc832cbfbcead45055b41f