### PR TITLE
Add top nav quick menu

### DIFF
--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -5,6 +5,13 @@ import TopNavAvatar from "./TopNavAvatar";
 import { useProfile } from "@/lib/hooks/useProfile";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 export default function TopNav() {
   const { profile, userId } = useProfile();
@@ -23,16 +30,26 @@ export default function TopNav() {
     getUserEmail();
   }, [supabase]);
 
-  const toggleSidebar = () => {
-    // Placeholder for future sidebar toggle
-    console.log("toggle sidebar");
-  };
-
   return (
     <nav className="w-full flex items-center justify-between px-4 py-2 bg-gray-900 text-white">
-      <button onClick={toggleSidebar} className="p-2 hover:text-blue-400">
-        <Menu className="h-6 w-6" />
-      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="p-2 hover:text-blue-400" aria-label="Open menu">
+            <Menu className="h-6 w-6" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem asChild>
+            <Link href="/analytics">Analytics</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/help">Help</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/settings">Settings</Link>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <span className="font-semibold" data-testid="username">
         {profile?.username || userEmail || "Guest"}
       </span>


### PR DESCRIPTION
## Summary
- add dropdown quick menu to top nav hamburger with Analytics, Help, and Settings links

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b7ad23a968832cad7d37b0ed702759