### PR TITLE
feat(dashboard): add cat carousel

### DIFF
--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -5,8 +5,8 @@ import Link from "next/link";
 import { Section } from "@/components/ui/Section";
 import { LevelBanner } from "@/components/ui/LevelBanner";
 import { MonumentContainer } from "@/components/ui/MonumentContainer";
-import CategorySection from "@/components/skills/CategorySection";
 import { SkillCardSkeleton } from "@/components/skills/SkillCardSkeleton";
+import CatCarousel from "@/components/skills/CatCarousel";
 import { GoalCard } from "../goals/components/GoalCard";
 import type { Goal, Project } from "../goals/types";
 import { getSupabaseBrowser } from "@/lib/supabase";
@@ -237,16 +237,7 @@ export default function DashboardClient() {
             ))}
           </div>
         ) : categories.length > 0 ? (
-          <div className="space-y-4">
-            {categories.map((cat) => (
-              <CategorySection
-                key={cat.cat_id}
-                title={cat.cat_name}
-                skillCount={cat.skill_count}
-                skills={cat.skills}
-              />
-            ))}
-          </div>
+          <CatCarousel cats={categories} />
         ) : (
           <div className="text-center py-8 text-gray-500">
             No skills found. Create your first skill to get started!

--- a/src/components/skills/CatCarousel.tsx
+++ b/src/components/skills/CatCarousel.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence, type PanInfo } from "framer-motion";
+import type { CatItem } from "@/types/dashboard";
+import { CatCard } from "@/components/ui/CatCard";
+
+interface CatCarouselProps {
+  cats: CatItem[];
+}
+
+export function CatCarousel({ cats }: CatCarouselProps) {
+  const [index, setIndex] = useState(0);
+  const total = cats.length;
+
+  const paginate = (newIndex: number) => {
+    const next = (newIndex + total) % total;
+    setIndex(next);
+  };
+
+  const handleDragEnd = (_e: unknown, info: PanInfo) => {
+    const offsetX = info.offset.x;
+    if (offsetX < -50) paginate(index + 1);
+    else if (offsetX > 50) paginate(index - 1);
+  };
+
+  const stack: { cat: CatItem; position: number }[] = [];
+  for (let i = 1; i < Math.min(3, total); i++) {
+    const nextIndex = (index + i) % total;
+    stack.push({ cat: cats[nextIndex], position: i });
+  }
+
+  if (total === 0) return null;
+
+  return (
+    <div className="relative h-64 w-full overflow-visible">
+      <AnimatePresence initial={false}>
+        <motion.div
+          key={cats[index].cat_id}
+          className="absolute inset-0"
+          drag="x"
+          dragConstraints={{ left: 0, right: 0 }}
+          onDragEnd={handleDragEnd}
+          initial={{ x: 300, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          exit={{ x: -300, opacity: 0 }}
+          transition={{ type: "spring", stiffness: 300, damping: 30 }}
+        >
+          <CatCard cat={cats[index]} />
+        </motion.div>
+      </AnimatePresence>
+
+      {stack.map(({ cat, position }) => (
+        <motion.div
+          key={cat.cat_id}
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            transform: `translateX(${position * 32}px) translateY(${-position * 4}px)` ,
+            zIndex: -position,
+          }}
+          initial={false}
+          animate={{ scale: 1 - position * 0.05 }}
+        >
+          <CatCard cat={cat} />
+        </motion.div>
+      ))}
+    </div>
+  );
+}
+
+export default CatCarousel;
+


### PR DESCRIPTION
## Summary
- add CatCarousel to swipe through skill categories
- render CatCarousel on dashboard skills section

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b9e24b9b4c832cbd43d23c82c169f5