### PR TITLE
Center auth page and rebrand to CREATOR

### DIFF
--- a/components/auth/AuthForm.tsx
+++ b/components/auth/AuthForm.tsx
@@ -54,7 +54,7 @@ export default function AuthForm() {
       <div className="w-full max-w-md mx-auto">
         <div className="text-center mb-8">
           <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-            ACCOUNTABILITY
+            CREATOR
           </h1>
           <p className="text-lg text-zinc-300">Level up your life!</p>
         </div>
@@ -194,7 +194,7 @@ export default function AuthForm() {
       {/* Header */}
       <div className="text-center mb-10">
         <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-          ACCOUNTABILITY
+          CREATOR
         </h1>
         <p className="text-lg text-zinc-300">Level up your life!</p>
       </div>

--- a/src/app/(public)/auth/page.tsx
+++ b/src/app/(public)/auth/page.tsx
@@ -5,10 +5,8 @@ import AuthForm from "@/components/auth/AuthForm";
 
 export default function Page() {
   return (
-    <main className="min-h-dvh w-full bg-[#121212]">
-      <div className="mx-auto flex max-w-6xl items-start justify-center px-4 pt-24 md:pt-28">
-        <AuthForm />
-      </div>
+    <main className="flex min-h-dvh w-full items-center justify-center bg-[#121212] px-4">
+      <AuthForm />
     </main>
   );
 }

--- a/src/app/(public)/auth/reset/page.tsx
+++ b/src/app/(public)/auth/reset/page.tsx
@@ -19,7 +19,7 @@ export default function ResetPasswordPage() {
       <div className="w-full max-w-md mx-auto">
         <div className="text-center mb-8">
           <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-            ACCOUNTABILITY
+            CREATOR
           </h1>
           <p className="text-lg text-zinc-300">Level up your life!</p>
         </div>
@@ -80,7 +80,7 @@ export default function ResetPasswordPage() {
       {/* Header */}
       <div className="text-center mb-10">
         <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-          ACCOUNTABILITY
+          CREATOR
         </h1>
         <p className="text-lg text-zinc-300">Reset your password</p>
       </div>

--- a/src/app/(public)/auth/update-password/page.tsx
+++ b/src/app/(public)/auth/update-password/page.tsx
@@ -48,7 +48,7 @@ export default function UpdatePasswordPage() {
       <div className="w-full max-w-md mx-auto">
         <div className="text-center mb-8">
           <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-            ACCOUNTABILITY
+            CREATOR
           </h1>
           <p className="text-lg text-zinc-300">Level up your life!</p>
         </div>
@@ -124,7 +124,7 @@ export default function UpdatePasswordPage() {
       <div className="w-full max-w-md mx-auto">
         <div className="text-center mb-10">
           <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-            ACCOUNTABILITY
+            CREATOR
           </h1>
           <p className="text-lg text-zinc-300">Update your password</p>
         </div>
@@ -154,7 +154,7 @@ export default function UpdatePasswordPage() {
       {/* Header */}
       <div className="text-center mb-10">
         <h1 className="text-5xl font-black tracking-widest text-white mb-4">
-          ACCOUNTABILITY
+          CREATOR
         </h1>
         <p className="text-lg text-zinc-300">Set your new password</p>
       </div>


### PR DESCRIPTION
## Summary
- Replace ACCOUNTABILITY with CREATOR across auth pages
- Center auth layout for a cleaner mobile experience

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b7e4c189fc832c973c7a3a0fae5a4d