### PR TITLE
feat: add skills stacked carousel

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryStackCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryStackCard.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  motion,
+  useReducedMotion,
+  type MotionStyle,
+  type PanInfo,
+} from "framer-motion";
+import clsx from "clsx";
+import type { CategoryWithSkills } from "./useSkillsData";
+import { SkillRow } from "./SkillRow";
+
+interface CategoryStackCardProps {
+  category: CategoryWithSkills;
+  active: boolean;
+  layer: number; // 0 active, 1 next, 2 next2
+  style: MotionStyle;
+  drag?: "x" | false;
+  onDrag?: (
+    event: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo
+  ) => void;
+  onDragEnd?: (
+    event: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo
+  ) => void;
+}
+
+export function CategoryStackCard({
+  category,
+  active,
+  layer,
+  style,
+  drag,
+  onDrag,
+  onDragEnd,
+}: CategoryStackCardProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const scales = [1, 0.98, 0.96];
+  const opacities = [1, 0.85, 0.7];
+  const z = [50, 40, 30];
+  const scale = prefersReducedMotion ? 1 : scales[layer] ?? 1;
+  const opacity = opacities[layer] ?? 0;
+  const zIndex = z[layer] ?? 20;
+
+  const cardClass = clsx(
+    "absolute inset-x-4 top-0 bottom-0 rounded-[28px] border border-black/10 p-4 sm:p-5 text-white",
+    active && "shadow-[0_18px_40px_-18px_rgba(0,0,0,0.75)]",
+    !active && "pointer-events-none"
+  );
+
+  return (
+    <motion.div
+      drag={drag}
+      onDrag={onDrag}
+      onDragEnd={onDragEnd}
+      style={{ ...style, backgroundColor: category.color_hex ?? "#675CFF", zIndex }}
+      animate={{ scale, opacity }}
+      transition={{ type: "spring", stiffness: 520, damping: 38 }}
+      className={cardClass}
+    >
+      <header className="mb-3 flex items-center justify-between">
+        <h3 className="text-white/95 font-semibold">{category.name}</h3>
+        <span className="bg-white/10 text-white/80 rounded-xl px-2 py-0.5 text-xs">
+          {category.skills.length}
+        </span>
+      </header>
+      <div
+        className="space-y-2 overflow-y-auto overscroll-contain pr-1"
+        style={{ maskImage: "linear-gradient(to bottom, black 85%, transparent)" }}
+      >
+        {category.skills.map((skill) => (
+          <SkillRow key={skill.id} skill={skill} />
+        ))}
+      </div>
+    </motion.div>
+  );
+}
+

--- a/src/app/(app)/dashboard/_skills/SkillRow.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillRow.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { Skill } from "./useSkillsData";
+
+interface SkillRowProps {
+  skill: Skill;
+}
+
+export function SkillRow({ skill }: SkillRowProps) {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => router.push(`/skills/${skill.id}`)}
+      className="w-full rounded-2xl bg-black/15 border border-black/20 px-3 py-2.5 flex items-center gap-3 text-left"
+    >
+      <div className="size-9 rounded-xl bg-black/20 flex items-center justify-center text-lg">
+        {skill.icon || "💡"}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1 truncate">
+          <span className="text-white/90 font-medium truncate">{skill.name}</span>
+          <span className="text-[10px] px-1.5 py-0.5 rounded-md border border-white/15 bg-white/10 text-white/70 flex-shrink-0">
+            Lv {skill.level}
+          </span>
+        </div>
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <div className="h-2 w-[38%] min-w-[120px] rounded-full bg-white/15 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-white/80 transition-[width] duration-200"
+            style={{ width: `${skill.progress}%` }}
+          />
+        </div>
+        <span className="text-xs text-white/70 w-9 text-right">
+          {Math.round(skill.progress)}%
+        </span>
+      </div>
+    </button>
+  );
+}
+

