### PR TITLE
feat: apply dark slate dashboard styling

### DIFF
--- a/components/ui/CatCard.tsx
+++ b/components/ui/CatCard.tsx
@@ -17,26 +17,26 @@ export function CatCard({ cat }: CatCardProps) {
   };
 
   return (
-    <div className="bg-[#2C2C2C] rounded-lg border border-[#333] overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
       {/* Category Header */}
-      <div 
-        className="p-4 cursor-pointer hover:bg-[#353535] transition-colors"
+      <div
+        className="cursor-pointer p-4 transition-colors hover:bg-cardho"
         onClick={toggleExpanded}
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="text-lg font-medium text-[#E0E0E0]">
+            <div className="text-lg font-medium text-texthi">
               {cat.cat_name}
             </div>
-            <div className="text-sm text-[#A0A0A0] bg-[#404040] px-2 py-1 rounded-full">
+            <div className="rounded-full bg-pill px-2 py-1 text-sm text-textmed">
               {cat.skill_count} skills
             </div>
           </div>
-          <div className="text-[#A0A0A0]">
+          <div className="text-icon">
             {isExpanded ? (
-              <ChevronDown className="w-5 h-5" />
+              <ChevronDown className="h-5 w-5" />
             ) : (
-              <ChevronRight className="w-5 h-5" />
+              <ChevronRight className="h-5 w-5" />
             )}
           </div>
         </div>
@@ -44,14 +44,14 @@ export function CatCard({ cat }: CatCardProps) {
 
       {/* Skills List */}
       {isExpanded && (
-        <div className="border-t border-[#333] bg-[#252525]">
-          <div className="p-4 space-y-3">
+        <div className="border-t border-border bg-panel">
+          <div className="space-y-3 p-4">
             {cat.skills && cat.skills.length > 0 ? (
               cat.skills.map((skill) => (
                 <SkillRow key={skill.skill_id} skill={skill} />
               ))
             ) : (
-              <div className="text-sm text-[#808080] text-center py-2">
+              <div className="py-2 text-center text-sm text-textmed">
                 No skills in this category
               </div>
             )}

--- a/components/ui/SkillRow.tsx
+++ b/components/ui/SkillRow.tsx
@@ -38,36 +38,36 @@ export function SkillRow({ skill }: SkillRowProps) {
   };
 
   return (
-    <div className="flex items-center gap-3 p-3 bg-[#1E1E1E] rounded-md border border-[#333] hover:bg-[#252525] transition-colors">
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-cardho">
       {/* Skill Icon */}
-      <div className="text-xl flex-shrink-0">
+      <div className="flex-shrink-0 text-xl text-icon">
         {getSkillIcon(skill.name, skill.icon)}
       </div>
-      
+
       {/* Skill Name */}
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-[#E0E0E0] truncate">
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-texthi">
           {skill.name}
         </div>
       </div>
-      
+
       {/* Level Badge */}
-      <div className="text-xs text-[#A0A0A0] bg-[#404040] px-2 py-1 rounded-full flex-shrink-0">
+      <div className="flex-shrink-0 rounded-full bg-pill px-2 py-1 text-xs text-textmed">
         Lv {skill.level}
       </div>
-      
+
       {/* Progress Bar */}
       <div className="w-20 flex-shrink-0">
-        <div className="w-full h-2 bg-[#333] rounded-full overflow-hidden">
-          <div 
-            className="h-full bg-[#BBB] rounded-full transition-all duration-300"
+        <div className="h-2 w-full overflow-hidden rounded-full bg-track">
+          <div
+            className="h-full rounded-full bg-fill transition-all duration-300"
             style={{ width: `${skill.progress}%` }}
           />
         </div>
       </div>
-      
+
       {/* Progress Percentage */}
-      <div className="text-xs text-[#A0A0A0] w-12 text-right flex-shrink-0">
+      <div className="w-12 flex-shrink-0 text-right text-xs text-textmed">
         {skill.progress}%
       </div>
     </div>

--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -5,17 +5,6 @@ import { motion } from "framer-motion";
 import SkillRow from "./SkillRow";
 import type { Category, Skill } from "./useSkillsData";
 
-function getOnColor(hex: string) {
-  if (!hex) return "#fff";
-  const c = hex.replace("#", "");
-  const r = parseInt(c.substring(0, 2), 16);
-  const g = parseInt(c.substring(2, 4), 16);
-  const b = parseInt(c.substring(4, 6), 16);
-  // luminance
-  const l = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return l > 0.6 ? "#000" : "#fff";
-}
-
 interface Props {
   category: Category;
   skills: Skill[];
@@ -23,16 +12,11 @@ interface Props {
 }
 
 export default function CategoryCard({ category, skills, active }: Props) {
-  const bg = category.color_hex || "#0B0B0F";
-  const on = getOnColor(bg);
-  const track = on === "#fff" ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
-  const fill = on === "#fff" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.7)";
-
   return (
     <motion.div
       layout
-      className="absolute inset-0 rounded-3xl border border-black/10 shadow-[0_20px_40px_-20px_rgba(0,0,0,0.8)] p-3 sm:p-4 flex flex-col"
-      style={{ backgroundColor: bg, color: on, pointerEvents: active ? "auto" : "none" }}
+      className="absolute inset-0 flex flex-col rounded-lg border border-border bg-panel p-3 shadow-soft sm:p-4 text-texthi"
+      style={{ pointerEvents: active ? "auto" : "none" }}
       initial={false}
       animate={active ? "active" : "inactive"}
       variants={{
@@ -47,22 +31,17 @@ export default function CategoryCard({ category, skills, active }: Props) {
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -4 }}
         transition={{ duration: 0.16 }}
-        className="flex-1 flex flex-col overflow-hidden"
+        className="flex flex-1 flex-col overflow-hidden"
       >
-        <header className="flex items-center justify-between mb-2">
-          <h3 className="font-semibold" style={{ color: on }}>
-            {category.name}
-          </h3>
-          <span
-            className="text-xs rounded-xl px-2 py-0.5"
-            style={{ backgroundColor: track, color: on }}
-          >
+        <header className="mb-2 flex items-center justify-between">
+          <h3 className="font-medium">{category.name}</h3>
+          <span className="rounded-xl bg-pill px-2 py-0.5 text-xs text-textmed">
             {skills.length}
           </span>
         </header>
-        <div className="flex-1 overflow-y-auto overscroll-contain flex flex-col gap-2 pt-3 pb-4">
+        <div className="flex flex-1 flex-col gap-2 overflow-y-auto overscroll-contain pt-3 pb-4">
           {skills.length === 0 ? (
-            <div className="text-sm" style={{ color: on }}>
+            <div className="text-sm text-textmed">
               No skills yet
               <div className="mt-2">
                 <Link href="/skills" className="underline">
@@ -71,9 +50,7 @@ export default function CategoryCard({ category, skills, active }: Props) {
               </div>
             </div>
           ) : (
-            skills.map((s) => (
-              <SkillRow key={s.id} skill={s} onColor={on} trackColor={track} fillColor={fill} />
-            ))
+            skills.map((s) => <SkillRow key={s.id} skill={s} />)
           )}
         </div>
       </motion.div>

--- a/src/app/(app)/dashboard/_skills/SkillRow.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillRow.tsx
@@ -10,51 +10,37 @@ export function computeWidth(percent: number) {
 
 interface Props {
   skill: Skill;
-  onColor: string;
-  trackColor: string;
-  fillColor: string;
 }
 
-export default function SkillRow({ skill, onColor, trackColor, fillColor }: Props) {
+export default function SkillRow({ skill }: Props) {
   const showLevel = skill.level !== null && skill.level !== undefined;
   const showProgress = skill.xpPercent !== null && skill.xpPercent !== undefined;
 
   return (
     <Link
       href={`/skills/${skill.id}`}
-      className="rounded-2xl bg-black/15 border border-black/20 px-3 py-2.5 flex items-center gap-3 active:scale-[.98] transition-transform"
-      style={{ color: onColor }}
+      className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-texthi transition-colors duration-150 hover:bg-cardho active:scale-[.98] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
     >
-      <div className="size-9 rounded-xl bg-black/25 flex items-center justify-center text-lg">
+      <div className="flex size-9 items-center justify-center rounded-full bg-pill text-lg text-icon">
         {skill.emoji || ""}
       </div>
-      <div className="flex-1 min-w-0">
-        <div className="font-medium truncate" style={{ color: onColor }}>
-          {skill.name}
-        </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium">{skill.name}</div>
         {showLevel && (
-          <div
-            className="mt-1 inline-block text-[10px] px-1.5 py-0.5 rounded-lg border border-white/15 bg-white/8"
-            style={{ color: onColor }}
-          >
+          <div className="mt-1 inline-block rounded-lg border border-border bg-pill px-1.5 py-0.5 text-[10px] text-textmed">
             Lv {skill.level}
           </div>
         )}
       </div>
       {showProgress && (
-        <div className="flex items-center gap-2 min-w-[36%]">
-          <div
-            className="flex-1 h-2 rounded-full overflow-hidden"
-            style={{ backgroundColor: trackColor }}
-          >
+        <div className="min-w-[36%] flex items-center gap-2">
+          <div className="flex-1 h-2 overflow-hidden rounded-full bg-track">
             <div
-              className="h-full rounded-full transition-[width] duration-200"
-              style={{ width: computeWidth(skill.xpPercent as number), backgroundColor: fillColor }}
+              className="h-full rounded-full bg-fill transition-[width] duration-200"
+              style={{ width: computeWidth(skill.xpPercent as number) }}
             />
           </div>
-          <span className="text-xs" style={{ color: onColor }}>
-            {skill.xpPercent}%
-          </span>
+          <span className="text-xs text-textmed">{skill.xpPercent}%</span>
         </div>
       )}
     </Link>

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -29,51 +29,46 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
     }
   };
 
-  const priorityColor =
-    goal.priority === "High"
-      ? "bg-red-600"
-      : goal.priority === "Medium"
-      ? "bg-yellow-600"
-      : "bg-green-600";
+  const priorityColor = "bg-pill text-textmed";
 
   return (
-    <div className="bg-gray-800 rounded-lg shadow text-left">
+    <div className="rounded-lg border border-border bg-card text-left">
       <div className="relative">
         <button
           onClick={toggle}
           aria-expanded={open}
           aria-controls={`goal-${goal.id}`}
-          className="w-full flex items-start justify-between p-4 active:scale-95 transition-transform motion-safe:duration-150 motion-reduce:transform-none"
+          className="flex w-full items-start justify-between p-4 transition-colors duration-150 hover:bg-cardho active:scale-95 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border motion-reduce:transform-none"
         >
           <div className="flex-1">
             <div className="flex items-center gap-2">
-              {goal.emoji && <span className="text-xl" aria-hidden>{goal.emoji}</span>}
-              <span id={`goal-${goal.id}-label`} className="font-medium truncate">
+              {goal.emoji && <span className="text-xl text-icon" aria-hidden>{goal.emoji}</span>}
+              <span id={`goal-${goal.id}-label`} className="truncate font-medium text-texthi">
                 {goal.title}
               </span>
             </div>
-            <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-300">
-              <div className="w-10 h-2 bg-gray-700 rounded-full overflow-hidden">
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-textmed">
+              <div className="h-2 w-10 overflow-hidden rounded-full bg-track">
                 <div
-                  className="h-full bg-blue-500"
+                  className="h-full bg-fill"
                   style={{ width: `${goal.progress}%` }}
                 />
               </div>
               {goal.dueDate && (
-                <span className="px-2 py-0.5 bg-gray-700 rounded-full">
+                <span className="rounded-full bg-pill px-2 py-0.5">
                   {new Date(goal.dueDate).toLocaleDateString()}
                 </span>
               )}
-              <span className={`px-2 py-0.5 rounded-full ${priorityColor}`}>
+              <span className={`rounded-full px-2 py-0.5 ${priorityColor}`}>
                 {goal.priority}
               </span>
-              <span className="px-2 py-0.5 bg-gray-700 rounded-full">
+              <span className="rounded-full bg-pill px-2 py-0.5">
                 {goal.projects.length} projects
               </span>
             </div>
           </div>
           <ChevronDown
-            className={`w-5 h-5 ml-2 transition-transform ${open ? "rotate-180" : ""}`}
+            className={`ml-2 h-5 w-5 transition-transform text-icon ${open ? "rotate-180" : ""}`}
           />
         </button>
         <div className="absolute top-2 right-2">
@@ -81,9 +76,9 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
             <DropdownMenuTrigger asChild>
               <button
                 aria-label="Goal actions"
-                className="p-1 rounded bg-gray-700"
+                className="rounded bg-pill p-1 text-icon hover:bg-cardho focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
               >
-                <MoreHorizontal className="w-4 h-4" />
+                <MoreHorizontal className="h-4 w-4" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">

--- a/src/components/MonumentGridWithSharedTransition.tsx
+++ b/src/components/MonumentGridWithSharedTransition.tsx
@@ -32,57 +32,57 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
 
   return (
     <div>
-      <div className="grid grid-cols-4 gap-1">
-        {monuments.map((m) => (
-          <motion.button
-            key={m.id}
-            layoutId={`card-${m.id}`}
-            onClick={() => setActiveId(m.id)}
-            className="card flex aspect-square w-full flex-col items-center justify-center p-1 transition-colors hover:bg-white/5"
-          >
-            <motion.div layoutId={`emoji-${m.id}`} className="mb-1 text-lg">
-              {m.emoji}
-            </motion.div>
-            <motion.h3
-              layoutId={`title-${m.id}`}
-              className="w-full break-words text-center text-[10px] font-semibold leading-tight"
+        <div className="grid grid-cols-4 gap-1">
+          {monuments.map((m) => (
+            <motion.button
+              key={m.id}
+              layoutId={`card-${m.id}`}
+              onClick={() => setActiveId(m.id)}
+              className="flex aspect-square w-full flex-col items-center justify-center rounded-lg border border-border bg-card p-4 text-icon transition-colors duration-150 hover:-translate-y-px hover:bg-cardho focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
             >
-              {m.title}
-            </motion.h3>
-            <p className="mt-0.5 text-[9px] text-zinc-500">{m.stats}</p>
-          </motion.button>
-        ))}
-      </div>
-
-      <AnimatePresence>
-        {selected && (
-          <motion.div
-            key="overlay"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2, ease: "easeInOut" }}
-          >
-            <motion.div
-              layoutId={`card-${selected.id}`}
-              className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl bg-zinc-900 shadow-xl"
-              initial={{ opacity: 0, scale: 0.95 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.25, ease: "easeInOut", layout: { duration: 0.25 } }}
-            >
-              <button
-                onClick={() => setActiveId(null)}
-                className="absolute right-4 top-4 z-10 rounded-md bg-zinc-800 px-3 py-1 text-sm"
+              <motion.div layoutId={`emoji-${m.id}`} className="mb-2 text-2xl">
+                {m.emoji}
+              </motion.div>
+              <motion.h3
+                layoutId={`title-${m.id}`}
+                className="w-full break-words text-center text-[15px] font-medium text-texthi"
               >
-                Close
-              </button>
-              <MonumentDetail id={selected.id} />
+                {m.title}
+              </motion.h3>
+              <p className="mt-1 text-[12px] text-textmed">{m.stats}</p>
+            </motion.button>
+          ))}
+        </div>
+
+        <AnimatePresence>
+          {selected && (
+            <motion.div
+              key="overlay"
+              className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--scrim)] p-4"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+            >
+              <motion.div
+                layoutId={`card-${selected.id}`}
+                className="relative h-full w-full max-w-md overflow-y-auto rounded-lg border border-border bg-panel shadow-soft"
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                transition={{ duration: 0.25, ease: "easeInOut", layout: { duration: 0.25 } }}
+              >
+                <button
+                  onClick={() => setActiveId(null)}
+                  className="absolute right-4 top-4 z-10 rounded-md bg-card px-3 py-1 text-sm text-textmed hover:bg-cardho focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+                >
+                  Close
+                </button>
+                <MonumentDetail id={selected.id} />
+              </motion.div>
             </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+          )}
+        </AnimatePresence>
     </div>
   );
 }

--- a/src/components/ui/LevelBanner.tsx
+++ b/src/components/ui/LevelBanner.tsx
@@ -5,17 +5,17 @@ export function LevelBanner({
 }:{level?:number; current?:number; total?:number;}){
   const pct = Math.max(0, Math.min(100, Math.round((current/total)*100)));
   return (
-    <div className="card mx-4 mt-4 p-4">
-      <div className="mb-3">
-        <div className="font-extrabold text-[18px] tracking-wide">LEVEL {level}</div>
+    <div className="mx-4 mt-4 rounded-lg border border-border bg-panel p-6 shadow-soft">
+      <div className="mb-4 text-[12.5px] font-semibold uppercase tracking-section text-textmed md:text-[13px]">
+        LEVEL {level}
       </div>
       <div className="relative">
-        <div className="h-[12px] w-full rounded-full bg-[#0c0f14] inner-hair" />
+        <div className="h-[10px] w-full rounded-full bg-track" />
         <div
-          className="absolute left-0 top-0 h-[12px] rounded-full bg-gradient-to-r from-gray-700 to-gray-900"
+          className="absolute left-0 top-0 h-[10px] rounded-full bg-fill"
           style={{ width: `${pct}%` }}
         />
-        <div className="absolute right-1 -top-6 text-[11px] px-2 py-[2px] rounded-full bg-[#0c0f14] border border-white/10">
+        <div className="absolute right-0 -top-6 rounded-md bg-card px-2 py-1 text-[11.5px] text-textmed">
           {current} / {total}
         </div>
       </div>

--- a/src/components/ui/MonoCard.tsx
+++ b/src/components/ui/MonoCard.tsx
@@ -2,15 +2,15 @@ import React from "react";
 
 export function MonoCard({emoji,title,value}:{emoji:string;title:string;value:number;}){
   return (
-    <div className="card snap-start w-[120px] h-[140px] p-3 flex-none flex flex-col items-center justify-between mr-3">
+    <div className="mr-3 flex h-[140px] w-[120px] flex-none snap-start flex-col items-center justify-between rounded-lg border border-border bg-card p-3 text-texthi transition-colors duration-150 hover:-translate-y-px hover:bg-cardho focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border">
       <div
-        className="w-12 h-12 rounded-full bg-[#0c0f14] border border-white/10 grid place-items-center text-2xl"
+        className="grid h-12 w-12 place-items-center rounded-full bg-pill text-2xl text-icon"
         aria-hidden="true"
       >
         {emoji}
       </div>
-      <div className="text-sm font-semibold text-center mt-2">{title}</div>
-      <div className="text-lg font-extrabold text-[#cfd6dd]">{value}</div>
+      <div className="mt-2 text-center text-sm font-medium">{title}</div>
+      <div className="text-lg font-extrabold">{value}</div>
     </div>
   );
 }

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 
 export function Section({title,children,className=""}:{title?:React.ReactNode;children?:React.ReactNode;className?:string;}){
-  return (<section className={`section ${className}`}>
-    {title ? <div className="h-label mb-3">{title}</div> : null}
-    {children}
-  </section>);
+  return (
+    <section className={`section ${className}`}>
+      {title ? <div className="h-label">{title}</div> : null}
+      {children}
+    </section>
+  );
 }

--- a/src/components/ui/SkillPill.tsx
+++ b/src/components/ui/SkillPill.tsx
@@ -5,18 +5,16 @@ export function SkillPill({
 }:{emoji?:string; title:string; pct?:number;}){
   const w = Math.max(0, Math.min(100, pct));
   return (
-    <div className="card rounded-full px-4 py-3 mb-3">
+    <div className="mb-3 rounded-lg border border-border bg-card p-4">
       <div className="flex items-center gap-3">
-        <div
-          className="w-9 h-9 rounded-full bg-[#0c0f14] border border-white/10 grid place-items-center text-[15px]"
-        >
+        <div className="grid h-9 w-9 place-items-center rounded-full bg-pill text-icon">
           {emoji}
         </div>
         <div className="flex-1">
-          <div className="font-semibold">{title}</div>
-          <div className="mt-1 h-[6px] rounded-full bg-[#0c0f14]">
+          <div className="text-[15px] font-medium text-texthi">{title}</div>
+          <div className="mt-1 h-2 rounded-full bg-track">
             <div
-              className="h-[6px] rounded-full bg-gradient-to-r from-gray-700 to-gray-900"
+              className="h-2 rounded-full bg-fill"
               style={{ width: `${w}%` }}
             />
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,20 +7,88 @@
   }
 }
 
-:root{
-  --bg:#0f1115; --surface:#171a21; --surface-2:#1c2028;
-  --text:#e6e7ea; --muted:#9aa3ad; --accent:#6ea8ff;
-  --radius:16px; --radius-sm:12px;
-  --popover:var(--surface); --popover-foreground:var(--text);
+:root {
+  --bg:        #0b0d0f;
+  --panel:     #13161a;
+  --card:      #181c20;
+  --card-ho:   #1e2328;
+  --border:    #242a30;
+  --track:     #242a30;
+  --fill:      #3b424a;
+  --text-hi:   #e6eaef;
+  --text-med:  #b0b7c0;
+  --text-lo:   #7f8791;
+  --pill:      #1a1f24;
+  --icon:      #9aa2ac;
+  --scrim:     rgba(0,0,0,.25);
+  --shadow:    0 4px 20px rgba(0,0,0,.35);
+  --radius-lg: 16px;
+  --radius-sm: 12px;
+  --gap-lg:    20px;
+  --gap-sm:    12px;
+
+  /* legacy aliases */
+  --surface: var(--panel);
+  --surface-2: var(--card);
+  --text: var(--text-hi);
+  --muted: var(--text-med);
+  --accent: var(--fill);
+  --radius: var(--radius-lg);
+  --popover: var(--panel);
+  --popover-foreground: var(--text-hi);
 }
-html,body{ background:var(--bg); color:var(--text); font-weight:600; touch-action:pan-y; overflow-x:hidden; }
-.section{ padding:20px 16px 8px; }
-.h-label{ letter-spacing:.12em; text-transform:uppercase; font-weight:700; color:var(--muted); font-size:12px; }
-.card{ background:linear-gradient(180deg,var(--surface),var(--surface-2));
-       border-radius:var(--radius);
-       box-shadow:0 1px 0 rgba(255,255,255,.04) inset, 0 10px 28px rgba(0,0,0,.5);
-       border:1px solid rgba(255,255,255,.06); }
-.inner-hair{ box-shadow:0 1px 0 rgba(255,255,255,.04) inset; }
-.safe-bottom{ padding-bottom:calc(env(safe-area-inset-bottom,16px) + 12px); }
-.scroll-snap{ scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch; touch-action:pan-x; }
-.snap-start{ scroll-snap-align:start; }
+
+html,body {
+  background: var(--bg);
+  color: var(--text-hi);
+  font-weight: 600;
+  touch-action: pan-y;
+  overflow-x: hidden;
+}
+
+.section {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--gap-lg);
+  box-shadow: var(--shadow);
+}
+
+.h-label {
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--text-med);
+  font-size: 12.5px;
+  margin-bottom: 16px;
+}
+
+@media (min-width: 768px) {
+  .h-label { font-size: 13px; }
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: background-color .15s cubic-bezier(.2,.8,.2,1),
+    transform .15s cubic-bezier(.2,.8,.2,1);
+}
+
+.card:hover {
+  background: var(--card-ho);
+  transform: translateY(-1px);
+}
+
+.card:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--border);
+}
+
+.inner-hair { box-shadow: none; }
+
+.safe-bottom { padding-bottom: calc(env(safe-area-inset-bottom,16px) + 12px); }
+
+.scroll-snap { scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch; touch-action: pan-x; }
+
+.snap-start { scroll-snap-align: start; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,40 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--bg)",
+        panel: "var(--panel)",
+        card: "var(--card)",
+        cardho: "var(--card-ho)",
+        border: "var(--border)",
+        track: "var(--track)",
+        fill: "var(--fill)",
+        texthi: "var(--text-hi)",
+        textmed: "var(--text-med)",
+        textlo: "var(--text-lo)",
+        pill: "var(--pill)",
+        icon: "var(--icon)",
+      },
+      borderRadius: {
+        lg: "var(--radius-lg)",
+        md: "var(--radius-sm)",
+      },
+      boxShadow: {
+        soft: "var(--shadow)",
+      },
+      spacing: {
+        gaplg: "var(--gap-lg)",
+        gapsm: "var(--gap-sm)",
+      },
+      fontFamily: {
+        ui: ["Inter", "system-ui", "Segoe UI", "Arial", "sans-serif"],
+      },
+      letterSpacing: {
+        section: ".08em",
+      },
+    },
+  },
   plugins: [],
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,4 +6,39 @@ export default {
     "./src/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
   ],
+  theme: {
+    extend: {
+      colors: {
+        bg: "var(--bg)",
+        panel: "var(--panel)",
+        card: "var(--card)",
+        cardho: "var(--card-ho)",
+        border: "var(--border)",
+        track: "var(--track)",
+        fill: "var(--fill)",
+        texthi: "var(--text-hi)",
+        textmed: "var(--text-med)",
+        textlo: "var(--text-lo)",
+        pill: "var(--pill)",
+        icon: "var(--icon)",
+      },
+      borderRadius: {
+        lg: "var(--radius-lg)",
+        md: "var(--radius-sm)",
+      },
+      boxShadow: {
+        soft: "var(--shadow)",
+      },
+      spacing: {
+        gaplg: "var(--gap-lg)",
+        gapsm: "var(--gap-sm)",
+      },
+      fontFamily: {
+        ui: ["Inter", "system-ui", "Segoe UI", "Arial", "sans-serif"],
+      },
+      letterSpacing: {
+        section: ".08em",
+      },
+    },
+  },
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add dark slate CSS variables and Tailwind tokens
- restyle dashboard cards, skills, and goals to grayscale palette
- refactor skill and category components to use muted progress bars and icons

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68ba3d5b203c832cbe35a4a1e359544c