### PR TITLE
feat(scheduler): surface projects in draft view

### DIFF
--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/lib/scheduler/weight";
 import { MOCK_TASKS, MOCK_WINDOWS, MOCK_PROJECTS } from "@/lib/scheduler/mock";
 
+type Energy = (typeof ENERGY.LIST)[number];
+
 function fmt(d: Date) {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
@@ -60,8 +62,9 @@ export default function DraftSchedulerPage() {
   const projectItems = useMemo(() => {
     const items: (
       ProjectLite & {
+        name: string;
         duration_min: number;
-        energy: string | null;
+        energy: Energy | null;
         weight: number;
       }
     )[] = [];
@@ -72,11 +75,12 @@ export default function DraftSchedulerPage() {
         (sum, t) => sum + t.duration_min,
         0
       );
-      const energy = related.reduce<string | null>((acc, t) => {
+      const energy = related.reduce<Energy | null>((acc, t) => {
         if (!t.energy) return acc;
-        if (!acc) return t.energy;
-        return ENERGY.LIST.indexOf(t.energy) > ENERGY.LIST.indexOf(acc)
-          ? t.energy
+        const current = t.energy as Energy;
+        if (!acc) return current;
+        return ENERGY.LIST.indexOf(current) > ENERGY.LIST.indexOf(acc)
+          ? current
           : acc;
       }, null);
       const relatedWeightSum = related.reduce(
@@ -84,7 +88,13 @@ export default function DraftSchedulerPage() {
         0
       );
       const weight = projectWeight(p, relatedWeightSum);
-      items.push({ ...p, duration_min, energy, weight });
+      items.push({
+        ...p,
+        name: p.name ?? "",
+        duration_min,
+        energy,
+        weight,
+      });
     }
     return items.sort((a, b) => b.weight - a.weight);
   }, [projects, tasks]);

--- a/src/app/(app)/schedule/draft/page.tsx
+++ b/src/app/(app)/schedule/draft/page.tsx
@@ -29,7 +29,6 @@ export default function DraftSchedulerPage() {
   const [tasks, setTasks] = useState<TaskLite[]>([]);
   const [windows, setWindows] = useState<WindowLite[]>([]);
   const [projects, setProjects] = useState<ProjectLite[]>([]);
-  const [mode, setMode] = useState<"TASK" | "PROJECT">("TASK");
   const [placements, setPlacements] = useState<
     ReturnType<typeof placeByEnergyWeight>["placements"]
   >([]);
@@ -147,35 +146,22 @@ export default function DraftSchedulerPage() {
     }
   }
 
-  function handleAutoPlace() {
+  function handleAutoPlaceTasks() {
     const date = new Date();
-    const items = mode === "PROJECT" ? projectItems : weightedTasks;
-    const result = placeByEnergyWeight(items, windows, date);
+    const result = placeByEnergyWeight(weightedTasks, windows, date);
+    setPlacements(result.placements);
+    setUnplaced(result.unplaced);
+  }
+
+  function handleAutoPlaceProjects() {
+    const date = new Date();
+    const result = placeByEnergyWeight(projectItems, windows, date);
     setPlacements(result.placements);
     setUnplaced(result.unplaced);
   }
 
   return (
     <div className="space-y-6 p-4 text-zinc-100">
-      <div className="flex gap-2">
-        <Button
-          className={`flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700 ${
-            mode === "TASK" ? "bg-zinc-700" : ""
-          }`}
-          onClick={() => setMode("TASK")}
-        >
-          Task Planning
-        </Button>
-        <Button
-          className={`flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700 ${
-            mode === "PROJECT" ? "bg-zinc-700" : ""
-          }`}
-          onClick={() => setMode("PROJECT")}
-        >
-          Project Planning
-        </Button>
-      </div>
-
       <div className="flex gap-2">
         <Button
           className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"
@@ -191,15 +177,17 @@ export default function DraftSchedulerPage() {
         </Button>
         <Button
           className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"
-          onClick={handleAutoPlace}
-          disabled={
-            !windows.length ||
-            (mode === "PROJECT"
-              ? projectItems.length === 0
-              : weightedTasks.length === 0)
-          }
+          onClick={handleAutoPlaceTasks}
+          disabled={!windows.length || weightedTasks.length === 0}
         >
-          Auto-place
+          Auto-place Tasks
+        </Button>
+        <Button
+          className="flex-1 bg-zinc-800 text-zinc-100 hover:bg-zinc-700"
+          onClick={handleAutoPlaceProjects}
+          disabled={!windows.length || projectItems.length === 0}
+        >
+          Auto-place Projects
         </Button>
       </div>
 
@@ -223,7 +211,7 @@ export default function DraftSchedulerPage() {
         </section>
       )}
 
-      {mode === "TASK" && weightedTasks.length > 0 && (
+      {weightedTasks.length > 0 && (
         <section>
           <h2 className="mb-2 font-semibold">Tasks</h2>
           <ul className="space-y-2">
@@ -251,7 +239,7 @@ export default function DraftSchedulerPage() {
         </section>
       )}
 
-      {mode === "PROJECT" && projectItems.length > 0 && (
+      {projectItems.length > 0 && (
         <section>
           <h2 className="mb-2 font-semibold">Projects</h2>
           <ul className="space-y-2">
@@ -355,7 +343,7 @@ export default function DraftSchedulerPage() {
         </Button>
         {debug && (
           <pre className="mt-2 max-h-60 overflow-auto rounded bg-zinc-900 p-2 text-[10px]">
-            {JSON.stringify({ tasks, projects, windows, placements, unplaced, mode }, null, 2)}
+            {JSON.stringify({ tasks, projects, windows, placements, unplaced }, null, 2)}
           </pre>
         )}
       </div>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { DayTimeline } from '@/components/schedule/DayTimeline'
@@ -8,6 +8,20 @@ import { MonthView } from '@/components/schedule/MonthView'
 import { WeekView } from '@/components/schedule/WeekView'
 import { FocusTimeline } from '@/components/schedule/FocusTimeline'
 import { Button } from '@/components/ui/button'
+import {
+  fetchReadyTasks,
+  fetchWindowsForDate,
+  fetchProjectsMap,
+  type WindowLite,
+} from '@/lib/scheduler/repo'
+import { placeByEnergyWeight } from '@/lib/scheduler/placer'
+import { ENERGY } from '@/lib/scheduler/config'
+import {
+  TaskLite,
+  ProjectLite,
+  taskWeight,
+  projectWeight,
+} from '@/lib/scheduler/weight'
 
 export default function SchedulePage() {
   const [currentDate, setCurrentDate] = useState(new Date())
@@ -16,11 +30,112 @@ export default function SchedulePage() {
     if (typeof window === 'undefined') return 'TASK'
     return (localStorage.getItem('planning-mode') as 'TASK' | 'PROJECT') || 'TASK'
   })
+  const [tasks, setTasks] = useState<TaskLite[]>([])
+  const [projects, setProjects] = useState<ProjectLite[]>([])
+  const [windows, setWindows] = useState<WindowLite[]>([])
+  const [placements, setPlacements] = useState<
+    ReturnType<typeof placeByEnergyWeight>['placements']
+  >([])
   const touchStartX = useRef<number | null>(null)
+
+  const startHour = 0
+  const pxPerMin = 2
 
   useEffect(() => {
     localStorage.setItem('planning-mode', planning)
   }, [planning])
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const weekday = currentDate.getDay()
+        const [ws, ts, pm] = await Promise.all([
+          fetchWindowsForDate(weekday),
+          fetchReadyTasks(),
+          fetchProjectsMap(),
+        ])
+        setWindows(ws)
+        setTasks(ts)
+        setProjects(Object.values(pm))
+      } catch (e) {
+        console.error(e)
+        setWindows([])
+        setTasks([])
+        setProjects([])
+      }
+    }
+    load()
+  }, [currentDate])
+
+  const weightedTasks = useMemo(
+    () => tasks.map(t => ({ ...t, weight: taskWeight(t) })),
+    [tasks]
+  )
+
+  const projectItems = useMemo(() => {
+    type Energy = (typeof ENERGY.LIST)[number]
+    const items: (
+      ProjectLite & {
+        name: string
+        duration_min: number
+        energy: Energy | null
+        weight: number
+      }
+    )[] = []
+    for (const p of projects) {
+      const related = tasks.filter(t => t.project_id === p.id)
+      if (related.length === 0) continue
+      const duration_min = related.reduce((sum, t) => sum + t.duration_min, 0)
+      const energy = related.reduce<Energy | null>((acc, t) => {
+        if (!t.energy) return acc
+        const current = t.energy as Energy
+        if (!acc) return current
+        return ENERGY.LIST.indexOf(current) > ENERGY.LIST.indexOf(acc)
+          ? current
+          : acc
+      }, null)
+      const relatedWeightSum = related.reduce(
+        (sum, t) => sum + taskWeight(t),
+        0
+      )
+      const weight = projectWeight(p, relatedWeightSum)
+      items.push({
+        ...p,
+        name: p.name ?? '',
+        duration_min,
+        energy,
+        weight,
+      })
+    }
+    return items
+  }, [projects, tasks])
+
+  const taskMap = useMemo(() => {
+    const map: Record<string, typeof weightedTasks[number]> = {}
+    for (const t of weightedTasks) map[t.id] = t
+    return map
+  }, [weightedTasks])
+
+  const projectMap = useMemo(() => {
+    const map: Record<string, typeof projectItems[number]> = {}
+    for (const p of projectItems) map[p.id] = p
+    return map
+  }, [projectItems])
+
+  const getItem = (id: string) =>
+    planning === 'TASK' ? taskMap[id] : projectMap[id]
+
+  useEffect(() => {
+    if (windows.length === 0) return
+    const date = currentDate
+    if (planning === 'TASK') {
+      const result = placeByEnergyWeight(weightedTasks, windows, date)
+      setPlacements(result.placements)
+    } else {
+      const result = placeByEnergyWeight(projectItems, windows, date)
+      setPlacements(result.placements)
+    }
+  }, [planning, weightedTasks, projectItems, windows, currentDate])
 
   function handleTouchStart(e: React.TouchEvent) {
     touchStartX.current = e.touches[0].clientX
@@ -123,7 +238,36 @@ export default function SchedulePage() {
         >
           {view === 'month' && <MonthView date={currentDate} />}
           {view === 'week' && <WeekView date={currentDate} />}
-          {view === 'day' && <DayTimeline date={currentDate} />}
+          {view === 'day' && (
+            <DayTimeline
+              date={currentDate}
+              startHour={startHour}
+              pxPerMin={pxPerMin}
+            >
+              {placements.map(p => {
+                const item = getItem(p.taskId)
+                if (!item) return null
+                const startMin =
+                  p.start.getHours() * 60 + p.start.getMinutes()
+                const top = (startMin - startHour * 60) * pxPerMin
+                const height =
+                  ((p.end.getTime() - p.start.getTime()) / 60000) * pxPerMin
+                return (
+                  <div
+                    key={p.taskId}
+                    className={`absolute left-0 right-2 overflow-hidden rounded p-1 text-xs text-white ${
+                      planning === 'TASK'
+                        ? 'bg-zinc-800'
+                        : 'bg-purple-800'
+                    }`}
+                    style={{ top, height }}
+                  >
+                    {item.name}
+                  </div>
+                )
+              })}
+            </DayTimeline>
+          )}
           {view === 'focus' && <FocusTimeline />}
         </div>
       </div>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
 import { DayTimeline } from '@/components/schedule/DayTimeline'
@@ -12,7 +12,15 @@ import { Button } from '@/components/ui/button'
 export default function SchedulePage() {
   const [currentDate, setCurrentDate] = useState(new Date())
   const [view, setView] = useState<'month' | 'week' | 'day' | 'focus'>('day')
+  const [planning, setPlanning] = useState<'TASK' | 'PROJECT'>(() => {
+    if (typeof window === 'undefined') return 'TASK'
+    return (localStorage.getItem('planning-mode') as 'TASK' | 'PROJECT') || 'TASK'
+  })
   const touchStartX = useRef<number | null>(null)
+
+  useEffect(() => {
+    localStorage.setItem('planning-mode', planning)
+  }, [planning])
 
   function handleTouchStart(e: React.TouchEvent) {
     touchStartX.current = e.touches[0].clientX
@@ -88,6 +96,20 @@ export default function SchedulePage() {
               {v}
             </button>
           ))}
+        </div>
+
+        <div className="flex justify-center">
+          <div className="flex rounded-full bg-zinc-900 p-1 text-xs">
+            {(['TASK','PROJECT'] as const).map(m => (
+              <button
+                key={m}
+                onClick={() => setPlanning(m)}
+                className={`rounded-full px-3 py-1 capitalize ${planning===m ? 'bg-zinc-800 text-white' : 'text-zinc-400'}`}
+              >
+                {m === 'TASK' ? 'Tasks' : 'Projects'}
+              </button>
+            ))}
+          </div>
         </div>
 
         <div className="text-center text-sm text-gray-200">

--- a/src/components/schedule/DayTimeline.tsx
+++ b/src/components/schedule/DayTimeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Clock } from "lucide-react";
 
 export const GEM_PURPLE = "#9966CC";
@@ -10,6 +10,7 @@ interface DayTimelineProps {
   endHour?: number;
   pxPerMin?: number;
   date?: Date;
+  children?: ReactNode;
 }
 
 export function DayTimeline({
@@ -17,6 +18,7 @@ export function DayTimeline({
   endHour = 24,
   pxPerMin = 2,
   date = new Date(),
+  children,
 }: DayTimelineProps) {
   const totalMinutes = (endHour - startHour) * 60;
   const timelineHeight = totalMinutes * pxPerMin;
@@ -76,6 +78,8 @@ export function DayTimeline({
           </div>
         );
       })}
+
+      {children}
 
       {showNowLine && (
         <>

--- a/src/lib/scheduler/mock.ts
+++ b/src/lib/scheduler/mock.ts
@@ -1,4 +1,4 @@
-import type { TaskLite } from './weight';
+import type { TaskLite, ProjectLite } from './weight';
 import type { WindowLite } from './repo';
 
 export const MOCK_WINDOWS: WindowLite[] = [
@@ -20,6 +20,21 @@ export const MOCK_WINDOWS: WindowLite[] = [
   },
 ];
 
+export const MOCK_PROJECTS: ProjectLite[] = [
+  {
+    id: 'p1',
+    name: 'Mock Project 1',
+    priority: 'HIGH',
+    stage: 'BUILD',
+  },
+  {
+    id: 'p2',
+    name: 'Mock Project 2',
+    priority: 'MEDIUM',
+    stage: 'RESEARCH',
+  },
+];
+
 export const MOCK_TASKS: TaskLite[] = [
   {
     id: 't1',
@@ -28,7 +43,7 @@ export const MOCK_TASKS: TaskLite[] = [
     stage: 'Prepare',
     duration_min: 60,
     energy: 'LOW',
-    project_id: null,
+    project_id: 'p1',
   },
   {
     id: 't2',
@@ -37,7 +52,7 @@ export const MOCK_TASKS: TaskLite[] = [
     stage: 'Produce',
     duration_min: 30,
     energy: 'HIGH',
-    project_id: null,
+    project_id: 'p1',
   },
   {
     id: 't3',
@@ -46,7 +61,7 @@ export const MOCK_TASKS: TaskLite[] = [
     stage: 'Perfect',
     duration_min: 45,
     energy: 'LOW',
-    project_id: null,
+    project_id: 'p2',
   },
 ];
 

--- a/src/lib/scheduler/placer.ts
+++ b/src/lib/scheduler/placer.ts
@@ -1,4 +1,4 @@
-import { TaskLite, taskWeight } from "./weight";
+import type { TaskLite } from "./weight";
 import { ENERGY } from "./config";
 
 export type WindowLite = {
@@ -78,8 +78,10 @@ function consume(slots: Slot[], startIndex: number, durationMin: number) {
   }
 }
 
+export type Schedulable = TaskLite & { weight: number };
+
 export function placeByEnergyWeight(
-  tasks: TaskLite[],
+  tasks: Schedulable[],
   windows: WindowLite[],
   date: Date
 ) {
@@ -105,7 +107,7 @@ export function placeByEnergyWeight(
   const unplaced: { taskId: string; reason: string }[] = [];
 
   const sortedTasks = [...tasks].sort((a, b) => {
-    const diff = taskWeight(b) - taskWeight(a);
+    const diff = b.weight - a.weight;
     return diff !== 0 ? diff : a.id.localeCompare(b.id);
   });
 
@@ -117,7 +119,6 @@ export function placeByEnergyWeight(
       unplaced.push({ taskId: task.id, reason: "no-window" });
       continue;
     }
-    const weight = taskWeight(task);
     let placed = false;
     for (const w of candidates) {
       const slots = slotsByWindow[w.id];
@@ -131,7 +132,7 @@ export function placeByEnergyWeight(
         windowId: w.id,
         start,
         end,
-        weight,
+        weight: task.weight,
       });
       placed = true;
       break;

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -55,7 +55,7 @@ export async function fetchProjectsMap(): Promise<
 
   const { data, error } = await supabase
     .from('projects')
-    .select('id, priority, stage');
+    .select('id, name, priority, stage');
 
   if (error) throw error;
   const map: Record<string, ProjectLite> = {};

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -18,6 +18,7 @@ export type TaskLite = {
 
 export type ProjectLite = {
   id: string;
+  name?: string;
   priority: string;
   stage: string;
 };


### PR DESCRIPTION
## Summary
- include project details in scheduler mocks
- load and weight projects in draft scheduler
- allow `ProjectLite` to carry names and fetch via `fetchProjectsMap`

## Testing
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b7dc10eb38832c8ad678213381cd8a