### PR TITLE
feat: shared element transition for monuments

### DIFF
--- a/src/app/(app)/dashboard/components/ClientDashboard.tsx
+++ b/src/app/(app)/dashboard/components/ClientDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import type { DashboardData } from "@/types/dashboard";
+import MonumentCard from "./MonumentCard";
 
 interface ClientDashboardProps {
   data: DashboardData;
@@ -289,6 +290,19 @@ export function ClientDashboard({ data }: ClientDashboardProps) {
                 {monuments.Pinnacle}
               </div>
             </div>
+          </div>
+          {/* Actual monument cards rendered with shared-element transitions */}
+          <div className="mt-6 grid grid-cols-2 gap-4">
+            {Object.keys(monuments).map((key) => (
+              <MonumentCard
+                key={key}
+                id={key.toLowerCase()}
+                title={key}
+                color="#2C2C2C"
+                icon={<span>🏔️</span>}
+                progress={0}
+              />
+            ))}
           </div>
         </div>
 

--- a/src/app/(app)/dashboard/components/MonumentCard.tsx
+++ b/src/app/(app)/dashboard/components/MonumentCard.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { fetchMonument, fetchGoals } from '@/lib/monuments';
+import { useMonumentView } from '@/app/state/useMonumentView';
+
+export interface MonumentCardProps {
+  id: string;
+  title: string;
+  color: string;
+  icon: ReactNode;
+  progress: number;
+}
+
+/**
+ * Card shown on the dashboard for a monument. It participates in the
+ * shared-element transition to the monument detail view by using
+ * consistent `layoutId` values for its surface, icon and title.
+ *
+ * Data for the detail view is prefetched on pointer down so that when
+ * the route changes there is no loading indicator and the header can
+ * paint instantly from a snapshot stored in Zustand.
+ */
+export function MonumentCard({ id, title, color, icon, progress }: MonumentCardProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const setSnapshot = useMonumentView((s) => s.setSnapshot);
+
+  const warm = () => {
+    setSnapshot({ id, title, color, progress, icon });
+    queryClient.prefetchQuery({ queryKey: ['monument', id], queryFn: () => fetchMonument(id) });
+    queryClient.prefetchQuery({ queryKey: ['monumentGoals', id], queryFn: () => fetchGoals(id) });
+    router.prefetch(`/monuments/${id}`);
+  };
+
+  return (
+    <motion.button
+      layoutId={`monument:${id}:surface`}
+      style={{ backgroundColor: color }}
+      className="relative w-full overflow-hidden rounded-lg text-left"
+      whileTap={{ scale: 0.98 }}
+      transition={{ type: 'spring', stiffness: 420, damping: 38, mass: 0.9 }}
+      onPointerDown={warm}
+      onClick={() => router.push(`/monuments/${id}`)}
+    >
+      <motion.div layoutId={`monument:${id}:icon`} className="p-4 text-3xl">
+        {icon}
+      </motion.div>
+      <motion.div layoutId={`monument:${id}:title`} className="px-4 pb-4 font-semibold">
+        {title}
+      </motion.div>
+    </motion.button>
+  );
+}
+
+export default MonumentCard;
+

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -2,16 +2,19 @@ import TopNav from "@/components/TopNav";
 import BottomNav from "@/components/BottomNav";
 import { ProfileProvider } from "@/components/ProfileProvider";
 import { ToastProvider } from "@/components/ui/toast";
+import SharedLayoutBridge from "@/app/components/transition/SharedLayoutBridge";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return (
     <ToastProvider>
       <ProfileProvider>
-        <TopNav />
-        <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))]">
-          {children}
-        </main>
-        <BottomNav />
+        <SharedLayoutBridge>
+          <TopNav />
+          <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))]">
+            {children}
+          </main>
+          <BottomNav />
+        </SharedLayoutBridge>
       </ProfileProvider>
     </ToastProvider>
   );

--- a/src/app/(app)/monuments/[id]/MonumentGoals.tsx
+++ b/src/app/(app)/monuments/[id]/MonumentGoals.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { fetchGoals, type Goal } from '@/lib/monuments';
+
+interface MonumentGoalsProps {
+  id: string;
+}
+
+const parent = {
+  hidden: {},
+  show: {
+    transition: { delayChildren: 0.08, staggerChildren: 0.05 },
+  },
+};
+
+const child = {
+  hidden: { opacity: 0, y: 12 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.18, ease: [0.25, 1, 0.5, 1] },
+  },
+};
+
+/**
+ * Staggered reveal list of goals for a monument. Only the first few
+ * goals are shown initially to keep the transition light.
+ */
+export function MonumentGoals({ id }: MonumentGoalsProps) {
+  const { data } = useQuery({ queryKey: ['monumentGoals', id], queryFn: () => fetchGoals(id) });
+
+  return (
+    <motion.section
+      variants={parent}
+      initial="hidden"
+      animate="show"
+      className="p-4 space-y-2"
+    >
+      {data?.slice(0, 6).map((goal: Goal) => (
+        <motion.div key={goal.id} variants={child} className="rounded-md bg-zinc-800 p-3">
+          {goal.title || goal.name}
+        </motion.div>
+      ))}
+    </motion.section>
+  );
+}
+
+export default MonumentGoals;
+

