### PR TITLE
Add swipeable Skills tabs to dashboard, fix goal edit menu

### DIFF
--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -23,19 +23,19 @@ export default function SettingsPage() {
   const initials = getInitials(profile?.name || null, email);
 
   return (
-    <div className="bg-[#1E1E1E] min-h-screen text-[#E6E6E6]">
-      <header className="sticky top-0 z-10 backdrop-blur bg-[#1E1E1E]/80 border-b border-[#353535]">
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <header className="sticky top-0 z-10 backdrop-blur bg-[var(--bg)]/80 border-b border-white/10">
         <div className="flex items-center gap-3 px-4 py-3">
           <button
             aria-label="Go back"
             onClick={() => router.push("/dashboard")}
-            className="text-2xl text-[#E6E6E6] focus:outline-none focus:ring-2 focus:ring-[#9966CC]"
+            className="text-2xl text-[var(--text)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
           >
             ←
           </button>
           <div>
             <h1 className="font-bold text-lg">Settings</h1>
-            <p className="text-sm text-[#A6A6A6]">
+            <p className="text-sm text-[var(--muted)]">
               Manage your account and preferences
             </p>
           </div>
@@ -53,7 +53,7 @@ export default function SettingsPage() {
                   className="h-12 w-12 rounded-full object-cover"
                 />
               ) : (
-                <div className="h-12 w-12 rounded-full bg-[#353535] flex items-center justify-center text-lg">
+                <div className="h-12 w-12 rounded-full bg-white/10 flex items-center justify-center text-lg">
                   {initials}
                 </div>
               )
@@ -62,7 +62,7 @@ export default function SettingsPage() {
               <div>
                 <p className="font-medium">{profile?.name || email || "User"}</p>
                 {email && (
-                  <p className="text-sm text-[#A6A6A6]">{email}</p>
+                  <p className="text-sm text-[var(--muted)]">{email}</p>
                 )}
               </div>
             }
@@ -129,7 +129,7 @@ export default function SettingsPage() {
             ariaLabel="App version"
             left="ℹ️"
             label="App Version"
-            right={<span className="text-[#A6A6A6]">v1.0.0</span>}
+            right={<span className="text-[var(--muted)]">v1.0.0</span>}
           />
         </SectionCard>
       </main>
@@ -138,7 +138,7 @@ export default function SettingsPage() {
 }
 
 function Chevron() {
-  return <span className="text-[#A6A6A6]">›</span>;
+  return <span className="text-[var(--muted)]">›</span>;
 }
 
 type SectionCardProps = {
@@ -148,9 +148,9 @@ type SectionCardProps = {
 
 function SectionCard({ title, children }: SectionCardProps) {
   return (
-    <section className="bg-[#242424] border border-[#353535] rounded-2xl overflow-hidden">
-      <h2 className="px-4 py-3 font-semibold">{title}</h2>
-      <div className="divide-y divide-[#353535]">{children}</div>
+    <section className="card overflow-hidden">
+      <h2 className="px-4 py-3 font-semibold inner-hair">{title}</h2>
+      <div className="divide-y divide-white/5">{children}</div>
     </section>
   );
 }
@@ -169,11 +169,11 @@ function Row({ left, label, right, ariaLabel, onClick }: RowProps) {
       type="button"
       onClick={onClick}
       aria-label={ariaLabel}
-      className="w-full flex items-center justify-between h-14 px-4 text-left transition-all duration-[160ms] hover:bg-[#2B2B2B] active:scale-[0.98] focus:outline-none focus:ring-2 focus:ring-[#9966CC]"
+      className="w-full flex items-center justify-between h-14 px-4 text-left transition-all duration-200 hover:bg-white/5 active:scale-[0.98] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
     >
       <div className="flex items-center gap-4">
         <span className="text-xl">{left}</span>
-        <span className="text-[#E6E6E6]">{label}</span>
+        <span className="text-[var(--text)]">{label}</span>
       </div>
       {right}
     </button>
@@ -194,7 +194,7 @@ function ToggleSwitch({ checked, onChange, ariaLabel }: ToggleSwitchProps) {
       aria-label={ariaLabel}
       onClick={onChange}
       className={`w-12 h-7 rounded-full p-1 transition-colors duration-200 ${
-        checked ? "bg-[#9966CC]" : "bg-[#353535]"
+        checked ? "bg-[var(--accent)]" : "bg-white/10"
       }`}
     >
       <span

--- a/src/app/(app)/dashboard/_skills/ProgressRing.tsx
+++ b/src/app/(app)/dashboard/_skills/ProgressRing.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React from "react";
+
+export function calculateDashOffset(radius: number, percent: number) {
+  const circumference = 2 * Math.PI * radius;
+  return circumference - (percent / 100) * circumference;
+}
+
+interface ProgressRingProps {
+  size?: number;
+  stroke?: number;
+  percent: number;
+  className?: string;
+}
+
+export function ProgressRing({
+  size = 28,
+  stroke = 3,
+  percent,
+  className,
+}: ProgressRingProps) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = calculateDashOffset(radius, percent);
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      className={["text-accent", className].filter(Boolean).join(" ")}
+      viewBox={`0 0 ${size} ${size}`}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="currentColor"
+        strokeWidth={stroke}
+        fill="transparent"
+        opacity={0.2}
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="currentColor"
+        strokeWidth={stroke}
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={dashOffset}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export default ProgressRing;
+

--- a/src/app/(app)/dashboard/_skills/SkillCard.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import ProgressRing from "./ProgressRing";
+import { Skill } from "./useSkills";
+
+interface SkillCardProps {
+  skill: Skill;
+}
+
+export function SkillCard({ skill }: SkillCardProps) {
+  return (
+    <motion.div
+      whileTap={{ scale: 0.97 }}
+      className="rounded-2xl border border-zinc-800 bg-zinc-900/60 shadow-sm p-3 flex items-center gap-3"
+    >
+      <Link href={`/skills/${skill.id}`} className="flex items-center gap-3 flex-1">
+        <div className="w-10 h-10 flex items-center justify-center rounded-full bg-zinc-800 text-lg">
+          {skill.icon || "💡"}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-zinc-100 truncate">{skill.name}</div>
+        </div>
+      </Link>
+      <div className="flex items-center gap-2">
+        <ProgressRing percent={skill.progress} className="text-zinc-400" />
+        <span className="text-xs bg-zinc-800 text-zinc-300 rounded-full px-2 py-0.5">
+          Lv {skill.level}
+        </span>
+      </div>
+    </motion.div>
+  );
+}
+
+export default SkillCard;

--- a/src/app/(app)/dashboard/_skills/TabsSkills.tsx
+++ b/src/app/(app)/dashboard/_skills/TabsSkills.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import React, { useRef, useState, useEffect } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
+import SkillCard from "./SkillCard";
+import { useSkillsTabs } from "./useSkills";
+
+export default function TabsSkills() {
+  const { tabs, activeTab, setActiveTab, skillsByTab, isLoading } = useSkillsTabs();
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const touchStart = useRef<number | null>(null);
+  const [showLeft, setShowLeft] = useState(false);
+  const [showRight, setShowRight] = useState(false);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const el = tabsRef.current;
+    if (!el) return;
+    const update = () => {
+      setShowLeft(el.scrollLeft > 0);
+      setShowRight(el.scrollWidth - el.clientWidth - el.scrollLeft > 1);
+    };
+    update();
+    el.addEventListener("scroll", update);
+    return () => el.removeEventListener("scroll", update);
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [activeTab]);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStart.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStart.current === null) return;
+    const dx = e.changedTouches[0].clientX - touchStart.current;
+    const threshold = 32;
+    const idx = tabs.findIndex((t) => t.id === activeTab);
+    if (dx < -threshold && idx < tabs.length - 1) setActiveTab(tabs[idx + 1].id);
+    if (dx > threshold && idx > 0) setActiveTab(tabs[idx - 1].id);
+    touchStart.current = null;
+  };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    const idx = tabs.findIndex((t) => t.id === activeTab);
+    if (e.key === "ArrowRight" && idx < tabs.length - 1) {
+      setActiveTab(tabs[idx + 1].id);
+    }
+    if (e.key === "ArrowLeft" && idx > 0) {
+      setActiveTab(tabs[idx - 1].id);
+    }
+  };
+
+  const scrollTabs = (dir: number) => {
+    const el = tabsRef.current;
+    if (el) el.scrollBy({ left: dir * 120, behavior: "smooth" });
+  };
+
+  if (isLoading) {
+    return <div className="py-8 text-center text-zinc-400">Loading...</div>;
+  }
+
+  if (tabs.length === 0) {
+    return (
+      <div className="text-center py-8 text-zinc-400">
+        No skills yet
+        <div className="mt-2">
+          <Link href="/skills" className="text-accent underline">
+            Add Skill
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const skills = activeTab ? skillsByTab[activeTab] || [] : [];
+  const paginated = skills.slice(0, page * 20);
+
+  return (
+    <div
+      className="relative"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className="sticky top-0 z-10 bg-[var(--bg)] pb-3">
+        <div className="relative">
+          {showLeft && (
+            <button
+              aria-label="Scroll left"
+              onClick={() => scrollTabs(-1)}
+              className="absolute left-0 top-1/2 -translate-y-1/2 p-1 bg-zinc-900/80 rounded-full shadow"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+          )}
+          <div
+            ref={tabsRef}
+            role="tablist"
+            onKeyDown={handleKey}
+            className="flex overflow-x-auto scrollbar-none gap-2 px-6 snap-x snap-mandatory"
+            style={{ maskImage: "linear-gradient(to right, transparent, black 16px, black calc(100% - 16px), transparent)" }}
+          >
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                role="tab"
+                aria-selected={tab.id === activeTab}
+                onClick={() => setActiveTab(tab.id)}
+                className={`px-4 py-2 rounded-xl border whitespace-nowrap snap-start ${
+                  tab.id === activeTab
+                    ? "border-zinc-600 bg-zinc-800 text-zinc-100 shadow"
+                    : "border-zinc-800 bg-zinc-900/60 text-zinc-300"
+                }`}
+              >
+                {tab.name.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          {showRight && (
+            <button
+              aria-label="Scroll right"
+              onClick={() => scrollTabs(1)}
+              className="absolute right-0 top-1/2 -translate-y-1/2 p-1 bg-zinc-900/80 rounded-full shadow"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeTab}
+          initial={{ x: 20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          exit={{ x: -20, opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+        >
+          {paginated.length > 0 ? (
+            paginated.map((skill) => <SkillCard key={skill.id} skill={skill} />)
+          ) : (
+            <div className="col-span-full text-center py-8 text-zinc-400">
+              No skills yet
+              <div className="mt-2">
+                <Link href="/skills" className="text-accent underline">
+                  Add Skill
+                </Link>
+              </div>
+            </div>
+          )}
+        </motion.div>
+      </AnimatePresence>
+      {paginated.length < skills.length && (
+        <div className="flex justify-center mt-4">
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            className="px-4 py-2 text-sm rounded-full border border-zinc-800 bg-zinc-900/60 text-zinc-300"
+          >
+            Load more
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/(app)/dashboard/_skills/useSkills.ts
+++ b/src/app/(app)/dashboard/_skills/useSkills.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+export interface Category {
+  id: string;
+  name: string;
+  order?: number | null;
+}
+
+export interface Skill {
+  id: string;
+  name: string;
+  icon?: string | null;
+  level: number;
+  progress: number;
+  category_id: string | null;
+}
+
+export async function getCategoriesForUser(userId: string): Promise<Category[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error("Supabase client not available");
+  const { data, error } = await supabase
+    .from("cats")
+    .select("id,name")
+    .eq("user_id", userId)
+    .order("name", { ascending: true });
+    
+  if (error) throw error;
+  return (data ?? []).map((c) => ({ id: c.id, name: c.name }));
+}
+
+export async function getSkillsForUser(userId: string): Promise<Skill[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error("Supabase client not available");
+  const { data, error } = await supabase
+    .from("skills")
+    .select("id,name,icon,level,cat_id")
+    .eq("user_id", userId)
+    .order("name", { ascending: true });
+  if (error) throw error;
+  return (data ?? []).map((s) => ({
+    id: s.id,
+    name: s.name || "Unnamed",
+    icon: s.icon,
+    level: s.level ?? 1,
+    progress: 0,
+    category_id: s.cat_id,
+  }));
+}
+
+export function groupSkillsByCategory(skills: Skill[]): Record<string, Skill[]> {
+  return skills.reduce<Record<string, Skill[]>>((acc, skill) => {
+    const key = skill.category_id || "uncategorized";
+    acc[key] = acc[key] || [];
+    acc[key].push(skill);
+    return acc;
+  }, {});
+}
+
+export function useSkillsTabs() {
+  const [tabs, setTabs] = useState<Category[]>([]);
+  const [skillsByTab, setSkillsByTab] = useState<Record<string, Skill[]>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const search = useSearchParams();
+  const router = useRouter();
+  const initial = search.get("cat") || undefined;
+  const [activeTab, setActiveTabState] = useState<string | undefined>(initial);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const supabase = getSupabaseBrowser();
+        if (!supabase) throw new Error("Supabase client not available");
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) throw new Error("No user");
+        const [cats, skills] = await Promise.all([
+          getCategoriesForUser(user.id),
+          getSkillsForUser(user.id),
+        ]);
+        setTabs(cats);
+        setSkillsByTab(groupSkillsByCategory(skills));
+        if (!initial && cats[0]) {
+          setActiveTabState(cats[0].id);
+          const params = new URLSearchParams(search);
+          params.set("cat", cats[0].id);
+          router.replace(`?${params.toString()}`);
+        }
+        } catch (e) {
+          setError(e as Error);
+        } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const setActiveTab = (id: string) => {
+    setActiveTabState(id);
+    const params = new URLSearchParams(search);
+    params.set("cat", id);
+    router.replace(`?${params.toString()}`);
+  };
+
+  const tabsWithUncat = useMemo(() => {
+    const t = [...tabs];
+    if (skillsByTab["uncategorized"]) {
+      t.push({ id: "uncategorized", name: "Uncategorized" });
+    }
+    return t;
+  }, [tabs, skillsByTab]);
+
+  return { tabs: tabsWithUncat, activeTab, setActiveTab, skillsByTab, isLoading, error };
+}
+

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -86,7 +86,7 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
                 <MoreHorizontal className="w-4 h-4" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="end" className="bg-popover text-popover-foreground">
               <DropdownMenuItem onClick={onEdit}>Edit</DropdownMenuItem>
               <DropdownMenuItem onClick={onToggleActive}>
                 {goal.active ? "Mark Inactive" : "Mark Active"}

--- a/src/app/(app)/goals/page.tsx
+++ b/src/app/(app)/goals/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { GoalsHeader } from "./components/GoalsHeader";
 import {
@@ -81,6 +82,8 @@ function goalStatusToStatus(status?: string | null): Goal["status"] {
 }
 
 export default function GoalsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [goals, setGoals] = useState<Goal[]>([]);
   const [search, setSearch] = useState("");
   const [energy, setEnergy] = useState<EnergyFilter>("All");
@@ -89,6 +92,17 @@ export default function GoalsPage() {
   const [drawer, setDrawer] = useState(false);
   const [editing, setEditing] = useState<Goal | null>(null);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const editId = searchParams.get("edit");
+    if (editId && goals.length > 0) {
+      const goal = goals.find((g) => g.id === editId);
+      if (goal) {
+        setEditing(goal);
+        setDrawer(true);
+      }
+    }
+  }, [searchParams, goals]);
 
   useEffect(() => {
     const load = async () => {
@@ -310,6 +324,7 @@ export default function GoalsPage() {
           onClose={() => {
             setDrawer(false);
             setEditing(null);
+            router.replace("/goals");
           }}
           onAdd={addGoal}
           initialGoal={editing}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,6 +11,7 @@
   --bg:#0f1115; --surface:#171a21; --surface-2:#1c2028;
   --text:#e6e7ea; --muted:#9aa3ad; --accent:#6ea8ff;
   --radius:16px; --radius-sm:12px;
+  --popover:var(--surface); --popover-foreground:var(--text);
 }
 html,body{ background:var(--bg); color:var(--text); font-weight:600; }
 .section{ padding:20px 16px 8px; }

--- a/test/dashboard/ProgressRing.spec.ts
+++ b/test/dashboard/ProgressRing.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { calculateDashOffset } from "../../src/app/(app)/dashboard/_skills/ProgressRing";
+
+describe("ProgressRing", () => {
+  it("calculates dash offset correctly", () => {
+    const radius = 10;
+    const circumference = 2 * Math.PI * radius;
+    const offset = calculateDashOffset(radius, 75);
+    expect(offset).toBeCloseTo(circumference * 0.25);
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace Skills accordion with swipeable category tabs and compact SkillCards
- fetch and group skills with new useSkills hook and show progress rings
- ensure goal card dropdown menus render on popover surfaces

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b93a234c60832c833c7350c4056d83