### PR TITLE
feat: redesign monument detail with hero and layout shell

### DIFF
--- a/src/components/MonumentGridWithSharedTransition.tsx
+++ b/src/components/MonumentGridWithSharedTransition.tsx
@@ -65,12 +65,11 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
             transition={{ duration: 0.2, ease: "easeInOut" }}
           >
             <motion.div
-              layoutId={`card-${selected.id}`}
               className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl bg-zinc-900 shadow-xl"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.25, ease: "easeInOut", layout: { duration: 0.25 } }}
+              transition={{ duration: 0.25, ease: "easeInOut" }}
             >
               <button
                 onClick={() => setActiveId(null)}
@@ -88,4 +87,3 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
 }
 
 export default MonumentGridWithSharedTransition;
-

--- a/src/components/monuments/ChargingRing.tsx
+++ b/src/components/monuments/ChargingRing.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+interface ChargingRingProps {
+  value: number;
+  size?: number;
+  strokeWidth?: number;
+}
+
+export function ChargingRing({ value, size = 80, strokeWidth = 8 }: ChargingRingProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (value / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} className="text-zinc-700">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeWidth={strokeWidth}
+        stroke="currentColor"
+        fill="transparent"
+      />
+      <motion.circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="var(--accent)"
+        strokeWidth={strokeWidth}
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        style={{ transform: "rotate(-90deg)", transformOrigin: "50% 50%" }}
+        transition={{ duration: 0.5 }}
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="text-sm font-semibold"
+      >
+        {Math.round(value)}%
+      </text>
+    </svg>
+  );
+}
+
+export default ChargingRing;

--- a/src/components/monuments/MonumentDetail.tsx
+++ b/src/components/monuments/MonumentDetail.tsx
@@ -1,17 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { FilteredGoalsGrid } from "@/components/goals/FilteredGoalsGrid";
-import {
-  ContentCard,
-  PageHeader,
-  SectionHeader,
-} from "@/components/ui/content-card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { ProgressBarGradient } from "@/components/skills/ProgressBarGradient";
 import { MonumentNotesGrid } from "@/components/notes/MonumentNotesGrid";
+import { MonumentDetailLayout, SectionShell } from "./MonumentDetailLayout";
+import { MonumentHero } from "./MonumentHero";
 
 interface Monument {
   id: string;
@@ -72,27 +66,13 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
 
   if (loading) {
     return (
-      <main className="p-4 space-y-8">
-        <div className="space-y-2">
-          <Skeleton className="h-10 w-3/4" />
-          <Skeleton className="h-4 w-1/3" />
-        </div>
-        <ContentCard className="flex flex-col items-center space-y-4">
-          <Skeleton className="h-16 w-16 rounded-full" />
-          <div className="w-full max-w-sm space-y-2">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-2 w-full" />
-          </div>
-        </ContentCard>
-        <div className="space-y-4">
-          <Skeleton className="h-6 w-32" />
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-32 rounded-lg" />
-            ))}
-          </div>
-        </div>
-      </main>
+      <MonumentDetailLayout
+        hero={<MonumentHero id={id} loading />}
+        milestones={<SectionShell title="Milestones" loading />}
+        goals={<SectionShell title="Goals" loading />}
+        notes={<SectionShell title="Notes" loading />}
+        activity={<SectionShell title="Activity" loading />}
+      />
     );
   }
 
@@ -100,7 +80,7 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
     return (
       <main className="p-4">
         <div className="text-center py-12">
-          <h1 className="text-2xl font-semibold text-red-400 mb-2">
+          <h1 className="mb-2 text-2xl font-semibold text-red-400">
             {error || "Monument not found"}
           </h1>
           <p className="text-gray-400">
@@ -113,59 +93,33 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
     );
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
-
   const mockProgress = 65;
 
   return (
-    <main className="p-4 space-y-8">
-      <PageHeader
-        title={
-          <div className="flex items-center gap-3">
-            <span
-              className="text-4xl"
-              role="img"
-              aria-label={`Monument: ${monument.title}`}
-            >
-              {monument.emoji || "\uD83D\uDDFC\uFE0F"}
-            </span>
-            {monument.title}
-          </div>
-        }
-        description={`Created ${formatDate(monument.created_at)}`}
-      >
-        <Link
-          href={`/monuments/${id}/edit`}
-          className="inline-block rounded-full bg-[var(--accent)] px-4 py-2 font-semibold text-black"
-        >
-          Edit Monument
-        </Link>
-      </PageHeader>
-
-      <ContentCard className="max-w-md mx-auto w-full space-y-2 text-center">
-        <span className="text-sm text-gray-400">Charging</span>
-        <ProgressBarGradient value={mockProgress} height={8} />
-      </ContentCard>
-
-      <section className="space-y-4">
-        <SectionHeader title="Related Goals" />
-        <FilteredGoalsGrid entity="monument" id={id} />
-      </section>
-
-      <section className="space-y-4">
-        <SectionHeader title="Notes" />
-        <MonumentNotesGrid monumentId={id} />
-      </section>
-    </main>
+    <MonumentDetailLayout
+      hero={<MonumentHero id={id} monument={monument} progress={mockProgress} />}
+      milestones={
+        <SectionShell title="Milestones">
+          <p className="text-sm text-muted-foreground">No milestones yet</p>
+        </SectionShell>
+      }
+      goals={
+        <SectionShell title="Goals">
+          <FilteredGoalsGrid entity="monument" id={id} />
+        </SectionShell>
+      }
+      notes={
+        <SectionShell title="Notes">
+          <MonumentNotesGrid monumentId={id} />
+        </SectionShell>
+      }
+      activity={
+        <SectionShell title="Activity">
+          <p className="text-sm text-muted-foreground">No activity yet</p>
+        </SectionShell>
+      }
+    />
   );
 }
 
 export default MonumentDetail;