--- a/src/app/(app)/monuments/[id]/MonumentHeader.tsx
+++ b/src/app/(app)/monuments/[id]/MonumentHeader.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { fetchMonument } from '@/lib/monuments';
+import { useMonumentView } from '@/app/state/useMonumentView';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+interface MonumentHeaderProps {
+  id: string;
+}
+
+/**
+ * Header for the monument detail page. It reuses layoutIds from the
+ * dashboard card so the icon, title and surface morph into place.
+ */
+export function MonumentHeader({ id }: MonumentHeaderProps) {
+  const router = useRouter();
+  const snapshot = useMonumentView((s) => s.last);
+  const { data } = useQuery({
+    queryKey: ['monument', id],
+    queryFn: () => fetchMonument(id),
+    initialData: snapshot && snapshot.id === id ? snapshot : undefined,
+  });
+
+  useEffect(() => {
+    return () => {
+      // clear snapshot when leaving
+      useMonumentView.getState().clear();
+    };
+  }, []);
+
+  const handleBack = () => router.back();
+
+  return (
+    <motion.header
+      className="relative overflow-hidden"
+      style={{ backgroundColor: data?.color || '#fff' }}
+    >
+      <motion.div
+        layoutId={`monument:${id}:surface`}
+        className="absolute inset-0"
+        style={{ backgroundColor: data?.color || '#fff' }}
+        transition={{ type: 'spring', stiffness: 420, damping: 38, mass: 0.9 }}
+      />
+      <div className="relative z-10 p-4">
+        <button onClick={handleBack} className="mb-2 text-sm">Back</button>
+        <motion.div layoutId={`monument:${id}:icon`} className="text-4xl">
+          {data?.icon}
+        </motion.div>
+        <motion.h1
+          layoutId={`monument:${id}:title`}
+          className="mt-2 text-2xl font-bold"
+        >
+          {data?.title}
+        </motion.h1>
+      </div>
+    </motion.header>
+  );
+}
+
+export default MonumentHeader;
+

--- a/src/app/(app)/monuments/[id]/page.tsx
+++ b/src/app/(app)/monuments/[id]/page.tsx
@@ -1,11 +1,18 @@
-"use client";
+import SharedLayoutBridge from '@/app/components/transition/SharedLayoutBridge';
+import { MonumentHeader } from './MonumentHeader';
+import { MonumentGoals } from './MonumentGoals';
 
-import { useParams } from "next/navigation";
-import { MonumentDetail } from "@/components/monuments/MonumentDetail";
+interface PageProps {
+  params: { id: string };
+}
 
-export default function MonumentDetailPage() {
-  const params = useParams();
-  const id = params.id as string;
-  return <MonumentDetail id={id} />;
+export default function MonumentPage({ params }: PageProps) {
+  const { id } = params;
+  return (
+    <SharedLayoutBridge>
+      <MonumentHeader id={id} />
+      <MonumentGoals id={id} />
+    </SharedLayoutBridge>
+  );
 }
 

--- a/src/app/components/transition/SharedLayoutBridge.tsx
+++ b/src/app/components/transition/SharedLayoutBridge.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { LayoutGroup } from 'framer-motion';
+
+/**
+ * SharedLayoutBridge wraps children with a framer-motion LayoutGroup
+ * so elements that share the same `layoutId` can animate seamlessly
+ * across different routes. All monument related transitions use the
+ * `monuments` group id so they can morph from dashboard cards to the
+ * monument detail header and back.
+ */
+export function SharedLayoutBridge({ children }: { children: ReactNode }) {
+  return <LayoutGroup id="monuments">{children}</LayoutGroup>;
+}
+
+export default SharedLayoutBridge;
+

--- a/src/app/state/useMonumentView.ts
+++ b/src/app/state/useMonumentView.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import type { ReactNode } from 'react';
+
+export interface MonumentSnapshot {
+  id: string;
+  title: string;
+  color: string;
+  progress: number;
+  icon: ReactNode;
+}
+
+interface MonumentViewState {
+  last?: MonumentSnapshot;
+  setSnapshot: (snap: MonumentSnapshot) => void;
+  clear: () => void;
+}
+
+/**
+ * Small Zustand store that remembers the most recently opened
+ * monument card. During navigation we paint the detail page from
+ * this snapshot instantly while the real data is fetched in the
+ * background.
+ */
+export const useMonumentView = create<MonumentViewState>((set) => ({
+  last: undefined,
+  setSnapshot: (snap) => set({ last: snap }),
+  clear: () => set({ last: undefined }),
+}));
+

--- a/src/lib/monuments.ts
+++ b/src/lib/monuments.ts
@@ -1,0 +1,28 @@
+import type { MonumentSnapshot } from '@/app/state/useMonumentView';
+
+// Basic API helpers used for prefetching monument data. The actual
+// backend implementation can be swapped later; for now we simply
+// fetch from REST endpoints and return JSON.
+
+export interface Goal {
+  id: string;
+  title?: string;
+  name?: string;
+}
+
+export async function fetchMonument(id: string): Promise<MonumentSnapshot> {
+  const res = await fetch(`/api/monuments/${id}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch monument');
+  }
+  return res.json();
+}
+
+export async function fetchGoals(id: string): Promise<Goal[]> {
+  const res = await fetch(`/api/monuments/${id}/goals`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch monument goals');
+  }
+  return res.json();
+}
+


### PR DESCRIPTION
## Summary
- add `SharedLayoutBridge` layout group wrapper for monument transitions
- implement `MonumentCard` with prefetch and layoutIds
- create monument detail header/goals components with staggered animation and snapshot store

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb4cd158832ca916a3d86b3a379f