### PR TITLE
fix: ensure window dialogs appear above bottom nav

### DIFF
--- a/components/WindowsPolishedUI.tsx
+++ b/components/WindowsPolishedUI.tsx
@@ -559,7 +559,7 @@ function Drawer({
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex justify-end" 
+      className="fixed inset-0 z-[60] bg-black/50 flex justify-end"
       role="dialog" aria-modal="true"
     >
       <div className="w-full max-w-md h-full bg-[#1C1F22] p-4 overflow-y-auto">
@@ -694,7 +694,11 @@ function ConfirmSheet({
     return () => document.removeEventListener("keydown", onKey)
   }, [onCancel])
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-end" role="dialog" aria-modal="true">
+    <div
+      className="fixed inset-0 z-[60] bg-black/50 flex items-end"
+      role="dialog"
+      aria-modal="true"
+    >
       <div className="w-full bg-[#1C1F22] p-4 rounded-t-xl">
         <p className="mb-4">Delete window? {item.name} {item.start} — {item.end}</p>
         <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- fix bottom nav overlapping window drawer and confirm sheet by raising their z-index

## Testing
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68be74ac8b5c832cbf88e9bff3d16af7