### PR TITLE
Restyle dashboard with dark slate design system

### DIFF
--- a/components/ui/MonumentCard.tsx
+++ b/components/ui/MonumentCard.tsx
@@ -1,21 +1,19 @@
-import { LucideIcon } from 'lucide-react'
+import { LucideIcon } from "lucide-react";
 
 interface MonumentCardProps {
-  icon: LucideIcon
-  title: string
-  count: number
+  icon: LucideIcon;
+  title: string;
+  count: number;
 }
 
 export function MonumentCard({ icon: Icon, title, count }: MonumentCardProps) {
   return (
-    <div className="group hover:translate-y-[-2px] transition-all duration-200 hover:shadow-[0_12px_32px_rgba(0,0,0,0.55)]">
-      <div className="bg-[#15161A] rounded-2xl shadow-[0_8px_24px_rgba(0,0,0,0.45)] border border-white/5 p-6 text-center">
-        <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-white/5 flex items-center justify-center">
-          <Icon className="w-8 h-8 text-white/70" aria-hidden="true" />
-        </div>
-        <h3 className="text-zinc-200 font-medium mb-2">{title}</h3>
-        <div className="text-2xl font-bold text-zinc-300">{count}</div>
+    <div className="transition-transform duration-150 hover:-translate-y-px">
+      <div className="bg-card rounded-lg border border-border p-4 text-center hover:bg-cardho">
+        <Icon className="mx-auto mb-3 h-7 w-7 text-icon" aria-hidden />
+        <h3 className="text-texthi text-[15px] font-medium">{title}</h3>
+        <div className="mt-1 text-textmed text-[12px]">{count}</div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -2,12 +2,11 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Section } from "@/components/ui/Section";
 import { LevelBanner } from "@/components/ui/LevelBanner";
-import { MonumentContainer } from "@/components/ui/MonumentContainer";
-import SkillsCarousel from "./_skills/SkillsCarousel";
-import { GoalCard } from "../goals/components/GoalCard";
+import MonumentsRow from "@/components/ui/MonumentsRow";
+import { SkillPill } from "@/components/ui/SkillPill";
+import useSkillsData from "./_skills/useSkillsData";
 import type { Goal, Project } from "../goals/types";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { getGoalsForUser } from "@/lib/queries/goals";
@@ -77,9 +76,11 @@ function goalStatusToStatus(status?: string | null): Goal["status"] {
 }
 
 export default function DashboardClient() {
-  const router = useRouter();
   const [goals, setGoals] = useState<Goal[]>([]);
   const [loadingGoals, setLoadingGoals] = useState(true);
+  const { skillsByCategory, isLoading: loadingSkills } = useSkillsData();
+
+  const skills = Object.values(skillsByCategory).flat();
 
   useEffect(() => {
     loadGoals();
@@ -203,37 +204,45 @@ export default function DashboardClient() {
   };
 
   return (
-    <main className="pb-20">
+    <main className="px-4 py-gaplg pb-20 flex flex-col gap-gaplg">
       <LevelBanner level={80} current={3200} total={4000} />
 
-      <MonumentContainer />
-
-      <Section title={<Link href="/skills">Skills</Link>} className="mt-1 px-4">
-        <SkillsCarousel />
+      <Section title="Monuments">
+        <MonumentsRow />
       </Section>
 
-      <Section
-        title={<Link href="/goals">Current Goals</Link>}
-        className="safe-bottom mt-2 px-4"
-      >
-        {loadingGoals ? (
-          <div className="space-y-2">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="h-24 bg-gray-800 animate-pulse rounded" />
-            ))}
-          </div>
-        ) : goals.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-            {goals.map((goal) => (
-              <GoalCard
-                key={goal.id}
-                goal={goal}
-                onEdit={() => router.push(`/goals?edit=${goal.id}`)}
+      <Section title={<Link href="/skills">Skills</Link>}>
+        {loadingSkills ? (
+          <div className="text-center text-textmed">Loading...</div>
+        ) : skills.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-gaplg">
+            {skills.slice(0, 6).map((s) => (
+              <SkillPill
+                key={s.id}
+                emoji={s.emoji || "✦"}
+                title={s.name}
+                pct={s.xpPercent || 0}
               />
             ))}
           </div>
         ) : (
-          <div className="text-center py-8 text-gray-500">No active goals.</div>
+          <div className="text-textmed">No skills yet</div>
+        )}
+      </Section>
+
+      <Section title={<Link href="/goals">Current Goals</Link>} className="safe-bottom">
+        {loadingGoals ? (
+          <div className="text-center text-textmed">Loading...</div>
+        ) : goals.length > 0 ? (
+          <div className="bg-card rounded-lg border border-border p-5">
+            <ul className="list-disc pl-5 space-y-1 text-texthi text-[14.5px] leading-[1.6] marker:text-textmed">
+              {goals.map((goal) => (
+                <li key={goal.id}>{goal.title}</li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className="text-textmed text-[14.5px]">No active goals.</div>
         )}
       </Section>
     </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="flex min-h-screen flex-col">
+      <body className="flex min-h-screen flex-col bg-bg text-texthi font-ui">
         <ErrorBoundary>
           <AuthProvider>
             <ClientProviders>

--- a/src/components/ui/LevelBanner.tsx
+++ b/src/components/ui/LevelBanner.tsx
@@ -1,24 +1,32 @@
 import React from "react";
 
 export function LevelBanner({
-  level = 80, current = 3200, total = 4000
-}:{level?:number; current?:number; total?:number;}){
-  const pct = Math.max(0, Math.min(100, Math.round((current/total)*100)));
+  level = 80,
+  current = 3200,
+  total = 4000,
+}: {
+  level?: number;
+  current?: number;
+  total?: number;
+}) {
+  const pct = Math.max(0, Math.min(100, Math.round((current / total) * 100)));
   return (
-    <div className="card mx-4 mt-4 p-4">
-      <div className="mb-3">
-        <div className="font-extrabold text-[18px] tracking-wide">LEVEL {level}</div>
-      </div>
+    <section className="bg-panel rounded-lg border border-border shadow-soft p-6 md:p-7">
+      <h2 className="mb-4 text-textmed text-[12.5px] md:text-[13px] font-semibold tracking-section uppercase">
+        LEVEL {level}
+      </h2>
       <div className="relative">
-        <div className="h-[12px] w-full rounded-full bg-[#0c0f14] inner-hair" />
+        <div className="h-[10px] w-full rounded-full bg-track" />
         <div
-          className="absolute left-0 top-0 h-[12px] rounded-full bg-gradient-to-r from-gray-700 to-gray-900"
+          className="absolute left-0 top-0 h-[10px] rounded-full bg-fill"
           style={{ width: `${pct}%` }}
         />
-        <div className="absolute right-1 -top-6 text-[11px] px-2 py-[2px] rounded-full bg-[#0c0f14] border border-white/10">
-          {current} / {total}
+        <div className="absolute right-0 -top-6">
+          <div className="px-2 py-1 bg-card text-textmed rounded-md text-[11.5px]">
+            {current} / {total}
+          </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/ui/MonumentsRow.tsx
+++ b/src/components/ui/MonumentsRow.tsx
@@ -1,0 +1,21 @@
+import { Trophy, Landmark, Medal, Mountain } from "lucide-react";
+import { MonumentCard } from "@/components/ui/MonumentCard";
+
+const monuments = [
+  { icon: Trophy, title: "Achievement", count: 5 },
+  { icon: Landmark, title: "Legacy", count: 10 },
+  { icon: Medal, title: "Triumph", count: 4 },
+  { icon: Mountain, title: "Pinnacle", count: 7 },
+];
+
+export function MonumentsRow() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-gaplg">
+      {monuments.map((m) => (
+        <MonumentCard key={m.title} icon={m.icon} title={m.title} count={m.count} />
+      ))}
+    </div>
+  );
+}
+
+export default MonumentsRow;

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,8 +1,28 @@
 import React from "react";
+import clsx from "clsx";
 
-export function Section({title,children,className=""}:{title?:React.ReactNode;children?:React.ReactNode;className?:string;}){
-  return (<section className={`section ${className}`}>
-    {title ? <div className="h-label mb-3">{title}</div> : null}
-    {children}
-  </section>);
+export function Section({
+  title,
+  children,
+  className = "",
+}: {
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      className={clsx(
+        "bg-panel rounded-lg border border-border shadow-soft p-6 md:p-7",
+        className
+      )}
+    >
+      {title ? (
+        <h2 className="mb-4 text-textmed text-[12.5px] md:text-[13px] font-semibold tracking-section uppercase">
+          {title}
+        </h2>
+      ) : null}
+      {children}
+    </section>
+  );
 }

--- a/src/components/ui/SkillPill.tsx
+++ b/src/components/ui/SkillPill.tsx
@@ -1,25 +1,24 @@
 import React from "react";
 
 export function SkillPill({
-  emoji = "✦", title, pct = 50
-}:{emoji?:string; title:string; pct?:number;}){
+  emoji = "✦",
+  title,
+  pct = 0,
+}: {
+  emoji?: string;
+  title: string;
+  pct?: number;
+}) {
   const w = Math.max(0, Math.min(100, pct));
   return (
-    <div className="card rounded-full px-4 py-3 mb-3">
-      <div className="flex items-center gap-3">
-        <div
-          className="w-9 h-9 rounded-full bg-[#0c0f14] border border-white/10 grid place-items-center text-[15px]"
-        >
-          {emoji}
-        </div>
-        <div className="flex-1">
-          <div className="font-semibold">{title}</div>
-          <div className="mt-1 h-[6px] rounded-full bg-[#0c0f14]">
-            <div
-              className="h-[6px] rounded-full bg-gradient-to-r from-gray-700 to-gray-900"
-              style={{ width: `${w}%` }}
-            />
-          </div>
+    <div className="bg-card rounded-lg border border-border p-4 flex items-center gap-3 hover:bg-cardho transition-colors duration-150">
+      <div className="w-9 h-9 rounded-full bg-pill flex items-center justify-center text-icon text-[15px]">
+        {emoji}
+      </div>
+      <div className="flex-1">
+        <div className="text-texthi text-[15px] font-medium">{title}</div>
+        <div className="mt-2 h-2 rounded bg-track">
+          <div className="h-2 rounded bg-fill" style={{ width: `${w}%` }} />
         </div>
       </div>
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,20 +7,59 @@
   }
 }
 
-:root{
-  --bg:#0f1115; --surface:#171a21; --surface-2:#1c2028;
-  --text:#e6e7ea; --muted:#9aa3ad; --accent:#6ea8ff;
-  --radius:16px; --radius-sm:12px;
-  --popover:var(--surface); --popover-foreground:var(--text);
+:root {
+  --bg: #0b0d0f;
+  --panel: #13161a;
+  --card: #181c20;
+  --card-ho: #1e2328;
+  --border: #242a30;
+  --track: #242a30;
+  --fill: #3b424a;
+  --text-hi: #e6eaef;
+  --text-med: #b0b7c0;
+  --text-lo: #7f8791;
+  --pill: #1a1f24;
+  --icon: #9aa2ac;
+  --scrim: rgba(0, 0, 0, 0.25);
+  --shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+  --radius-lg: 16px;
+  --radius-sm: 12px;
+  --gap-lg: 20px;
+  --gap-sm: 12px;
 }
-html,body{ background:var(--bg); color:var(--text); font-weight:600; touch-action:pan-y; overflow-x:hidden; }
-.section{ padding:20px 16px 8px; }
-.h-label{ letter-spacing:.12em; text-transform:uppercase; font-weight:700; color:var(--muted); font-size:12px; }
-.card{ background:linear-gradient(180deg,var(--surface),var(--surface-2));
-       border-radius:var(--radius);
-       box-shadow:0 1px 0 rgba(255,255,255,.04) inset, 0 10px 28px rgba(0,0,0,.5);
-       border:1px solid rgba(255,255,255,.06); }
-.inner-hair{ box-shadow:0 1px 0 rgba(255,255,255,.04) inset; }
-.safe-bottom{ padding-bottom:calc(env(safe-area-inset-bottom,16px) + 12px); }
-.scroll-snap{ scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch; touch-action:pan-x; }
-.snap-start{ scroll-snap-align:start; }
+
+html, body {
+  background: var(--bg);
+  color: var(--text-hi);
+  touch-action: pan-y;
+  overflow-x: hidden;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.h-label {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--text-med);
+  font-size: 12.5px;
+}
+
+.safe-bottom {
+  padding-bottom: calc(env(safe-area-inset-bottom, 16px) + 12px);
+}
+
+.scroll-snap {
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-x;
+}
+
+.snap-start {
+  scroll-snap-align: start;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,40 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--bg)",
+        panel: "var(--panel)",
+        card: "var(--card)",
+        cardho: "var(--card-ho)",
+        border: "var(--border)",
+        track: "var(--track)",
+        fill: "var(--fill)",
+        texthi: "var(--text-hi)",
+        textmed: "var(--text-med)",
+        textlo: "var(--text-lo)",
+        pill: "var(--pill)",
+        icon: "var(--icon)",
+      },
+      borderRadius: {
+        lg: "var(--radius-lg)",
+        md: "var(--radius-sm)",
+      },
+      boxShadow: {
+        soft: "var(--shadow)",
+      },
+      spacing: {
+        gaplg: "var(--gap-lg)",
+        gapsm: "var(--gap-sm)",
+      },
+      fontFamily: {
+        ui: ["Inter", "system-ui", "Segoe UI", "Arial", "sans-serif"],
+      },
+      letterSpacing: {
+        section: ".08em",
+      },
+    },
+  },
   plugins: [],
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,4 +6,39 @@ export default {
     "./src/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
   ],
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--bg)",
+        panel: "var(--panel)",
+        card: "var(--card)",
+        cardho: "var(--card-ho)",
+        border: "var(--border)",
+        track: "var(--track)",
+        fill: "var(--fill)",
+        texthi: "var(--text-hi)",
+        textmed: "var(--text-med)",
+        textlo: "var(--text-lo)",
+        pill: "var(--pill)",
+        icon: "var(--icon)",
+      },
+      borderRadius: {
+        lg: "var(--radius-lg)",
+        md: "var(--radius-sm)",
+      },
+      boxShadow: {
+        soft: "var(--shadow)",
+      },
+      spacing: {
+        gaplg: "var(--gap-lg)",
+        gapsm: "var(--gap-sm)",
+      },
+      fontFamily: {
+        ui: ["Inter", "system-ui", "Segoe UI", "Arial", "sans-serif"],
+      },
+      letterSpacing: {
+        section: ".08em",
+      },
+    },
+  },
 } satisfies Config;


### PR DESCRIPTION
## Summary
- introduce slate monochrome design tokens and extend Tailwind theme
- restyle dashboard components (level, monuments, skills, goals) using new palette
- add MonumentsRow component

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68ba3d224ba4832c9dc5097d28b7f450