### PR TITLE
feat: allow customizing cat card colors and order

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -26,7 +26,7 @@ interface Props {
 }
 
 export default function CategoryCard({ category, skills, active }: Props) {
-  const [color, setColor] = useState(category.color_hex || "#0B0B0F");
+  const [color, setColor] = useState(category.color_hex || "#000000");
   const [menuOpen, setMenuOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [orderOpen, setOrderOpen] = useState(false);
@@ -34,7 +34,7 @@ export default function CategoryCard({ category, skills, active }: Props) {
   const router = useRouter();
 
   useEffect(() => {
-    setColor(category.color_hex || "#0B0B0F");
+    setColor(category.color_hex || "#000000");
   }, [category.color_hex]);
   useEffect(() => {
     setOrderValue(category.order ?? 0);

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -79,7 +79,7 @@ export async function GET() {
     return {
       ...skill,
       cat_name: category?.name || "Uncategorized",
-      cat_color_hex: category?.color_hex || null,
+      cat_color_hex: category?.color_hex || "#000000",
     };
   });
 
@@ -137,7 +137,7 @@ export async function GET() {
           cat_name: catName,
           user_id: skill.user_id,
           skill_count: 0,
-          color_hex: catId ? skill.cat_color_hex : null,
+          color_hex: catId ? skill.cat_color_hex || "#000000" : "#000000",
           skills: [],
         };
       }
@@ -175,7 +175,11 @@ export async function GET() {
     // Check if this CAT has skills in the skillsByCategory
     const catSkills = skillsByCategory[cat.id];
     if (catSkills) {
-      return { ...catSkills, order: cat.sort_order ?? null }; // Return CAT with its skills
+      return {
+        ...catSkills,
+        color_hex: cat.color_hex || catSkills.color_hex || "#000000",
+        order: cat.sort_order ?? null,
+      }; // Return CAT with its skills
     } else {
       // CAT exists but has no skills
       return {
@@ -183,7 +187,7 @@ export async function GET() {
         cat_name: cat.name,
         user_id: cat.user_id,
         skill_count: 0,
-        color_hex: cat.color_hex || null,
+        color_hex: cat.color_hex || "#000000",
         order: cat.sort_order ?? null,
         skills: [],
       };

--- a/supabase/migrations/20250827050222_remote_schema.sql
+++ b/supabase/migrations/20250827050222_remote_schema.sql
@@ -21,7 +21,9 @@ create table "public"."cats" (
   "id" uuid not null default gen_random_uuid(),
   "user_id" uuid not null,
   "name" text not null,
-  "created_at" timestamp with time zone not null default now()
+  "created_at" timestamp with time zone not null default now(),
+  "color_hex" text default '#000000'::text,
+  "sort_order" integer
 );
 
 alter table "public"."cats" enable row level security;

--- a/supabase/migrations/20250827050222_remote_schema_clean.sql
+++ b/supabase/migrations/20250827050222_remote_schema_clean.sql
@@ -21,7 +21,9 @@ create table "public"."cats" (
   "id" uuid not null default gen_random_uuid(),
   "user_id" uuid not null,
   "name" text not null,
-  "created_at" timestamp with time zone not null default now()
+  "created_at" timestamp with time zone not null default now(),
+  "color_hex" text default '#000000'::text,
+  "sort_order" integer
 );
 
 alter table "public"."cats" enable row level security;

--- a/supabase/migrations/20250827050223_add_skills_view.sql
+++ b/supabase/migrations/20250827050223_add_skills_view.sql
@@ -3,10 +3,12 @@
 
 -- Create the skills_by_cats_v view
 CREATE OR REPLACE VIEW public.skills_by_cats_v AS
-SELECT 
+SELECT
   c.id as cat_id,
   c.name as cat_name,
   c.user_id,
+  c.color_hex,
+  c.sort_order,
   COUNT(s.id) as skill_count,
   ARRAY_AGG(
     json_build_object(
@@ -20,8 +22,8 @@ SELECT
 FROM public.cats c
 LEFT JOIN public.skills s ON c.id = s.cat_id
 WHERE c.user_id = auth.uid()
-GROUP BY c.id, c.name, c.user_id
-ORDER BY c.name;
+GROUP BY c.id, c.name, c.user_id, c.color_hex, c.sort_order
+ORDER BY c.sort_order NULLS LAST, c.name;
 
 -- Grant permissions on the view
 GRANT SELECT ON public.skills_by_cats_v TO authenticated;

--- a/supabase/migrations/20250827050226_add_cat_color_order.sql
+++ b/supabase/migrations/20250827050226_add_cat_color_order.sql
@@ -1,0 +1,28 @@
+-- Migration to add color and ordering to cats
+ALTER TABLE public.cats
+  ADD COLUMN IF NOT EXISTS color_hex text DEFAULT '#000000'::text,
+  ADD COLUMN IF NOT EXISTS sort_order integer;
+
+CREATE OR REPLACE VIEW public.skills_by_cats_v AS
+SELECT
+  c.id AS cat_id,
+  c.name AS cat_name,
+  c.user_id,
+  c.color_hex,
+  c.sort_order,
+  COUNT(s.id) AS skill_count,
+  ARRAY_AGG(
+    json_build_object(
+      'skill_id', s.id,
+      'name', s.name,
+      'icon', COALESCE(s.icon, '💡'),
+      'level', COALESCE(s.level, 1),
+      'progress', GREATEST(0, LEAST(100, COALESCE(s.progress, 0)))::int
+    ) ORDER BY s.name
+  ) FILTER (WHERE s.id IS NOT NULL) AS skills
+FROM public.cats c
+LEFT JOIN public.skills s ON c.id = s.cat_id
+GROUP BY c.id, c.name, c.user_id, c.color_hex, c.sort_order
+ORDER BY c.sort_order NULLS LAST, c.name;
+
+GRANT SELECT ON public.skills_by_cats_v TO authenticated;


### PR DESCRIPTION
## Summary
- default cat cards to black and support inline color/order editing
- expose `color_hex` and `sort_order` in cats schema and skills view
- ensure dashboard API returns color and order with black fallback

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68bb3caa0280832c89fa86aa6be6a3e2