### PR TITLE
feat: allow customizing category card color

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
-import { updateCatColor } from "@/lib/data/cats";
+import { useRouter } from "next/navigation";
+import { updateCatColor, updateCatOrder } from "@/lib/data/cats";
 import SkillRow from "./SkillRow";
 import type { Category, Skill } from "./useSkillsData";
 
@@ -28,10 +29,16 @@ export default function CategoryCard({ category, skills, active }: Props) {
   const [color, setColor] = useState(category.color_hex || "#0B0B0F");
   const [menuOpen, setMenuOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [orderOpen, setOrderOpen] = useState(false);
+  const [orderValue, setOrderValue] = useState<number>(category.order ?? 0);
+  const router = useRouter();
 
   useEffect(() => {
     setColor(category.color_hex || "#0B0B0F");
   }, [category.color_hex]);
+  useEffect(() => {
+    setOrderValue(category.order ?? 0);
+  }, [category.order]);
 
   const bg = color;
   const on = getOnColor(bg);
@@ -46,6 +53,18 @@ export default function CategoryCard({ category, skills, active }: Props) {
       console.error("Failed to update category color", e);
     } finally {
       setPickerOpen(false);
+      setMenuOpen(false);
+    }
+  };
+
+  const handleOrderSave = async () => {
+    try {
+      await updateCatOrder(category.id, orderValue);
+      router.refresh();
+    } catch (e) {
+      console.error("Failed to update category order", e);
+    } finally {
+      setOrderOpen(false);
       setMenuOpen(false);
     }
   };
@@ -94,13 +113,33 @@ export default function CategoryCard({ category, skills, active }: Props) {
                   onChange={(e) => handleColorChange(e.target.value)}
                   className="h-24 w-24 p-0 border-0 bg-transparent"
                 />
+              ) : orderOpen ? (
+                <div className="flex flex-col gap-2">
+                  <input
+                    type="number"
+                    value={orderValue}
+                    onChange={(e) => setOrderValue(parseInt(e.target.value, 10))}
+                    className="w-20 p-1 border border-black/20 rounded"
+                  />
+                  <button className="underline" onClick={handleOrderSave}>
+                    Save order
+                  </button>
+                </div>
               ) : (
-                <button
-                  className="underline"
-                  onClick={() => setPickerOpen(true)}
-                >
-                  Change cat color
-                </button>
+                <>
+                  <button
+                    className="underline block text-left"
+                    onClick={() => setPickerOpen(true)}
+                  >
+                    Change cat color
+                  </button>
+                  <button
+                    className="underline block text-left mt-1"
+                    onClick={() => setOrderOpen(true)}
+                  >
+                    Change order
+                  </button>
+                </>
               )}
             </div>
           )}

--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+import { updateCatColor } from "@/lib/data/cats";
 import SkillRow from "./SkillRow";
 import type { Category, Skill } from "./useSkillsData";
 
@@ -23,10 +25,30 @@ interface Props {
 }
 
 export default function CategoryCard({ category, skills, active }: Props) {
-  const bg = category.color_hex || "#0B0B0F";
+  const [color, setColor] = useState(category.color_hex || "#0B0B0F");
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  useEffect(() => {
+    setColor(category.color_hex || "#0B0B0F");
+  }, [category.color_hex]);
+
+  const bg = color;
   const on = getOnColor(bg);
   const track = on === "#fff" ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
   const fill = on === "#fff" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.7)";
