### PR TITLE
Ensure scheduler matches tasks to same-energy windows

### DIFF
--- a/src/lib/scheduler/config.ts
+++ b/src/lib/scheduler/config.ts
@@ -1,6 +1,5 @@
 export const ENERGY = {
-  // TODO: replace with full energy tiers
-  LIST: ["LOW", "MEDIUM", "HIGH"], // placeholder values
+  LIST: ["NO", "LOW", "MEDIUM", "HIGH", "ULTRA", "EXTREME"],
 } as const;
 
 export const TASK_PRIORITY_WEIGHT = {

--- a/src/lib/scheduler/config.ts
+++ b/src/lib/scheduler/config.ts
@@ -2,6 +2,8 @@ export const ENERGY = {
   LIST: ["NO", "LOW", "MEDIUM", "HIGH", "ULTRA", "EXTREME"],
 } as const;
 
+export type Energy = (typeof ENERGY.LIST)[number];
+
 export const TASK_PRIORITY_WEIGHT = {
   NO: 0,
   LOW: 1,

--- a/src/lib/scheduler/placer.ts
+++ b/src/lib/scheduler/placer.ts
@@ -1,5 +1,5 @@
 import type { TaskLite } from "./weight";
-import { ENERGY } from "./config";
+import { ENERGY, type Energy } from "./config";
 
 export type WindowLite = {
   id: string;
@@ -102,8 +102,8 @@ export function placeByEnergyWeight(
   }[] = [];
   const unplaced: { taskId: string; reason: string }[] = [];
 
-  const energyIdx = (e?: string) =>
-    ENERGY.LIST.indexOf((e ?? "").toUpperCase());
+  const energyIdx = (e?: string | null) =>
+    ENERGY.LIST.indexOf((e ?? "").toUpperCase() as Energy);
   const sortedTasks = [...tasks].sort((a, b) => {
     const energyDiff = energyIdx(b.energy) - energyIdx(a.energy);
     if (energyDiff !== 0) return energyDiff;

--- a/src/lib/scheduler/placer.ts
+++ b/src/lib/scheduler/placer.ts
@@ -1,5 +1,4 @@
 import type { TaskLite } from "./weight";
-import { ENERGY } from "./config";
 
 export type WindowLite = {
   id: string;
@@ -27,10 +26,6 @@ function parseTime(date: Date, time: string): Date {
   return d;
 }
 
-function energyIndex(level: string | null | undefined): number {
-  const idx = (ENERGY.LIST as readonly string[]).indexOf(level ?? "");
-  return idx === -1 ? ENERGY.LIST.length : idx;
-}
 
 export function genSlotsForWindow(
   win: WindowLite,
@@ -112,8 +107,9 @@ export function placeByEnergyWeight(
   });
 
   for (const task of sortedTasks) {
+    const taskEnergy = (task.energy ?? "").toUpperCase();
     const candidates = windowsSorted.filter(
-      (w) => energyIndex(task.energy) <= energyIndex(w.energy)
+      (w) => taskEnergy === (w.energy ?? "").toUpperCase()
     );
     if (candidates.length === 0) {
       unplaced.push({ taskId: task.id, reason: "no-window" });

--- a/src/lib/scheduler/projects.ts
+++ b/src/lib/scheduler/projects.ts
@@ -23,10 +23,14 @@ export function buildProjectItems(
     const duration_min =
       related.reduce((sum, t) => sum + t.duration_min, 0) ||
       DEFAULT_PROJECT_DURATION_MIN
+    const norm = (e?: string | null): Energy | null => {
+      const up = (e ?? '').toUpperCase()
+      return ENERGY.LIST.includes(up as Energy) ? (up as Energy) : null
+    }
     const energy =
       related.reduce<Energy | null>((acc, t) => {
-        if (!t.energy) return acc
-        const current = t.energy as Energy
+        const current = norm(t.energy)
+        if (!current) return acc
         if (!acc) return current
         return ENERGY.LIST.indexOf(current) > ENERGY.LIST.indexOf(acc)
           ? current

--- a/src/lib/scheduler/projects.ts
+++ b/src/lib/scheduler/projects.ts
@@ -1,0 +1,51 @@
+import { ENERGY, type Energy } from './config'
+import type { TaskLite, ProjectLite } from './weight'
+import { taskWeight, projectWeight } from './weight'
+
+export const DEFAULT_PROJECT_DURATION_MIN = 60
+export const DEFAULT_PROJECT_ENERGY: Energy = 'NO'
+
+export type ProjectItem = ProjectLite & {
+  name: string
+  duration_min: number
+  energy: Energy
+  weight: number
+  taskCount: number
+}
+
+export function buildProjectItems(
+  projects: ProjectLite[],
+  tasks: TaskLite[]
+): ProjectItem[] {
+  const items: ProjectItem[] = []
+  for (const p of projects) {
+    const related = tasks.filter(t => t.project_id === p.id)
+    const duration_min =
+      related.reduce((sum, t) => sum + t.duration_min, 0) ||
+      DEFAULT_PROJECT_DURATION_MIN
+    const energy =
+      related.reduce<Energy | null>((acc, t) => {
+        if (!t.energy) return acc
+        const current = t.energy as Energy
+        if (!acc) return current
+        return ENERGY.LIST.indexOf(current) > ENERGY.LIST.indexOf(acc)
+          ? current
+          : acc
+      }, null) ?? DEFAULT_PROJECT_ENERGY
+    const relatedWeightSum = related.reduce(
+      (sum, t) => sum + taskWeight(t),
+      0
+    )
+    const weight = projectWeight(p, relatedWeightSum)
+    items.push({
+      ...p,
+      name: p.name ?? '',
+      duration_min,
+      energy,
+      weight,
+      taskCount: related.length,
+    })
+  }
+  return items
+}
+

--- a/src/lib/scheduler/projects.ts
+++ b/src/lib/scheduler/projects.ts
@@ -35,7 +35,7 @@ export function buildProjectItems(
         return ENERGY.LIST.indexOf(current) > ENERGY.LIST.indexOf(acc)
           ? current
           : acc
-      }, null) ?? DEFAULT_PROJECT_ENERGY
+      }, norm(p.energy)) ?? DEFAULT_PROJECT_ENERGY
     const relatedWeightSum = related.reduce(
       (sum, t) => sum + taskWeight(t),
       0

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -55,7 +55,7 @@ export async function fetchProjectsMap(): Promise<
 
   const { data, error } = await supabase
     .from('projects')
-    .select('id, name, priority, stage');
+    .select('id, name, priority, stage, energy');
 
   if (error) throw error;
   const map: Record<string, ProjectLite> = {};

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -21,6 +21,7 @@ export type ProjectLite = {
   name?: string;
   priority: string;
   stage: string;
+  energy?: string | null;
 };
 
 export type GoalLite = {

--- a/test/lib/scheduler/placer.spec.ts
+++ b/test/lib/scheduler/placer.spec.ts
@@ -41,7 +41,7 @@ describe("placeByEnergyWeight", () => {
       { id: "wH", label: "High", energy: "HIGH", start_local: "10:00", end_local: "11:00" },
     ];
     const projects: ProjectLite[] = [
-      { id: "p1", name: "Proj", priority: "LOW", stage: "RESEARCH" },
+      { id: "p1", name: "Proj", priority: "LOW", stage: "RESEARCH", energy: null },
     ];
     const tasks: TaskLite[] = [
       { id: "t1", name: "T", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "high", project_id: "p1" },
@@ -50,6 +50,21 @@ describe("placeByEnergyWeight", () => {
     const result = placeByEnergyWeight(items, windows, date);
     expect(result.placements).toHaveLength(1);
     expect(result.placements[0]).toMatchObject({ taskId: "p1", windowId: "wH" });
+  });
+
+  it("places project by its own energy when it has no tasks", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "wN", label: "No", energy: "NO", start_local: "09:00", end_local: "10:00" },
+      { id: "wU", label: "Ultra", energy: "ULTRA", start_local: "10:00", end_local: "11:00" },
+    ];
+    const projects: ProjectLite[] = [
+      { id: "p1", name: "Proj", priority: "LOW", stage: "RESEARCH", energy: "ULTRA" },
+    ];
+    const items = buildProjectItems(projects, []);
+    const result = placeByEnergyWeight(items, windows, date);
+    expect(result.placements).toHaveLength(1);
+    expect(result.placements[0]).toMatchObject({ taskId: "p1", windowId: "wU" });
   });
 });
 

--- a/test/lib/scheduler/placer.spec.ts
+++ b/test/lib/scheduler/placer.spec.ts
@@ -2,22 +2,34 @@ import { describe, it, expect } from "vitest";
 import { placeByEnergyWeight, type WindowLite } from "../../../src/lib/scheduler/placer";
 
 describe("placeByEnergyWeight", () => {
-  it("only schedules tasks into windows with matching energy", () => {
+  it("falls back to lower-energy tasks when no equal energy task exists", () => {
     const date = new Date("2024-01-01T00:00:00");
     const windows: WindowLite[] = [
-      { id: "w1", label: "Low", energy: "LOW", start_local: "09:00", end_local: "10:00" },
-      { id: "w2", label: "High", energy: "HIGH", start_local: "10:00", end_local: "11:00" },
+      { id: "w1", label: "High", energy: "HIGH", start_local: "09:00", end_local: "10:00" },
+      { id: "w2", label: "Low", energy: "LOW", start_local: "10:00", end_local: "11:00" },
     ];
     const tasks = [
-      { id: "t1", name: "L", priority: "LOW", stage: "Prepare", duration_min: 30, energy: "LOW", weight: 1 },
-      { id: "t2", name: "H", priority: "LOW", stage: "Prepare", duration_min: 30, energy: "HIGH", weight: 1 },
-      { id: "t3", name: "M", priority: "LOW", stage: "Prepare", duration_min: 30, energy: "MEDIUM", weight: 1 },
+      { id: "t1", name: "M", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "MEDIUM", weight: 1 },
+      { id: "t2", name: "L", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "LOW", weight: 1 },
     ];
     const result = placeByEnergyWeight(tasks, windows, date);
     expect(result.placements).toHaveLength(2);
     const map = Object.fromEntries(result.placements.map(p => [p.taskId, p.windowId]));
     expect(map["t1"]).toBe("w1");
     expect(map["t2"]).toBe("w2");
-    expect(result.unplaced).toEqual([{ taskId: "t3", reason: "no-window" }]);
+  });
+
+  it("does not place higher-energy tasks into lower-energy windows", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "w1", label: "Low", energy: "LOW", start_local: "09:00", end_local: "10:00" },
+    ];
+    const tasks = [
+      { id: "t1", name: "H", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "HIGH", weight: 1 },
+    ];
+    const result = placeByEnergyWeight(tasks, windows, date);
+    expect(result.placements).toHaveLength(0);
+    expect(result.unplaced).toEqual([{ taskId: "t1", reason: "no-window" }]);
   });
 });
+

--- a/test/lib/scheduler/placer.spec.ts
+++ b/test/lib/scheduler/placer.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { placeByEnergyWeight, type WindowLite } from "../../../src/lib/scheduler/placer";
+
+describe("placeByEnergyWeight", () => {
+  it("only schedules tasks into windows with matching energy", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "w1", label: "Low", energy: "LOW", start_local: "09:00", end_local: "10:00" },
+      { id: "w2", label: "High", energy: "HIGH", start_local: "10:00", end_local: "11:00" },
+    ];
+    const tasks = [
+      { id: "t1", name: "L", priority: "LOW", stage: "Prepare", duration_min: 30, energy: "LOW", weight: 1 },
+      { id: "t2", name: "H", priority: "LOW", stage: "Prepare", duration_min: 30, energy: "HIGH", weight: 1 },
+      { id: "t3", name: "M", priority: "LOW", stage: "Prepare", duration_min: 30, energy: "MEDIUM", weight: 1 },
+    ];
+    const result = placeByEnergyWeight(tasks, windows, date);
+    expect(result.placements).toHaveLength(2);
+    const map = Object.fromEntries(result.placements.map(p => [p.taskId, p.windowId]));
+    expect(map["t1"]).toBe("w1");
+    expect(map["t2"]).toBe("w2");
+    expect(result.unplaced).toEqual([{ taskId: "t3", reason: "no-window" }]);
+  });
+});

--- a/test/lib/scheduler/projects.spec.ts
+++ b/test/lib/scheduler/projects.spec.ts
@@ -56,5 +56,33 @@ describe('buildProjectItems', () => {
       taskCount: 2,
     })
   })
+
+  it('handles task energy case-insensitively', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH' },
+    ]
+    const tasks: TaskLite[] = [
+      {
+        id: 't1',
+        name: 'T1',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 30,
+        energy: 'low',
+        project_id: 'p1',
+      },
+      {
+        id: 't2',
+        name: 'T2',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 60,
+        energy: 'HIGH',
+        project_id: 'p1',
+      },
+    ]
+    const items = buildProjectItems(projects, tasks)
+    expect(items[0].energy).toBe('HIGH')
+  })
 })
 

