### PR TITLE
Enable navigation to projects overview and add project edit links

### DIFF
--- a/components/ui/ProjectList.tsx
+++ b/components/ui/ProjectList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useEffect } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { Badge } from "./badge";
@@ -112,9 +113,17 @@ export function ProjectList() {
           <CardContent className="p-4">
             <div className="flex items-start justify-between mb-2">
               <h3 className="font-medium text-white">{project.name}</h3>
-              <Badge variant="outline" className="text-xs">
-                {project.goal_name}
-              </Badge>
+              <div className="flex items-center gap-2">
+                <Badge variant="outline" className="text-xs">
+                  {project.goal_name}
+                </Badge>
+                <Link
+                  href={`/projects/${project.id}/edit`}
+                  className="text-xs text-blue-400"
+                >
+                  Edit
+                </Link>
+              </div>
             </div>
             <div className="flex gap-2">
               <Badge variant={getPriorityVariant(project.priority)}>

--- a/src/app/(app)/goals/components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/components/ProjectsDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { ProjectRow } from "./ProjectRow";
 import type { Project } from "../types";
 import { Progress } from "@/components/ui/Progress";
@@ -52,7 +53,12 @@ export function ProjectsDropdown({
               <button className="ml-2 text-blue-400">Add Project</button>
             </div>
           )}
-          <button className="mt-3 text-xs text-blue-400">View all projects</button>
+          <Link
+            href="/projects"
+            className="mt-3 text-xs text-blue-400"
+          >
+            See all projects
+          </Link>
         </div>
       )}
     </div>

--- a/src/app/(app)/projects/[id]/edit/page.tsx
+++ b/src/app/(app)/projects/[id]/edit/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { PageHeader } from "@/components/ui";
+
+export default function EditProjectPage() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id ?? "";
+
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen bg-gray-900 text-white">
+        <div className="container mx-auto px-4 py-6">
+          <PageHeader
+            title="Edit Project"
+            description="Update your project details"
+          />
+          <div className="text-center py-12">
+            <p className="text-gray-400">
+              Editing form for project {id} coming soon...
+            </p>
+          </div>
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Make 'See all projects' link on goal cards navigate to the projects overview
- Show an Edit link on each project card
- Scaffold a placeholder edit page for individual projects

## Testing
- `pnpm lint "src/app/(app)/goals/components/ProjectsDropdown.tsx" "components/ui/ProjectList.tsx" "src/app/(app)/projects/[id]/edit/page.tsx"`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9828fd4832ca280684ca7130924