+
+  const handleColorChange = async (newColor: string) => {
+    setColor(newColor);
+    try {
+      await updateCatColor(category.id, newColor);
+    } catch (e) {
+      console.error("Failed to update category color", e);
+    } finally {
+      setPickerOpen(false);
+      setMenuOpen(false);
+    }
+  };
 
   return (
     <motion.div
@@ -49,16 +71,39 @@ export default function CategoryCard({ category, skills, active }: Props) {
         transition={{ duration: 0.16 }}
         className="flex-1 flex flex-col overflow-hidden"
       >
-        <header className="flex items-center justify-between mb-2">
-          <h3 className="font-semibold" style={{ color: on }}>
+        <header className="flex items-center justify-between mb-2 relative">
+          <button
+            className="font-semibold"
+            style={{ color: on }}
+            onClick={() => setMenuOpen((o) => !o)}
+          >
             {category.name}
-          </h3>
+          </button>
           <span
             className="text-xs rounded-xl px-2 py-0.5"
             style={{ backgroundColor: track, color: on }}
           >
             {skills.length}
           </span>
+          {menuOpen && (
+            <div className="absolute left-0 top-full mt-1 z-10 rounded-md bg-white/90 p-2 text-sm text-black shadow">
+              {pickerOpen ? (
+                <input
+                  type="color"
+                  value={color}
+                  onChange={(e) => handleColorChange(e.target.value)}
+                  className="h-24 w-24 p-0 border-0 bg-transparent"
+                />
+              ) : (
+                <button
+                  className="underline"
+                  onClick={() => setPickerOpen(true)}
+                >
+                  Change cat color
+                </button>
+              )}
+            </div>
+          )}
         </header>
         <div className="flex-1 overflow-y-auto overscroll-contain flex flex-col gap-2 pt-3 pb-4">
           {skills.length === 0 ? (

--- a/src/app/(app)/dashboard/_skills/useSkillsData.ts
+++ b/src/app/(app)/dashboard/_skills/useSkillsData.ts
@@ -24,20 +24,22 @@ export async function fetchCategories(userId: string): Promise<Category[]> {
   if (!supabase) throw new Error("Supabase client not available");
   const { data, error } = await supabase
     .from("cats")
-    .select("id,name,color_hex")
+    .select("id,name,color_hex,sort_order")
     .eq("user_id", userId)
+    .order("sort_order", { ascending: true, nullsLast: true })
     .order("name", { ascending: true });
   if (error) {
     // Try again without optional color column; if still failing, return empty list
     const fallback = await supabase
       .from("cats")
-      .select("id,name")
+      .select("id,name,sort_order")
       .eq("user_id", userId)
+      .order("sort_order", { ascending: true, nullsLast: true })
       .order("name", { ascending: true });
     if (fallback.error) return [];
-    return (fallback.data ?? []).map((c) => ({ id: c.id, name: c.name }));
+    return (fallback.data ?? []).map((c) => ({ id: c.id, name: c.name, order: c.sort_order }));
   }
-  return (data ?? []).map((c) => ({ id: c.id, name: c.name, color_hex: c.color_hex }));
+  return (data ?? []).map((c) => ({ id: c.id, name: c.name, color_hex: c.color_hex, order: c.sort_order }));
 }
 
 export async function fetchSkills(userId: string): Promise<Skill[]> {

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -34,7 +34,10 @@ export async function GET() {
       )
       .eq("user_id", user.id)
       .order("created_at", { ascending: false }),
-    supabase.from("cats").select("id,name,user_id").eq("user_id", user.id),
+    supabase
+      .from("cats")
+      .select("id,name,user_id,color_hex")
+      .eq("user_id", user.id),
   ]);
 
   // Debug logging for development
@@ -64,12 +67,17 @@ export async function GET() {
   // Join the data manually
   const skillsData = (skillsResponse ?? []).map((skill: SkillRow) => {
     const category = catsResponse.data?.find(
-      (cat: { id: string; name: string; user_id: string }) =>
-        cat.id === skill.cat_id
+      (cat: {
+        id: string;
+        name: string;
+        user_id: string;
+        color_hex?: string | null;
+      }) => cat.id === skill.cat_id
     );
     return {
       ...skill,
       cat_name: category?.name || "Uncategorized",
+      cat_color_hex: category?.color_hex || null,
     };
   });
 
@@ -113,7 +121,10 @@ export async function GET() {
 
   // Group skills by category for the frontend
   const skillsByCategory = skillsData.reduce(
-    (acc: Record<string, CatItem>, skill: SkillRow & { cat_name: string }) => {
+    (
+      acc: Record<string, CatItem>,
+      skill: SkillRow & { cat_name: string; cat_color_hex: string | null }
+    ) => {
       const catId = skill.cat_id;
       const catName = catId ? skill.cat_name : "Uncategorized";
       const key = catId || "uncategorized";
@@ -124,6 +135,7 @@ export async function GET() {
           cat_name: catName,
           user_id: skill.user_id,
           skill_count: 0,
+          color_hex: catId ? skill.cat_color_hex : null,
           skills: [],
         };
       }
@@ -163,6 +175,7 @@ export async function GET() {
         cat_name: cat.name,
         user_id: cat.user_id,
         skill_count: 0,
+        color_hex: cat.color_hex || null,
         skills: [],
       };
     }

--- a/src/app/dev/cats-skills/page.tsx
+++ b/src/app/dev/cats-skills/page.tsx
@@ -20,6 +20,7 @@ interface DebugData {
     name: string;
     user_id: string;
     created_at?: string | null;
+    color_hex?: string | null;
   }>;
   firstThreeSkills: Array<{
     id: string;

--- a/src/app/dev/cats-skills/page.tsx
+++ b/src/app/dev/cats-skills/page.tsx
@@ -21,6 +21,7 @@ interface DebugData {
     user_id: string;
     created_at?: string | null;
     color_hex?: string | null;
+    sort_order?: number | null;
   }>;
   firstThreeSkills: Array<{
     id: string;

--- a/src/lib/data/cats.ts
+++ b/src/lib/data/cats.ts
@@ -7,10 +7,20 @@ export async function getCatsForUser(userId: string) {
   
   const { data, error } = await sb
     .from("cats")
-    .select("id,name,created_at")
+    .select("id,name,user_id,created_at,color_hex")
     .eq("user_id", userId)
     .order("created_at", { ascending: false });
   
   if (error) throw error;
   return (data ?? []) as CatRow[];
+}
+
+export async function updateCatColor(catId: string, color: string) {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("Supabase client not available");
+  const { error } = await sb
+    .from("cats")
+    .update({ color_hex: color })
+    .eq("id", catId);
+  if (error) throw error;
 }

--- a/src/lib/data/cats.ts
+++ b/src/lib/data/cats.ts
@@ -4,13 +4,14 @@ import type { CatRow } from "../types/cat";
 export async function getCatsForUser(userId: string) {
   const sb = getSupabaseBrowser();
   if (!sb) throw new Error("Supabase client not available");
-  
+
   const { data, error } = await sb
     .from("cats")
-    .select("id,name,user_id,created_at,color_hex")
+    .select("id,name,user_id,created_at,color_hex,sort_order")
     .eq("user_id", userId)
+    .order("sort_order", { ascending: true, nullsLast: true })
     .order("created_at", { ascending: false });
-  
+
   if (error) throw error;
   return (data ?? []) as CatRow[];
 }
@@ -21,6 +22,16 @@ export async function updateCatColor(catId: string, color: string) {
   const { error } = await sb
     .from("cats")
     .update({ color_hex: color })
+    .eq("id", catId);
+  if (error) throw error;
+}
+
+export async function updateCatOrder(catId: string, order: number) {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("Supabase client not available");
+  const { error } = await sb
+    .from("cats")
+    .update({ sort_order: order })
     .eq("id", catId);
   if (error) throw error;
 }

--- a/src/lib/types/cat.ts
+++ b/src/lib/types/cat.ts
@@ -4,4 +4,5 @@ export type CatRow = {
   name: string;
   created_at?: string | null;
   color_hex?: string | null;
+  sort_order?: number | null;
 };

--- a/src/lib/types/cat.ts
+++ b/src/lib/types/cat.ts
@@ -1,6 +1,7 @@
-export type CatRow = { 
-  id: string; 
-  user_id: string; 
-  name: string; 
-  created_at?: string | null; 
+export type CatRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  created_at?: string | null;
+  color_hex?: string | null;
 };

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -17,6 +17,7 @@ export type CatItem = {
   cat_name: string;
   user_id: string;
   skill_count: number;
+  color_hex?: string | null;
   skills: SkillItem[];
 };
 

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -18,6 +18,7 @@ export type CatItem = {
   user_id: string;
   skill_count: number;
   color_hex?: string | null;
+  order?: number | null;
   skills: SkillItem[];
 };
 


### PR DESCRIPTION
## Summary
- enable color customization for skill categories with inline color picker
- persist category colors to database and expose color in dashboard API

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68bae023c130832caf176d5ef68c883f