-

--- a/src/components/monuments/MonumentDetailLayout.tsx
+++ b/src/components/monuments/MonumentDetailLayout.tsx
@@ -1,0 +1,46 @@
+import { ReactNode } from "react";
+import { SectionHeader } from "@/components/ui/content-card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SectionShellProps {
+  title: string;
+  children?: ReactNode;
+  loading?: boolean;
+}
+
+export function SectionShell({ title, children, loading = false }: SectionShellProps) {
+  return (
+    <section className="space-y-4">
+      <SectionHeader title={title} />
+      {loading ? <Skeleton className="h-32 w-full rounded-lg" /> : children}
+    </section>
+  );
+}
+
+interface MonumentDetailLayoutProps {
+  hero: ReactNode;
+  milestones: ReactNode;
+  goals: ReactNode;
+  notes: ReactNode;
+  activity: ReactNode;
+}
+
+export function MonumentDetailLayout({
+  hero,
+  milestones,
+  goals,
+  notes,
+  activity,
+}: MonumentDetailLayoutProps) {
+  return (
+    <main className="p-4 space-y-8">
+      {hero}
+      {milestones}
+      {goals}
+      {notes}
+      {activity}
+    </main>
+  );
+}
+
+export default MonumentDetailLayout;

--- a/src/components/monuments/MonumentHero.tsx
+++ b/src/components/monuments/MonumentHero.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { ChargingRing } from "./ChargingRing";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Monument {
+  title: string;
+  emoji: string | null;
+}
+
+interface MonumentHeroProps {
+  id: string;
+  monument?: Monument;
+  progress?: number;
+  loading?: boolean;
+}
+
+export function MonumentHero({ id, monument, progress = 0, loading = false }: MonumentHeroProps) {
+  if (loading || !monument) {
+    return (
+      <motion.div
+        layoutId={`card-${id}`}
+        className="flex flex-col items-center space-y-4"
+      >
+        <motion.div layoutId={`emoji-${id}`}>
+          <Skeleton className="h-16 w-16 rounded-full" />
+        </motion.div>
+        <motion.div layoutId={`title-${id}`} className="w-1/2">
+          <Skeleton className="h-8 w-full" />
+        </motion.div>
+        <Skeleton className="h-20 w-20 rounded-full" />
+        <Skeleton className="h-6 w-24 rounded-full" />
+        <div className="flex gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-20 rounded-md" />
+          ))}
+        </div>
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div
+      layoutId={`card-${id}`}
+      className="flex flex-col items-center space-y-4 text-center"
+    >
+      <div className="flex items-center gap-3">
+        <motion.div layoutId={`emoji-${id}`} className="text-5xl">
+          {monument.emoji || "\uD83D\uDDFC\uFE0F"}
+        </motion.div>
+        <motion.h1 layoutId={`title-${id}`} className="text-3xl font-bold">
+          {monument.title}
+        </motion.h1>
+      </div>
+      <ChargingRing value={progress} />
+      <div className="rounded-full bg-zinc-800 px-2 py-1 text-xs font-medium">
+        +3 day streak
+      </div>
+      <div className="flex flex-wrap justify-center gap-2">
+        <Link
+          href={`/monuments/${id}/edit`}
+          className="rounded-md bg-[var(--accent)] px-3 py-1 text-sm font-semibold text-black"
+        >
+          Edit
+        </Link>
+        <button className="rounded-md bg-zinc-800 px-3 py-1 text-sm">
+          +Milestone
+        </button>
+        <button className="rounded-md bg-zinc-800 px-3 py-1 text-sm">+Goal</button>
+        <button className="rounded-md bg-zinc-800 px-3 py-1 text-sm">+Note</button>
+      </div>
+    </motion.div>
+  );
+}
+
+export default MonumentHero;


### PR DESCRIPTION
## Summary
- add charging ring, momentum chip, and quick actions via new `MonumentHero`
- introduce `MonumentDetailLayout` and `SectionShell` with skeleton placeholders
- update monument detail overlay to use shared element transition from grid card to hero

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68bf57827ef8832c99237908e0307d18