### PR TITLE
feat: show schedule windows as lines

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -266,8 +266,8 @@ export default function SchedulePage() {
                   <div
                     key={w.id}
                     aria-label={w.label}
-                    className="absolute left-0 right-0 rounded-md border border-zinc-700 bg-zinc-800"
-                    style={{ top, height, opacity: 0.25 }}
+                    className="absolute left-0 w-0.5 bg-zinc-700"
+                    style={{ top, height, opacity: 0.5 }}
                   />
                 )
               })}


### PR DESCRIPTION
## Summary
- show schedule windows as thin vertical lines on the left edge of the day view timeline

## Testing
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b8b1304832cb13c37b0252ea09d