--- a/test/lib/scheduler/projects.spec.ts
+++ b/test/lib/scheduler/projects.spec.ts
@@ -9,7 +9,7 @@ import type { ProjectLite, TaskLite } from '../../../src/lib/scheduler/weight'
 describe('buildProjectItems', () => {
   it('includes projects even without tasks', () => {
     const projects: ProjectLite[] = [
-      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH' },
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: null },
     ]
     const tasks: TaskLite[] = []
     const items = buildProjectItems(projects, tasks)
@@ -25,7 +25,7 @@ describe('buildProjectItems', () => {
 
   it('aggregates related tasks', () => {
     const projects: ProjectLite[] = [
-      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH' },
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: null },
     ]
     const tasks: TaskLite[] = [
       {
@@ -59,7 +59,7 @@ describe('buildProjectItems', () => {
 
   it('handles task energy case-insensitively', () => {
     const projects: ProjectLite[] = [
-      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH' },
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: null },
     ]
     const tasks: TaskLite[] = [
       {
@@ -83,6 +83,25 @@ describe('buildProjectItems', () => {
     ]
     const items = buildProjectItems(projects, tasks)
     expect(items[0].energy).toBe('HIGH')
+  })
+
+  it('uses project energy when higher than related tasks', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: 'ULTRA' },
+    ]
+    const tasks: TaskLite[] = [
+      {
+        id: 't1',
+        name: 'T1',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 30,
+        energy: 'LOW',
+        project_id: 'p1',
+      },
+    ]
+    const items = buildProjectItems(projects, tasks)
+    expect(items[0].energy).toBe('ULTRA')
   })
 })
 

--- a/test/lib/scheduler/projects.spec.ts
+++ b/test/lib/scheduler/projects.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildProjectItems,
+  DEFAULT_PROJECT_DURATION_MIN,
+  DEFAULT_PROJECT_ENERGY,
+} from '../../../src/lib/scheduler/projects'
+import type { ProjectLite, TaskLite } from '../../../src/lib/scheduler/weight'
+
+describe('buildProjectItems', () => {
+  it('includes projects even without tasks', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH' },
+    ]
+    const tasks: TaskLite[] = []
+    const items = buildProjectItems(projects, tasks)
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      id: 'p1',
+      name: 'P1',
+      duration_min: DEFAULT_PROJECT_DURATION_MIN,
+      energy: DEFAULT_PROJECT_ENERGY,
+      taskCount: 0,
+    })
+  })
+
+  it('aggregates related tasks', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH' },
+    ]
+    const tasks: TaskLite[] = [
+      {
+        id: 't1',
+        name: 'T1',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 30,
+        energy: 'LOW',
+        project_id: 'p1',
+      },
+      {
+        id: 't2',
+        name: 'T2',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 60,
+        energy: 'MEDIUM',
+        project_id: 'p1',
+      },
+    ]
+    const items = buildProjectItems(projects, tasks)
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      id: 'p1',
+      duration_min: 90,
+      energy: 'MEDIUM',
+      taskCount: 2,
+    })
+  })
+})
+


### PR DESCRIPTION
## Summary
- expand energy tiers to full list
- only place tasks/projects into windows with matching energy
- add unit test verifying scheduling respects energy levels

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68bc87fe1464832c855670bd608c481e