### PR TITLE
feat: polish monument overlay

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -16,7 +16,7 @@ export default function BottomNav() {
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50">
+    <div className="bottom-nav fixed bottom-0 left-0 right-0 z-50 transition-transform">
       <div className="relative">
         <BottomBarNav
           items={items}

--- a/src/components/MonumentGridWithSharedTransition.tsx
+++ b/src/components/MonumentGridWithSharedTransition.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
 import { MonumentDetail } from "@/components/monuments/MonumentDetail";
 
@@ -22,11 +23,14 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
   useEffect(() => {
     if (activeId) {
       document.body.style.overflow = "hidden";
+      document.body.classList.add("detail-overlay-open");
     } else {
       document.body.style.overflow = "";
+      document.body.classList.remove("detail-overlay-open");
     }
     return () => {
       document.body.style.overflow = "";
+      document.body.classList.remove("detail-overlay-open");
     };
   }, [activeId]);
 
@@ -58,7 +62,7 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
         {selected && (
           <motion.div
             key="overlay"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -66,19 +70,52 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
           >
             <motion.div
               layoutId={`card-${selected.id}`}
-              className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl bg-zinc-900 shadow-xl"
+              className="relative flex h-full w-full max-w-md flex-col overflow-y-auto rounded-2xl border border-white/10 bg-gradient-to-b from-zinc-900 to-zinc-950 shadow-[0_0_15px_rgba(255,255,255,0.1)]"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ duration: 0.25, ease: "easeInOut", layout: { duration: 0.25 } }}
             >
-              <button
-                onClick={() => setActiveId(null)}
-                className="absolute right-4 top-4 z-10 rounded-md bg-zinc-800 px-3 py-1 text-sm"
-              >
-                Close
-              </button>
-              <MonumentDetail id={selected.id} />
+              <div className="flex items-center justify-between rounded-t-2xl bg-gradient-to-r from-zinc-800 to-zinc-700 px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <motion.div layoutId={`emoji-${selected.id}`} className="text-2xl">
+                    {selected.emoji}
+                  </motion.div>
+                  <motion.h2
+                    layoutId={`title-${selected.id}`}
+                    className="text-lg font-semibold"
+                  >
+                    {selected.title}
+                  </motion.h2>
+                </div>
+                <button
+                  onClick={() => setActiveId(null)}
+                  className="rounded-md bg-zinc-800/80 px-3 py-1 text-sm shadow hover:bg-zinc-700"
+                >
+                  Close
+                </button>
+              </div>
+              <div className="flex flex-wrap justify-center gap-2 p-4">
+                <span className="rounded-full border border-[var(--accent)] px-3 py-1 text-sm text-[var(--accent)]">
+                  Streak 0
+                </span>
+                <Link
+                  href={`/monuments/${selected.id}/edit`}
+                  className="rounded-full border border-[var(--accent)] px-3 py-1 text-sm text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-black"
+                >
+                  Edit
+                </Link>
+                <button className="rounded-full border border-[var(--accent)] px-3 py-1 text-sm text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-black">
+                  +Milestone
+                </button>
+                <button className="rounded-full border border-[var(--accent)] px-3 py-1 text-sm text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-black">
+                  +Goal
+                </button>
+                <button className="rounded-full border border-[var(--accent)] px-3 py-1 text-sm text-[var(--accent)] transition-colors hover:bg-[var(--accent)] hover:text-black">
+                  +Note
+                </button>
+              </div>
+              <MonumentDetail id={selected.id} showHeader={false} />
             </motion.div>
           </motion.div>
         )}

--- a/src/components/monuments/MonumentDetail.tsx
+++ b/src/components/monuments/MonumentDetail.tsx
@@ -22,9 +22,10 @@ interface Monument {
 
 interface MonumentDetailProps {
   id: string;
+  showHeader?: boolean;
 }
 
-export function MonumentDetail({ id }: MonumentDetailProps) {
+export function MonumentDetail({ id, showHeader = true }: MonumentDetailProps) {
   const [monument, setMonument] = useState<Monument | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -126,28 +127,30 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
 
   return (
     <main className="p-4 space-y-8">
-      <PageHeader
-        title={
-          <div className="flex items-center gap-3">
-            <span
-              className="text-4xl"
-              role="img"
-              aria-label={`Monument: ${monument.title}`}
-            >
-              {monument.emoji || "\uD83D\uDDFC\uFE0F"}
-            </span>
-            {monument.title}
-          </div>
-        }
-        description={`Created ${formatDate(monument.created_at)}`}
-      >
-        <Link
-          href={`/monuments/${id}/edit`}
-          className="inline-block rounded-full bg-[var(--accent)] px-4 py-2 font-semibold text-black"
+      {showHeader && (
+        <PageHeader
+          title={
+            <div className="flex items-center gap-3">
+              <span
+                className="text-4xl"
+                role="img"
+                aria-label={`Monument: ${monument.title}`}
+              >
+                {monument.emoji || "\uD83D\uDDFC\uFE0F"}
+              </span>
+              {monument.title}
+            </div>
+          }
+          description={`Created ${formatDate(monument.created_at)}`}
         >
-          Edit Monument
-        </Link>
-      </PageHeader>
+          <Link
+            href={`/monuments/${id}/edit`}
+            className="inline-block rounded-full bg-[var(--accent)] px-4 py-2 font-semibold text-black"
+          >
+            Edit Monument
+          </Link>
+        </PageHeader>
+      )}
 
       <ContentCard className="max-w-md mx-auto w-full space-y-2 text-center">
         <span className="text-sm text-gray-400">Charging</span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,3 +50,7 @@ html,body{ background:var(--bg); color:var(--text); font-weight:600; touch-actio
   from{background-position:200% 0;}
   to{background-position:-200% 0;}
 }
+
+body.detail-overlay-open .bottom-nav{
+  transform:translateY(100%);
+}


### PR DESCRIPTION
## Summary
- add polished hero overlay with gradient header and quick actions
- collapse bottom nav when detail overlay is open
- make monument detail header optional for reuse inside overlay

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68bfcaa478b0832c9d81b812ba884dd5