### PR TITLE
Prefer exact energy matches with fallback and respect project energy

### DIFF
--- a/components/WindowsPolishedUI.tsx
+++ b/components/WindowsPolishedUI.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef } from "react"
+import FlameEmber, { type FlameLevel } from "@/components/FlameEmber"
 
 // Utility to join class names conditionally
 function classNames(...classes: Array<string | false | null | undefined>) {
@@ -449,8 +450,16 @@ function WindowCard({
           </p>
           <TimelineMini start={startPct} end={endPct} />
         </div>
-        <div className="flex gap-2 flex-wrap">
-          {item.energy && <EnergyChip energy={item.energy} label={item.energy} active={false} onClick={() => {}} />}
+        <div className="flex gap-2 flex-wrap items-center">
+          {item.energy && (
+            <span className="px-2 h-6 rounded-md bg-[#22262A] text-xs flex items-center gap-1">
+              <FlameEmber
+                level={item.energy.toUpperCase() as FlameLevel}
+                size="sm"
+              />
+              <span className="capitalize">{item.energy}</span>
+            </span>
+          )}
           {item.location && (
             <span className="px-2 h-6 rounded-md bg-[#22262A] text-xs flex items-center">
               {item.location}

--- a/src/lib/scheduler/config.ts
+++ b/src/lib/scheduler/config.ts
@@ -1,7 +1,8 @@
 export const ENERGY = {
-  // TODO: replace with full energy tiers
-  LIST: ["LOW", "MEDIUM", "HIGH"], // placeholder values
+  LIST: ["NO", "LOW", "MEDIUM", "HIGH", "ULTRA", "EXTREME"],
 } as const;
+
+export type Energy = (typeof ENERGY.LIST)[number];
 
 export const TASK_PRIORITY_WEIGHT = {
   NO: 0,

--- a/src/lib/scheduler/projects.ts
+++ b/src/lib/scheduler/projects.ts
@@ -1,0 +1,55 @@
+import { ENERGY, type Energy } from './config'
+import type { TaskLite, ProjectLite } from './weight'
+import { taskWeight, projectWeight } from './weight'
+
+export const DEFAULT_PROJECT_DURATION_MIN = 60
+export const DEFAULT_PROJECT_ENERGY: Energy = 'NO'
+
+export type ProjectItem = ProjectLite & {
+  name: string
+  duration_min: number
+  energy: Energy
+  weight: number
+  taskCount: number
+}
+
+export function buildProjectItems(
+  projects: ProjectLite[],
+  tasks: TaskLite[]
+): ProjectItem[] {
+  const items: ProjectItem[] = []
+  for (const p of projects) {
+    const related = tasks.filter(t => t.project_id === p.id)
+    const duration_min =
+      related.reduce((sum, t) => sum + t.duration_min, 0) ||
+      DEFAULT_PROJECT_DURATION_MIN
+    const norm = (e?: string | null): Energy | null => {
+      const up = (e ?? '').toUpperCase()
+      return ENERGY.LIST.includes(up as Energy) ? (up as Energy) : null
+    }
+    const energy =
+      related.reduce<Energy | null>((acc, t) => {
+        const current = norm(t.energy)
+        if (!current) return acc
+        if (!acc) return current
+        return ENERGY.LIST.indexOf(current) > ENERGY.LIST.indexOf(acc)
+          ? current
+          : acc
+      }, norm(p.energy)) ?? DEFAULT_PROJECT_ENERGY
+    const relatedWeightSum = related.reduce(
+      (sum, t) => sum + taskWeight(t),
+      0
+    )
+    const weight = projectWeight(p, relatedWeightSum)
+    items.push({
+      ...p,
+      name: p.name ?? '',
+      duration_min,
+      energy,
+      weight,
+      taskCount: related.length,
+    })
+  }
+  return items
+}
+

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -55,7 +55,7 @@ export async function fetchProjectsMap(): Promise<
 
   const { data, error } = await supabase
     .from('projects')
-    .select('id, name, priority, stage');
+    .select('id, name, priority, stage, energy');
 
   if (error) throw error;
   const map: Record<string, ProjectLite> = {};

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -21,6 +21,7 @@ export type ProjectLite = {
   name?: string;
   priority: string;
   stage: string;
+  energy?: string | null;
 };
 
 export type GoalLite = {

--- a/test/lib/scheduler/placer.spec.ts
+++ b/test/lib/scheduler/placer.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { placeByEnergyWeight, type WindowLite } from "../../../src/lib/scheduler/placer";
+import { buildProjectItems } from "../../../src/lib/scheduler/projects";
+import type { ProjectLite, TaskLite } from "../../../src/lib/scheduler/weight";
+
+describe("placeByEnergyWeight", () => {
+  it("falls back to lower-energy tasks when no equal energy task exists", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "w1", label: "High", energy: "HIGH", start_local: "09:00", end_local: "10:00" },
+      { id: "w2", label: "Low", energy: "LOW", start_local: "10:00", end_local: "11:00" },
+    ];
+    const tasks = [
+      { id: "t1", name: "M", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "MEDIUM", weight: 1 },
+      { id: "t2", name: "L", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "LOW", weight: 1 },
+    ];
+    const result = placeByEnergyWeight(tasks, windows, date);
+    expect(result.placements).toHaveLength(2);
+    const map = Object.fromEntries(result.placements.map(p => [p.taskId, p.windowId]));
+    expect(map["t1"]).toBe("w1");
+    expect(map["t2"]).toBe("w2");
+  });
+
+  it("does not place higher-energy tasks into lower-energy windows", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "w1", label: "Low", energy: "LOW", start_local: "09:00", end_local: "10:00" },
+    ];
+    const tasks = [
+      { id: "t1", name: "H", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "HIGH", weight: 1 },
+    ];
+    const result = placeByEnergyWeight(tasks, windows, date);
+    expect(result.placements).toHaveLength(0);
+    expect(result.unplaced).toEqual([{ taskId: "t1", reason: "no-window" }]);
+  });
+
+  it("places projects into matching-energy windows", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "wL", label: "Low", energy: "LOW", start_local: "09:00", end_local: "10:00" },
+      { id: "wH", label: "High", energy: "HIGH", start_local: "10:00", end_local: "11:00" },
+    ];
+    const projects: ProjectLite[] = [
+      { id: "p1", name: "Proj", priority: "LOW", stage: "RESEARCH", energy: null },
+    ];
+    const tasks: TaskLite[] = [
+      { id: "t1", name: "T", priority: "LOW", stage: "Prepare", duration_min: 60, energy: "high", project_id: "p1" },
+    ];
+    const items = buildProjectItems(projects, tasks);
+    const result = placeByEnergyWeight(items, windows, date);
+    expect(result.placements).toHaveLength(1);
+    expect(result.placements[0]).toMatchObject({ taskId: "p1", windowId: "wH" });
+  });
+
+  it("places project by its own energy when it has no tasks", () => {
+    const date = new Date("2024-01-01T00:00:00");
+    const windows: WindowLite[] = [
+      { id: "wN", label: "No", energy: "NO", start_local: "09:00", end_local: "10:00" },
+      { id: "wU", label: "Ultra", energy: "ULTRA", start_local: "10:00", end_local: "11:00" },
+    ];
+    const projects: ProjectLite[] = [
+      { id: "p1", name: "Proj", priority: "LOW", stage: "RESEARCH", energy: "ULTRA" },
+    ];
+    const items = buildProjectItems(projects, []);
+    const result = placeByEnergyWeight(items, windows, date);
+    expect(result.placements).toHaveLength(1);
+    expect(result.placements[0]).toMatchObject({ taskId: "p1", windowId: "wU" });
+  });
+});
+

