### PR TITLE
Use dark gray monochrome theme

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,8 +8,8 @@
 }
 
 :root{
-  --bg:#0f1115; --surface:#171a21; --surface-2:#1c2028;
-  --text:#e6e7ea; --muted:#9aa3ad; --accent:#6ea8ff;
+  --bg:#0a0a0a; --surface:#1a1a1a; --surface-2:#2a2a2a;
+  --text:#e5e5e5; --muted:#8a8a8a; --accent:#555555;
   --radius:16px; --radius-sm:12px;
   --popover:var(--surface); --popover-foreground:var(--text);
 }


### PR DESCRIPTION
## Summary
- switch global theme colors to a dark gray monochrome palette

## Testing
- `pnpm lint` *(fails: command not found)*
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4dc01d90832c9d97bf1461583d41