### PR TITLE
Add slide animation to dashboard skill dropdowns

### DIFF
--- a/src/components/skills/CategorySection.tsx
+++ b/src/components/skills/CategorySection.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { ChevronDown } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
 import SkillCard from "@/components/skills/SkillCard";
 import { cn } from "@/lib/utils";
 // Removed unused import
@@ -46,28 +47,36 @@ export function CategorySection({
           )}
         />
       </button>
-      {open && (
-        <div className="bg-slate-900/60 border-t border-white/5 px-4 pb-4 pt-2 space-y-2">
-          {skills && skills.length > 0 ? (
-            skills.map((skill) => (
-              <SkillCard
-                key={skill.skill_id}
-                icon={skill.icon}
-                name={skill.name}
-                level={skill.level}
-                percent={skill.progress || 0}
-                skillId={skill.skill_id}
-              />
-            ))
-          ) : (
-            <div className="text-center py-4 text-gray-500 text-sm">
-              No skills
-            </div>
+        <AnimatePresence initial={false}>
+          {open && (
+            <motion.div
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: "auto", opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className="bg-slate-900/60 border-t border-white/5 px-4 pb-4 pt-2 space-y-2 overflow-hidden"
+            >
+              {skills && skills.length > 0 ? (
+                skills.map((skill) => (
+                  <SkillCard
+                    key={skill.skill_id}
+                    icon={skill.icon}
+                    name={skill.name}
+                    level={skill.level}
+                    percent={skill.progress || 0}
+                    skillId={skill.skill_id}
+                  />
+                ))
+              ) : (
+                <div className="text-center py-4 text-gray-500 text-sm">
+                  No skills
+                </div>
+              )}
+            </motion.div>
           )}
-        </div>
-      )}
-    </div>
-  );
-}
+        </AnimatePresence>
+      </div>
+    );
+  }
 
 export default CategorySection;


### PR DESCRIPTION
## Summary
- enhance dashboard skill categories with animated open/close using framer-motion

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b6529cd548832ca2c60daf64a300e0