--- a/src/app/(app)/dashboard/_skills/SkillsStack.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillsStack.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { PanInfo } from "framer-motion";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useSkillsData } from "./useSkillsData";
+import { CategoryStackCard } from "./CategoryStackCard";
+
+export function SkillsStack() {
+  const { categories } = useSkillsData();
+  const router = useRouter();
+  const search = useSearchParams();
+  const [activeIndex, setActiveIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cardWidth, setCardWidth] = useState(0);
+  const [dragX, setDragX] = useState(0);
+  const [lockScroll, setLockScroll] = useState(false);
+
+  // derive initial index from query
+  useEffect(() => {
+    if (!categories.length) return;
+    const slug = search.get("cat");
+    const idx = slug
+      ? categories.findIndex((c) => c.slug === slug)
+      : 0;
+    setActiveIndex(idx >= 0 ? idx : 0);
+  }, [categories, search]);
+
+  // persist index
+  useEffect(() => {
+    if (categories[activeIndex]) {
+      const params = new URLSearchParams(search.toString());
+      params.set("cat", categories[activeIndex].slug);
+      router.replace(`?${params.toString()}`, { scroll: false });
+    }
+  }, [activeIndex, categories, router, search]);
+
+  // measure card width
+  useEffect(() => {
+    const measure = () => {
+      if (containerRef.current) {
+        setCardWidth(containerRef.current.offsetWidth - 32); // inset-x-4
+      }
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
+
+  useEffect(() => {
+    document.body.style.overflow = lockScroll ? "hidden" : "";
+  }, [lockScroll]);
+
+  const handleDrag = (
+    _: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo
+  ) => {
+    setDragX(info.offset.x);
+    if (!lockScroll && Math.abs(info.offset.x) > 16) setLockScroll(true);
+  };
+
+  const handleDragEnd = (
+    _: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo
+  ) => {
+    setLockScroll(false);
+    const swipe = info.offset.x + info.velocity.x * 100;
+    let next = activeIndex;
+    if (swipe < -100 && activeIndex < categories.length - 1) next++;
+    if (swipe > 100 && activeIndex > 0) next--;
+    setActiveIndex(next);
+    setDragX(0);
+  };
+
+  const baseX = (index: number) => {
+    if (!cardWidth) return 0;
+    const diff = index - activeIndex;
+    const layer = diff > 0 ? Math.min(diff, 2) : 0;
+    const offsets = [0, 14, 28];
+    return diff * (cardWidth * 0.86) + (diff > 0 ? offsets[layer] : 0);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative min-h-[62vh] w-full"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Skill categories"
+    >
+      {categories.map((cat, index) => {
+        const layer = index > activeIndex ? Math.min(index - activeIndex, 2) : 0;
+        const x = baseX(index) +
+          (index === activeIndex
+            ? dragX
+            : index > activeIndex
+            ? dragX * 0.2
+            : 0);
+        return (
+          <CategoryStackCard
+            key={cat.id}
+            category={cat}
+            active={index === activeIndex}
+            layer={layer}
+            style={{ x }}
+            drag={index === activeIndex ? "x" : false}
+            onDrag={handleDrag}
+            onDragEnd={handleDragEnd}
+          />
+        );
+      })}
+      <div
+        className="mt-4 flex justify-center gap-2"
+        role="tablist"
+        onKeyDown={(e) => {
+          if (e.key === "ArrowRight" && activeIndex < categories.length - 1) {
+            setActiveIndex(activeIndex + 1);
+          } else if (e.key === "ArrowLeft" && activeIndex > 0) {
+            setActiveIndex(activeIndex - 1);
+          }
+        }}
+      >
+        {categories.map((cat, i) => (
+          <button
+            key={cat.id}
+            role="tab"
+            aria-selected={i === activeIndex}
+            className={`h-2 w-2 rounded-full ${
+              i === activeIndex ? "bg-white/80" : "bg-white/40"
+            }`}
+            onClick={() => setActiveIndex(i)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(app)/dashboard/_skills/useSkillsData.ts
+++ b/src/app/(app)/dashboard/_skills/useSkillsData.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+export interface Skill {
+  id: string;
+  name: string;
+  icon: string | null;
+  level: number;
+  progress: number;
+  cat_id: number | null;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+  slug: string;
+  color_hex: string | null;
+  order: number | null;
+}
+
+export interface CategoryWithSkills extends Category {
+  skills: Skill[];
+}
+
+export function useSkillsData() {
+  const [categories, setCategories] = useState<CategoryWithSkills[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const sb = getSupabaseBrowser();
+      const {
+        data: { user },
+      } = await sb.auth.getUser();
+      if (!user) return;
+
+      const { data: cats } = await sb
+        .from("cats")
+        .select("id,name,slug,color_hex,order")
+        .eq("user_id", user.id)
+        .order("order", { ascending: true });
+
+      const { data: skills } = await sb
+        .from("skills")
+        .select("id,name,icon,level,progress,cat_id")
+        .eq("user_id", user.id);
+
+      const grouped: CategoryWithSkills[] = (cats ?? []).map((c) => ({
+        id: c.id,
+        name: c.name,
+        slug: c.slug,
+        color_hex: c.color_hex,
+        order: c.order,
+        skills: (skills ?? []).filter((s) => s.cat_id === c.id),
+      }));
+
+      setCategories(grouped);
+      setLoading(false);
+    };
+    load();
+  }, []);
+
+  return { categories, loading };
+}
+


### PR DESCRIPTION
## Summary
- add useSkillsData hook to load categories & skills
- implement stacked carousel with drag, query sync and accessibility
- style category cards and skill rows with progress bars

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b9e60f69fc832c9a5f3ee680786dd8