### PR TITLE
Enable project link and editable project cards

### DIFF
--- a/components/BottomBarNav.tsx
+++ b/components/BottomBarNav.tsx
@@ -34,14 +34,28 @@ export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavPro
         className="flex items-center justify-center"
       >
         <div
-          className={`flex flex-col items-center gap-1 rounded-md px-3 py-1 text-xs transition-colors ${
-            isActive
-              ? "border border-gray-700 bg-gray-800/60 text-white shadow-[0_0_8px_#9966CC]"
-              : "hover:text-white"
+          className={`flex flex-col items-center gap-1 px-3 py-1 text-xs transition-colors ${
+            isActive ? "text-white" : "hover:text-white"
           }`}
         >
-          {item.icon}
-          <span>{item.label}</span>
+          <div
+            className={
+              isActive
+                ? "drop-shadow-[0_0_4px_rgba(255,255,255,0.6)]"
+                : undefined
+            }
+          >
+            {item.icon}
+          </div>
+          <span
+            className={
+              isActive
+                ? "drop-shadow-[0_0_4px_rgba(255,255,255,0.6)]"
+                : undefined
+            }
+          >
+            {item.label}
+          </span>
         </div>
       </a>
     );

--- a/components/ui/ProjectCard.tsx
+++ b/components/ui/ProjectCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+import FlameEmber, { type FlameLevel } from "@/components/FlameEmber";
+import { Badge } from "./badge";
+import { Card, CardContent } from "./card";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+interface ProjectCardProps {
+  project: {
+    id: string;
+    name: string;
+    goal_name: string;
+    priority: string;
+    energy: string;
+    stage: string;
+  };
+}
+
+export function ProjectCard({ project }: ProjectCardProps) {
+  const handleEdit = () => {
+    // Placeholder for future edit functionality
+    console.log("Edit project", project.id);
+  };
+
+  return (
+    <Card className="hover:bg-gray-800/50 transition-colors">
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between mb-2">
+          <h3 className="font-medium text-white">{project.name}</h3>
+          <div className="flex items-center gap-2">
+            <FlameEmber level={project.energy as FlameLevel} size="sm" />
+            <Badge variant="outline" className="text-xs">
+              {project.goal_name}
+            </Badge>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  aria-label="Project actions"
+                  className="p-1 rounded bg-gray-700"
+                >
+                  <MoreHorizontal className="w-4 h-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={handleEdit}>
+                  Edit
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Badge variant={getPriorityVariant(project.priority)}>
+            {project.priority}
+          </Badge>
+          <Badge variant={getEnergyVariant(project.energy)}>
+            {project.energy}
+          </Badge>
+          <Badge variant="secondary">{project.stage}</Badge>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function getPriorityVariant(
+  priority: string
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (priority) {
+    case "CRITICAL":
+    case "ULTRA-CRITICAL":
+      return "destructive";
+    case "HIGH":
+      return "default";
+    case "MEDIUM":
+      return "secondary";
+    default:
+      return "outline";
+  }
+}
+
+function getEnergyVariant(
+  energy: string
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (energy) {
+    case "EXTREME":
+      return "destructive";
+    case "ULTRA":
+      return "default";
+    case "HIGH":
+      return "secondary";
+    default:
+      return "outline";
+  }
+}

--- a/components/ui/ProjectList.tsx
+++ b/components/ui/ProjectList.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
-import { Badge } from "./badge";
-import { Card, CardContent, CardHeader, CardTitle } from "./card";
 import { EmptyState } from "./empty-state";
 import { getProjectsForUser } from "@/lib/queries/projects";
 import { getGoalById } from "@/lib/queries/goals";
-import FlameEmber, { type FlameLevel } from "@/components/FlameEmber";
+import { Card, CardContent } from "./card";
+import { ProjectCard } from "./ProjectCard";
 
 interface Project {
   id: string;
@@ -106,66 +105,8 @@ export function ProjectList() {
   return (
     <div className="space-y-4">
       {projects.map((project) => (
-        <Card
-          key={project.id}
-          className="hover:bg-gray-800/50 transition-colors"
-        >
-          <CardContent className="p-4">
-            <div className="flex items-start justify-between mb-2">
-              <h3 className="font-medium text-white">{project.name}</h3>
-              <div className="flex items-center gap-2">
-                <FlameEmber
-                  level={project.energy as FlameLevel}
-                  size="sm"
-                />
-                <Badge variant="outline" className="text-xs">
-                  {project.goal_name}
-                </Badge>
-              </div>
-            </div>
-            <div className="flex gap-2">
-              <Badge variant={getPriorityVariant(project.priority)}>
-                {project.priority}
-              </Badge>
-              <Badge variant={getEnergyVariant(project.energy)}>
-                {project.energy}
-              </Badge>
-              <Badge variant="secondary">{project.stage}</Badge>
-            </div>
-          </CardContent>
-        </Card>
+        <ProjectCard key={project.id} project={project} />
       ))}
     </div>
   );
-}
-
-function getPriorityVariant(
-  priority: string
-): "default" | "secondary" | "destructive" | "outline" {
-  switch (priority) {
-    case "CRITICAL":
-    case "ULTRA-CRITICAL":
-      return "destructive";
-    case "HIGH":
-      return "default";
-    case "MEDIUM":
-      return "secondary";
-    default:
-      return "outline";
-  }
-}
-
-function getEnergyVariant(
-  energy: string
-): "default" | "secondary" | "destructive" | "outline" {
-  switch (energy) {
-    case "EXTREME":
-      return "destructive";
-    case "ULTRA":
-      return "default";
-    case "HIGH":
-      return "secondary";
-    default:
-      return "outline";
-  }
 }

--- a/src/app/(app)/goals/components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/components/ProjectsDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { ProjectRow } from "./ProjectRow";
 import type { Project } from "../types";
 import { Progress } from "@/components/ui/Progress";
@@ -52,7 +53,12 @@ export function ProjectsDropdown({
               <button className="ml-2 text-blue-400">Add Project</button>
             </div>
           )}
-          <button className="mt-3 text-xs text-blue-400">View all projects</button>
+          <Link
+            href="/projects"
+            className="mt-3 inline-block text-xs text-blue-400"
+          >
+            View all projects
+          </Link>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- link "View all projects" from goal cards to `/projects`
- display projects as cards with an edit menu
- soften bottom nav by replacing the purple square glow with a subtle white glow around the icon and label

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b9d3752b7c832c8f2de73ff3d9e468