--- a/test/lib/scheduler/projects.spec.ts
+++ b/test/lib/scheduler/projects.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildProjectItems,
+  DEFAULT_PROJECT_DURATION_MIN,
+  DEFAULT_PROJECT_ENERGY,
+} from '../../../src/lib/scheduler/projects'
+import type { ProjectLite, TaskLite } from '../../../src/lib/scheduler/weight'
+
+describe('buildProjectItems', () => {
+  it('includes projects even without tasks', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: null },
+    ]
+    const tasks: TaskLite[] = []
+    const items = buildProjectItems(projects, tasks)
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      id: 'p1',
+      name: 'P1',
+      duration_min: DEFAULT_PROJECT_DURATION_MIN,
+      energy: DEFAULT_PROJECT_ENERGY,
+      taskCount: 0,
+    })
+  })
+
+  it('aggregates related tasks', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: null },
+    ]
+    const tasks: TaskLite[] = [
+      {
+        id: 't1',
+        name: 'T1',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 30,
+        energy: 'LOW',
+        project_id: 'p1',
+      },
+      {
+        id: 't2',
+        name: 'T2',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 60,
+        energy: 'MEDIUM',
+        project_id: 'p1',
+      },
+    ]
+    const items = buildProjectItems(projects, tasks)
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      id: 'p1',
+      duration_min: 90,
+      energy: 'MEDIUM',
+      taskCount: 2,
+    })
+  })
+
+  it('handles task energy case-insensitively', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: null },
+    ]
+    const tasks: TaskLite[] = [
+      {
+        id: 't1',
+        name: 'T1',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 30,
+        energy: 'low',
+        project_id: 'p1',
+      },
+      {
+        id: 't2',
+        name: 'T2',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 60,
+        energy: 'HIGH',
+        project_id: 'p1',
+      },
+    ]
+    const items = buildProjectItems(projects, tasks)
+    expect(items[0].energy).toBe('HIGH')
+  })
+
+  it('uses project energy when higher than related tasks', () => {
+    const projects: ProjectLite[] = [
+      { id: 'p1', name: 'P1', priority: 'LOW', stage: 'RESEARCH', energy: 'ULTRA' },
+    ]
+    const tasks: TaskLite[] = [
+      {
+        id: 't1',
+        name: 'T1',
+        priority: 'LOW',
+        stage: 'Prepare',
+        duration_min: 30,
+        energy: 'LOW',
+        project_id: 'p1',
+      },
+    ]
+    const items = buildProjectItems(projects, tasks)
+    expect(items[0].energy).toBe('ULTRA')
+  })
+})
+


### PR DESCRIPTION
## Summary
- share a single `Energy` union so scheduling logic and config agree on energy tiers
- cast energy lookups to that union in scheduler to satisfy TypeScript
- keep improved energy-based window selection with fallback to higher-energy windows when necessary
- ensure projects without tasks still produce schedulable entries by assigning default energy and duration
- normalize project energy values and add tests for project placement
- include project energy field and use it when building project items so windows reflect each project's energy
- display flame animations on the Windows page so each window shows its energy level visually

## Testing
- `pnpm test:run`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68bc87fe1464832c855670bd608c481e