### PR TITLE
feat: overhaul monument detail empty states

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -16,7 +16,7 @@ export default function BottomNav() {
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50">
+    <div className="fixed bottom-0 left-0 right-0 z-50" data-bottom-nav>
       <div className="relative">
         <BottomBarNav
           items={items}

--- a/components/ui/GoalList.tsx
+++ b/components/ui/GoalList.tsx
@@ -105,7 +105,6 @@ export function GoalList() {
   if (goals.length === 0) {
     return (
       <EmptyState
-        variant="goals"
         title="No goals yet"
         description="Start by creating your first goal to track your progress."
       />

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,64 +1,52 @@
-import { Button } from "./button"
-import { Plus, Target, Mountain, CheckCircle, Star, Calendar } from "lucide-react"
+import { ReactNode } from "react";
+import { Button } from "./button";
+import {
+  Plus,
+  Target,
+  Mountain,
+  CheckCircle,
+  Star,
+  Calendar,
+} from "lucide-react";
 
 interface EmptyStateProps {
-  title: string
-  description: string
-  icon?: React.ComponentType<{ className?: string }>
-  actionLabel?: string
-  onAction?: () => void
-  variant?: 'default' | 'goals' | 'habits' | 'skills' | 'monuments' | 'schedule'
+  title?: string;
+  description: string;
+  cta?: ReactNode;
+  icon?: ReactNode;
 }
 
-export function EmptyState({ 
-  title, 
-  description, 
-  icon: Icon, 
-  actionLabel = "Create New", 
-  onAction,
-  variant = 'default'
-}: EmptyStateProps) {
-  const getDefaultIcon = () => {
-    switch (variant) {
-      case 'goals': return Target
-      case 'habits': return CheckCircle
-      case 'skills': return Star
-      case 'monuments': return Mountain
-      case 'schedule': return Calendar
-      default: return Plus
-    }
-  }
-
-  const DefaultIcon = Icon || getDefaultIcon()
-
+export function EmptyState({ title, description, cta, icon }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-      <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-muted mb-4">
-        <DefaultIcon className="h-8 w-8 text-muted-foreground" />
-      </div>
-      <h3 className="text-lg font-semibold text-foreground mb-2">{title}</h3>
-      <p className="text-sm text-muted-foreground mb-6 max-w-sm">{description}</p>
-      {onAction && (
-        <Button onClick={onAction} className="gap-2">
-          <Plus className="h-4 w-4" />
-          {actionLabel}
-        </Button>
+      {icon && (
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+          {icon}
+        </div>
       )}
+      {title && <h3 className="text-lg font-semibold text-foreground mb-2">{title}</h3>}
+      <p className="text-sm text-muted-foreground mb-6 max-w-sm">{description}</p>
+      {cta}
     </div>
-  )
+  );
 }
 
-// Predefined empty states for common scenarios
 export function GoalsEmptyState({ onAction }: { onAction?: () => void }) {
   return (
     <EmptyState
       title="No goals yet"
       description="Create your first goal to start tracking your progress and achievements."
-      variant="goals"
-      actionLabel="Create Goal"
-      onAction={onAction}
+      icon={<Target className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Create Goal
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }
 
 export function HabitsEmptyState({ onAction }: { onAction?: () => void }) {
@@ -66,11 +54,17 @@ export function HabitsEmptyState({ onAction }: { onAction?: () => void }) {
     <EmptyState
       title="No habits yet"
       description="Build positive habits to improve your daily routine and productivity."
-      variant="habits"
-      actionLabel="Create Habit"
-      onAction={onAction}
+      icon={<CheckCircle className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Create Habit
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }
 
 export function SkillsEmptyState({ onAction }: { onAction?: () => void }) {
@@ -78,11 +72,17 @@ export function SkillsEmptyState({ onAction }: { onAction?: () => void }) {
     <EmptyState
       title="No skills yet"
       description="Track your skills and set targets to continuously improve and grow."
-      variant="skills"
-      actionLabel="Add Skill"
-      onAction={onAction}
+      icon={<Star className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Add Skill
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }
 
 export function MonumentsEmptyState({ onAction }: { onAction?: () => void }) {
@@ -90,11 +90,17 @@ export function MonumentsEmptyState({ onAction }: { onAction?: () => void }) {
     <EmptyState
       title="No monuments yet"
       description="Celebrate your achievements and milestones by creating monuments."
-      variant="monuments"
-      actionLabel="Create Monument"
-      onAction={onAction}
+      icon={<Mountain className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Create Monument
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }
 
 export function ScheduleEmptyState({ onAction }: { onAction?: () => void }) {
@@ -102,11 +108,17 @@ export function ScheduleEmptyState({ onAction }: { onAction?: () => void }) {
     <EmptyState
       title="No events scheduled"
       description="Plan your day by adding events and tasks to your schedule."
-      variant="schedule"
-      actionLabel="Add Event"
-      onAction={onAction}
+      icon={<Calendar className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Add Event
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }
 
 export function TasksEmptyState({ onAction }: { onAction?: () => void }) {
@@ -114,11 +126,17 @@ export function TasksEmptyState({ onAction }: { onAction?: () => void }) {
     <EmptyState
       title="No tasks yet"
       description="Organize your work by creating tasks and setting priorities."
-      variant="default"
-      actionLabel="Create Task"
-      onAction={onAction}
+      icon={<Plus className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Create Task
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }
 
 export function ProjectsEmptyState({ onAction }: { onAction?: () => void }) {
@@ -126,9 +144,15 @@ export function ProjectsEmptyState({ onAction }: { onAction?: () => void }) {
     <EmptyState
       title="No projects yet"
       description="Start managing your projects and track their progress over time."
-      variant="default"
-      actionLabel="Create Project"
-      onAction={onAction}
+      icon={<Plus className="h-8 w-8 text-muted-foreground" />}
+      cta={
+        onAction ? (
+          <Button onClick={onAction} className="gap-2">
+            <Plus className="h-4 w-4" />
+            Create Project
+          </Button>
+        ) : null
+      }
     />
-  )
+  );
 }

--- a/src/components/MonumentGridWithSharedTransition.tsx
+++ b/src/components/MonumentGridWithSharedTransition.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
 import { MonumentDetail } from "@/components/monuments/MonumentDetail";
 
 export interface Monument {
@@ -76,7 +77,7 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
               layoutId={`card-${selected.id}`}
               role="dialog"
               aria-modal="true"
-              className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl bg-[#0B0E13] shadow-xl"
+              className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl border border-white/5 bg-[#0B0E13] shadow-[0_6px_24px_rgba(0,0,0,0.35)]"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.95 }}
@@ -84,12 +85,12 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
             >
               <Button
                 variant="secondary"
-                size="sm"
+                size="icon"
                 aria-label="Close detail"
                 onClick={() => setActiveId(null)}
                 className="absolute right-4 top-4 z-10"
               >
-                Close
+                <X className="h-4 w-4" />
               </Button>
               <MonumentDetail id={selected.id} />
             </motion.div>

--- a/src/components/MonumentGridWithSharedTransition.tsx
+++ b/src/components/MonumentGridWithSharedTransition.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { Button } from "@/components/ui/button";
 import { MonumentDetail } from "@/components/monuments/MonumentDetail";
 
 export interface Monument {
@@ -19,14 +20,21 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
   const [activeId, setActiveId] = useState<string | null>(null);
   const selected = monuments.find((m) => m.id === activeId) || null;
 
+  const previousFocus = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     if (activeId) {
+      previousFocus.current = document.activeElement as HTMLElement;
       document.body.style.overflow = "hidden";
+      document.body.classList.add("modal-open");
     } else {
       document.body.style.overflow = "";
+      document.body.classList.remove("modal-open");
+      previousFocus.current?.focus();
     }
     return () => {
       document.body.style.overflow = "";
+      document.body.classList.remove("modal-open");
     };
   }, [activeId]);
 
@@ -58,7 +66,7 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
         {selected && (
           <motion.div
             key="overlay"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-md p-4"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -66,18 +74,23 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
           >
             <motion.div
               layoutId={`card-${selected.id}`}
-              className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl bg-zinc-900 shadow-xl"
+              role="dialog"
+              aria-modal="true"
+              className="relative h-full w-full max-w-md overflow-y-auto rounded-2xl bg-[#0B0E13] shadow-xl"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.25, ease: "easeInOut", layout: { duration: 0.25 } }}
+              transition={{ type: "spring", stiffness: 500, damping: 40, mass: 0.9 }}
             >
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
+                aria-label="Close detail"
                 onClick={() => setActiveId(null)}
-                className="absolute right-4 top-4 z-10 rounded-md bg-zinc-800 px-3 py-1 text-sm"
+                className="absolute right-4 top-4 z-10"
               >
                 Close
-              </button>
+              </Button>
               <MonumentDetail id={selected.id} />
             </motion.div>
           </motion.div>

--- a/src/components/goals/FilteredGoalsGrid.tsx
+++ b/src/components/goals/FilteredGoalsGrid.tsx
@@ -18,7 +18,7 @@ function GridSkeleton() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       {Array.from({ length: 6 }).map((_, i) => (
-        <Skeleton key={i} className="h-32 rounded-lg" />
+        <Skeleton key={i} className="h-32 rounded-2xl bg-[#111520]" />
       ))}
     </div>
   );
@@ -36,6 +36,7 @@ export function FilteredGoalsGrid({ entity, id, onCreateGoal }: FilteredGoalsGri
             key={f}
             variant={active === f ? "default" : "outline"}
             className="px-3 py-1 cursor-pointer"
+            aria-label={`Show ${f} goals`}
             onClick={() => setActive(f)}
           >
             {f}
@@ -51,7 +52,7 @@ export function FilteredGoalsGrid({ entity, id, onCreateGoal }: FilteredGoalsGri
           <p className="text-sm text-gray-400">{error}</p>
         </div>
       ) : !goals || goals.length === 0 ? (
-        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4">
+        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
           <p className="text-[#A7B0BD] mb-4">No goals linked to this monument.</p>
           <Button variant="outline" onClick={onCreateGoal}>+ Goal</Button>
         </Card>

--- a/src/components/goals/FilteredGoalsGrid.tsx
+++ b/src/components/goals/FilteredGoalsGrid.tsx
@@ -1,59 +1,67 @@
 "use client";
 
+import { useState } from "react";
 import { GoalCard } from "@/components/ui/GoalCard";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { useFilteredGoals } from "@/lib/hooks/useFilteredGoals";
 
 interface FilteredGoalsGridProps {
   entity: "monument" | "skill";
   id: string;
+  onCreateGoal?: () => void;
 }
 
-export function FilteredGoalsGrid({ entity, id }: FilteredGoalsGridProps) {
-  const { goals, loading, error } = useFilteredGoals({ entity, id, limit: 12 });
-
-  if (loading) {
-    return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="h-32 rounded-lg" />
-        ))}
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="text-center py-8">
-        <p className="text-red-400 mb-2">Error loading goals</p>
-        <p className="text-sm text-gray-400">{error}</p>
-      </div>
-    );
-  }
-
-  if (!goals || goals.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <div className="text-4xl mb-4" role="img" aria-hidden="true">
-          🎯
-        </div>
-        <h3 className="text-lg font-medium text-white mb-2">
-          No related goals yet
-        </h3>
-        <p className="text-gray-400 text-sm">
-          {entity === "monument"
-            ? "Goals linked to this monument will appear here."
-            : "Goals that use this skill will appear here."}
-        </p>
-      </div>
-    );
-  }
-
+function GridSkeleton() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {goals.map((goal) => (
-        <GoalCard key={goal.id} goal={goal} showLink={false} />
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Skeleton key={i} className="h-32 rounded-lg" />
       ))}
+    </div>
+  );
+}
+
+export function FilteredGoalsGrid({ entity, id, onCreateGoal }: FilteredGoalsGridProps) {
+  const { goals, loading, error } = useFilteredGoals({ entity, id, limit: 12 });
+  const [active, setActive] = useState("Active");
+
+  return (
+    <div>
+      <div className="mb-3 flex gap-2">
+        {(["Active", "Blocked", "Completed"] as const).map((f) => (
+          <Badge
+            key={f}
+            variant={active === f ? "default" : "outline"}
+            className="px-3 py-1 cursor-pointer"
+            onClick={() => setActive(f)}
+          >
+            {f}
+          </Badge>
+        ))}
+      </div>
+
+      {loading ? (
+        <GridSkeleton />
+      ) : error ? (
+        <div className="text-center py-8">
+          <p className="text-red-400 mb-2">Error loading goals</p>
+          <p className="text-sm text-gray-400">{error}</p>
+        </div>
+      ) : !goals || goals.length === 0 ? (
+        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4">
+          <p className="text-[#A7B0BD] mb-4">No goals linked to this monument.</p>
+          <Button variant="outline" onClick={onCreateGoal}>+ Goal</Button>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {goals.map((goal) => (
+            <GoalCard key={goal.id} goal={goal} showLink={false} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/goals/FilteredGoalsGrid.tsx
+++ b/src/components/goals/FilteredGoalsGrid.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useState } from "react";
-import { GoalCard } from "@/components/ui/GoalCard";
-import { Skeleton } from "@/components/ui/skeleton";
+import { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useFilteredGoals } from "@/lib/hooks/useFilteredGoals";
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+import { GoalCard as GoalFolder } from "@/app/(app)/goals/components/GoalCard";
+import type { Goal, Project } from "@/app/(app)/goals/types";
 
 interface FilteredGoalsGridProps {
   entity: "monument" | "skill";
@@ -24,9 +27,109 @@ function GridSkeleton() {
   );
 }
 
+function mapPriority(priority: string): Goal["priority"] {
+  switch (priority) {
+    case "HIGH":
+    case "CRITICAL":
+    case "ULTRA-CRITICAL":
+      return "High";
+    case "MEDIUM":
+      return "Medium";
+    default:
+      return "Low";
+  }
+}
+
+function mapEnergy(energy: string): Goal["energy"] {
+  switch (energy) {
+    case "LOW":
+      return "Low";
+    case "MEDIUM":
+      return "Medium";
+    case "HIGH":
+      return "High";
+    case "ULTRA":
+      return "Ultra";
+    case "EXTREME":
+      return "Extreme";
+    default:
+      return "No";
+  }
+}
+
+function projectStageToStatus(stage: string): Project["status"] {
+  switch (stage) {
+    case "RESEARCH":
+      return "Todo";
+    case "RELEASE":
+      return "Done";
+    default:
+      return "In-Progress";
+  }
+}
+
 export function FilteredGoalsGrid({ entity, id, onCreateGoal }: FilteredGoalsGridProps) {
-  const { goals, loading, error } = useFilteredGoals({ entity, id, limit: 12 });
+  const { goals, loading: goalsLoading, error } = useFilteredGoals({ entity, id, limit: 12 });
   const [active, setActive] = useState("Active");
+  const [goalFolders, setGoalFolders] = useState<Goal[]>([]);
+  const [projLoading, setProjLoading] = useState(true);
+
+  useEffect(() => {
+    const loadProjects = async () => {
+      if (!goals || goals.length === 0) {
+        setGoalFolders([]);
+        setProjLoading(false);
+        return;
+      }
+
+      const supabase = getSupabaseBrowser();
+      if (!supabase) return;
+
+      setProjLoading(true);
+
+      const goalIds = goals.map((g) => g.id);
+      const { data: projectsData } = await supabase
+        .from("projects")
+        .select("id,name,goal_id,stage,energy,due_date")
+        .in("goal_id", goalIds);
+
+      const projectsByGoal: Record<string, Project[]> = {};
+      projectsData?.forEach((p) => {
+        const proj: Project = {
+          id: p.id,
+          name: p.name,
+          status: projectStageToStatus(p.stage),
+          progress: 0,
+          energy: mapEnergy(p.energy),
+          tasks: [],
+          dueDate: p.due_date || undefined,
+        };
+        projectsByGoal[p.goal_id] = projectsByGoal[p.goal_id] || [];
+        projectsByGoal[p.goal_id].push(proj);
+      });
+
+      const mapped: Goal[] = goals.map((g) => ({
+        id: g.id,
+        title: g.name,
+        priority: mapPriority(g.priority),
+        energy: mapEnergy(g.energy),
+        progress: 0,
+        status: "Active",
+        active: true,
+        updatedAt: g.created_at,
+        projects: projectsByGoal[g.id] || [],
+      }));
+
+      setGoalFolders(mapped);
+      setProjLoading(false);
+    };
+
+    if (!goalsLoading) {
+      loadProjects();
+    }
+  }, [goals, goalsLoading]);
+
+  const loading = goalsLoading || projLoading;
 
   return (
     <div>
@@ -51,15 +154,15 @@ export function FilteredGoalsGrid({ entity, id, onCreateGoal }: FilteredGoalsGri
           <p className="text-red-400 mb-2">Error loading goals</p>
           <p className="text-sm text-gray-400">{error}</p>
         </div>
-      ) : !goals || goals.length === 0 ? (
+      ) : goalFolders.length === 0 ? (
         <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
           <p className="text-[#A7B0BD] mb-4">No goals linked to this monument.</p>
           <Button variant="outline" onClick={onCreateGoal}>+ Goal</Button>
         </Card>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {goals.map((goal) => (
-            <GoalCard key={goal.id} goal={goal} showLink={false} />
+        <div className="flex flex-col gap-4">
+          {goalFolders.map((goal) => (
+            <GoalFolder key={goal.id} goal={goal} />
           ))}
         </div>
       )}

--- a/src/components/monuments/ActivityPanel.tsx
+++ b/src/components/monuments/ActivityPanel.tsx
@@ -1,0 +1,13 @@
+import { Card } from "@/components/ui/card";
+
+export default function ActivityPanel() {
+  return (
+    <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5">
+      <h3 className="text-[#E7ECF2] font-medium mb-3">Activity</h3>
+      <div className="relative pl-6">
+        <div className="absolute left-2 top-0 bottom-0 w-px bg-white/10" />
+        <p className="text-[#A7B0BD]">No activity yet. Progress will appear here once milestones or goals are updated.</p>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/monuments/ActivityPanel.tsx
+++ b/src/components/monuments/ActivityPanel.tsx
@@ -2,7 +2,7 @@ import { Card } from "@/components/ui/card";
 
 export default function ActivityPanel() {
   return (
-    <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5">
+    <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
       <h3 className="text-[#E7ECF2] font-medium mb-3">Activity</h3>
       <div className="relative pl-6">
         <div className="absolute left-2 top-0 bottom-0 w-px bg-white/10" />

--- a/src/components/monuments/MilestonesPanel.tsx
+++ b/src/components/monuments/MilestonesPanel.tsx
@@ -1,0 +1,19 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function MilestonesPanel({ onAdd, onAutoSplit }:{
+  onAdd: ()=>void; onAutoSplit: ()=>void;
+}) {
+  return (
+    <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5">
+      <h3 className="text-[#E7ECF2] font-medium mb-3">Milestones</h3>
+      <p className="text-[#A7B0BD] mb-4">
+        No milestones yet. Add your first milestone to start tracking progress.
+      </p>
+      <div className="flex gap-2">
+        <Button onClick={onAdd}>+ Milestone</Button>
+        <Button variant="outline" onClick={onAutoSplit}>Auto Split</Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/monuments/MilestonesPanel.tsx
+++ b/src/components/monuments/MilestonesPanel.tsx
@@ -1,18 +1,21 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
-export default function MilestonesPanel({ onAdd, onAutoSplit }:{
-  onAdd: ()=>void; onAutoSplit: ()=>void;
+export default function MilestonesPanel({ onAdd, onAutoSplit }: {
+  onAdd: () => void; onAutoSplit: () => void;
 }) {
   return (
-    <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5">
+    <Card
+      id="monument-milestones"
+      className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]"
+    >
       <h3 className="text-[#E7ECF2] font-medium mb-3">Milestones</h3>
       <p className="text-[#A7B0BD] mb-4">
         No milestones yet. Add your first milestone to start tracking progress.
       </p>
       <div className="flex gap-2">
-        <Button onClick={onAdd}>+ Milestone</Button>
-        <Button variant="outline" onClick={onAutoSplit}>Auto Split</Button>
+        <Button onClick={onAdd} aria-label="Add milestone">+ Milestone</Button>
+        <Button variant="outline" onClick={onAutoSplit} aria-label="Auto split milestones">Auto Split</Button>
       </div>
     </Card>
   );

--- a/src/components/monuments/MonumentDetail.tsx
+++ b/src/components/monuments/MonumentDetail.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card } from "@/components/ui/card";
@@ -27,6 +28,8 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const supabase = getSupabaseBrowser();
+  const router = useRouter();
+  const noteInputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -96,6 +99,30 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
     );
   }
 
+  const handleCreateMilestone = () => {
+    console.log("Milestone creation coming soon");
+  };
+
+  const handleAddMilestone = () => {
+    document
+      .getElementById("monument-milestones")
+      ?.scrollIntoView({ behavior: "smooth" });
+    handleCreateMilestone();
+  };
+
+  const handleAutoSplit = () => {
+    console.log("Auto Split coming soon");
+  };
+
+  const handleAddNote = () => {
+    noteInputRef.current?.scrollIntoView({ behavior: "smooth" });
+    noteInputRef.current?.focus();
+  };
+
+  const handleCreateGoal = () => {
+    router.push("/goals/new");
+  };
+
   return (
     <main className="p-4 flex flex-col gap-4 sm:gap-5">
       <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
@@ -115,14 +142,18 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
           <Button asChild>
             <Link href={`/monuments/${id}/edit`}>Edit</Link>
           </Button>
-          <Button variant="outline" onClick={() => {}}>+ Milestone</Button>
-          <Button variant="outline" onClick={() => {}}>+ Note</Button>
+          <Button variant="outline" onClick={handleAddMilestone} aria-label="Add milestone">+ Milestone</Button>
+          <Button variant="outline" onClick={handleAddNote} aria-label="Add note">+ Note</Button>
         </div>
       </Card>
 
-      <MilestonesPanel onAdd={() => {}} onAutoSplit={() => {}} />
-      <FilteredGoalsGrid entity="monument" id={id} onCreateGoal={() => {}} />
-      <MonumentNotesGrid monumentId={id} />
+      <MilestonesPanel onAdd={handleCreateMilestone} onAutoSplit={handleAutoSplit} />
+      <FilteredGoalsGrid
+        entity="monument"
+        id={id}
+        onCreateGoal={handleCreateGoal}
+      />
+      <MonumentNotesGrid monumentId={id} inputRef={noteInputRef} />
       <ActivityPanel />
     </main>
   );

--- a/src/components/monuments/MonumentDetail.tsx
+++ b/src/components/monuments/MonumentDetail.tsx
@@ -3,21 +3,19 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getSupabaseBrowser } from "@/lib/supabase";
-import { FilteredGoalsGrid } from "@/components/goals/FilteredGoalsGrid";
-import {
-  ContentCard,
-  PageHeader,
-  SectionHeader,
-} from "@/components/ui/content-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ProgressBarGradient } from "@/components/skills/ProgressBarGradient";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import MilestonesPanel from "./MilestonesPanel";
+import ActivityPanel from "./ActivityPanel";
+import { FilteredGoalsGrid } from "@/components/goals/FilteredGoalsGrid";
 import { MonumentNotesGrid } from "@/components/notes/MonumentNotesGrid";
 
 interface Monument {
   id: string;
   title: string;
   emoji: string | null;
-  created_at: string;
 }
 
 interface MonumentDetailProps {
@@ -34,36 +32,30 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
     let cancelled = false;
     async function load() {
       if (!supabase || !id) return;
-
       setLoading(true);
       setError(null);
-
       try {
         await supabase.auth.getSession();
         const { data, error } = await supabase
           .from("monuments")
-          .select("id,title,emoji,created_at")
+          .select("id,title,emoji")
           .eq("id", id)
           .single();
-
         if (!cancelled) {
           if (error) {
-            console.error("Error fetching monument:", error);
             setError("Failed to load monument");
           } else {
             setMonument(data);
           }
           setLoading(false);
         }
-      } catch (err) {
+      } catch {
         if (!cancelled) {
-          console.error("Error loading monument:", err);
           setError("Failed to load monument");
           setLoading(false);
         }
       }
     }
-
     load();
     return () => {
       cancelled = true;
@@ -72,26 +64,24 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
 
   if (loading) {
     return (
-      <main className="p-4 space-y-8">
-        <div className="space-y-2">
-          <Skeleton className="h-10 w-3/4" />
-          <Skeleton className="h-4 w-1/3" />
-        </div>
-        <ContentCard className="flex flex-col items-center space-y-4">
-          <Skeleton className="h-16 w-16 rounded-full" />
-          <div className="w-full max-w-sm space-y-2">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-2 w-full" />
+      <main className="p-4 flex flex-col gap-4 sm:gap-5">
+        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5">
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-14 w-14 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-5 w-1/2" />
+              <Skeleton className="h-4 w-1/3" />
+            </div>
           </div>
-        </ContentCard>
-        <div className="space-y-4">
-          <Skeleton className="h-6 w-32" />
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-32 rounded-lg" />
-            ))}
+          <div className="mt-4 flex gap-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-8 w-24" />
           </div>
-        </div>
+        </Card>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-32 rounded-2xl" />
+        ))}
       </main>
     );
   }
@@ -99,73 +89,43 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
   if (error || !monument) {
     return (
       <main className="p-4">
-        <div className="text-center py-12">
-          <h1 className="text-2xl font-semibold text-red-400 mb-2">
-            {error || "Monument not found"}
-          </h1>
-          <p className="text-gray-400">
-            {error
-              ? "Please try again later."
-              : "This monument doesn't exist or you don't have access to it."}
-          </p>
-        </div>
+        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 text-center">
+          <p className="text-[#A7B0BD]">{error || "Monument not found"}</p>
+        </Card>
       </main>
     );
   }
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  };
-
-  const mockProgress = 65;
-
   return (
-    <main className="p-4 space-y-8">
-      <PageHeader
-        title={
-          <div className="flex items-center gap-3">
-            <span
-              className="text-4xl"
-              role="img"
-              aria-label={`Monument: ${monument.title}`}
-            >
-              {monument.emoji || "\uD83D\uDDFC\uFE0F"}
-            </span>
-            {monument.title}
+    <main className="p-4 flex flex-col gap-4 sm:gap-5">
+      <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
+        <div className="flex items-center gap-4">
+          <span className="text-5xl" role="img" aria-label={`Monument: ${monument.title}`}>
+            {monument.emoji || "\uD83D\uDDFC\uFE0F"}
+          </span>
+          <div className="flex flex-col">
+            <h2 className="text-[#E7ECF2] font-bold">{monument.title}</h2>
+            <Badge variant="outline" className="mt-1 self-start px-2 py-0">
+              0 day streak
+            </Badge>
           </div>
-        }
-        description={`Created ${formatDate(monument.created_at)}`}
-      >
-        <Link
-          href={`/monuments/${id}/edit`}
-          className="inline-block rounded-full bg-[var(--accent)] px-4 py-2 font-semibold text-black"
-        >
-          Edit Monument
-        </Link>
-      </PageHeader>
+        </div>
+        <p className="mt-3 text-[#A7B0BD]">Not charging yet.</p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <Button asChild>
+            <Link href={`/monuments/${id}/edit`}>Edit</Link>
+          </Button>
+          <Button variant="outline" onClick={() => {}}>+ Milestone</Button>
+          <Button variant="outline" onClick={() => {}}>+ Note</Button>
+        </div>
+      </Card>
 
-      <ContentCard className="max-w-md mx-auto w-full space-y-2 text-center">
-        <span className="text-sm text-gray-400">Charging</span>
-        <ProgressBarGradient value={mockProgress} height={8} />
-      </ContentCard>
-
-      <section className="space-y-4">
-        <SectionHeader title="Related Goals" />
-        <FilteredGoalsGrid entity="monument" id={id} />
-      </section>
-
-      <section className="space-y-4">
-        <SectionHeader title="Notes" />
-        <MonumentNotesGrid monumentId={id} />
-      </section>
+      <MilestonesPanel onAdd={() => {}} onAutoSplit={() => {}} />
+      <FilteredGoalsGrid entity="monument" id={id} onCreateGoal={() => {}} />
+      <MonumentNotesGrid monumentId={id} />
+      <ActivityPanel />
     </main>
   );
 }
 
 export default MonumentDetail;
-

--- a/src/components/monuments/MonumentsList.tsx
+++ b/src/components/monuments/MonumentsList.tsx
@@ -58,7 +58,7 @@ export function MonumentsList({
     return (
       <div className="grid grid-cols-4 gap-1">
         {Array.from({ length: 8 }).map((_, i) => (
-          <Skeleton key={i} className="aspect-square w-full" />
+          <Skeleton key={i} className="aspect-square w-full rounded-2xl bg-[#111520]" />
         ))}
       </div>
     );

--- a/src/components/monuments/MonumentsList.tsx
+++ b/src/components/monuments/MonumentsList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { MonumentsEmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export interface Monument {
   id: string;
@@ -54,7 +55,13 @@ export function MonumentsList({
   }, [supabase, limit]);
 
   if (loading) {
-    return <p className="text-sm text-[var(--muted)]">Loading…</p>;
+    return (
+      <div className="grid grid-cols-4 gap-1">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="aspect-square w-full" />
+        ))}
+      </div>
+    );
   }
 
   if (monuments.length === 0) {

--- a/src/components/notes/MonumentNotesGrid.tsx
+++ b/src/components/notes/MonumentNotesGrid.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { Plus } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
+import { useEffect, useState, useRef, FormEvent } from "react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import type { MonumentNote } from "@/lib/types/monument-note";
 import {
   getMonumentNotes,
@@ -17,6 +17,8 @@ interface MonumentNotesGridProps {
 
 export function MonumentNotesGrid({ monumentId }: MonumentNotesGridProps) {
   const [notes, setNotes] = useState<MonumentNote[]>([]);
+  const [draft, setDraft] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     setNotes(getMonumentNotes(monumentId));
@@ -26,22 +28,61 @@ export function MonumentNotesGrid({ monumentId }: MonumentNotesGridProps) {
     saveMonumentNotes(monumentId, notes);
   }, [monumentId, notes]);
 
+  const hasNotes = notes && notes.length > 0;
+
+  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setDraft(e.target.value);
+    e.target.style.height = "auto";
+    e.target.style.height = `${e.target.scrollHeight}px`;
+  };
+
+  const handleAdd = (e: FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim()) return;
+    const newNote: MonumentNote = {
+      id: Date.now().toString(),
+      monumentId,
+      title: draft.trim(),
+      content: draft.trim(),
+    };
+    setNotes([...notes, newNote]);
+    setDraft("");
+    if (textareaRef.current) textareaRef.current.style.height = "auto";
+  };
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-      {notes.map((note) => (
-        <MonumentNoteCard
-          key={note.id}
-          note={note}
-          monumentId={monumentId}
+    <div className="space-y-4">
+      <form onSubmit={handleAdd} className="space-y-2">
+        <Textarea
+          ref={textareaRef}
+          rows={1}
+          value={draft}
+          onChange={handleInput}
+          placeholder="Quick note..."
+          className="resize-none overflow-hidden rounded-2xl border border-white/5 bg-[#111520] p-3 text-sm text-[#E7ECF2] placeholder-[#A7B0BD]"
         />
-      ))}
-      <Link href={`/monuments/${monumentId}/notes/new`}>
-        <Card className="flex items-center justify-center h-full border-dashed hover:bg-gray-800 transition-colors">
-          <CardContent className="p-4 flex items-center justify-center">
-            <Plus className="w-5 h-5 text-gray-400" />
-          </CardContent>
+        <div className="flex justify-end">
+          <Button type="submit" size="sm" disabled={!draft.trim()}>
+            Save
+          </Button>
+        </div>
+      </form>
+
+      {hasNotes ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {notes.map((note) => (
+            <MonumentNoteCard
+              key={note.id}
+              note={note}
+              monumentId={monumentId}
+            />
+          ))}
+        </div>
+      ) : (
+        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4">
+          <p className="text-[#A7B0BD]">No notes yet. Capture your first thought here.</p>
         </Card>
-      </Link>
+      )}
     </div>
   );
 }

--- a/src/components/notes/MonumentNotesGrid.tsx
+++ b/src/components/notes/MonumentNotesGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, FormEvent } from "react";
+import { useEffect, useState, useRef, FormEvent, type Ref, type MutableRefObject } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -13,12 +13,22 @@ import { MonumentNoteCard } from "./MonumentNoteCard";
 
 interface MonumentNotesGridProps {
   monumentId: string;
+  inputRef?: Ref<HTMLTextAreaElement>;
 }
 
-export function MonumentNotesGrid({ monumentId }: MonumentNotesGridProps) {
+export function MonumentNotesGrid({ monumentId, inputRef }: MonumentNotesGridProps) {
   const [notes, setNotes] = useState<MonumentNote[]>([]);
   const [draft, setDraft] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!inputRef) return;
+    if (typeof inputRef === "function") {
+      inputRef(textareaRef.current);
+    } else {
+      (inputRef as MutableRefObject<HTMLTextAreaElement | null>).current = textareaRef.current;
+    }
+  }, [inputRef]);
 
   useEffect(() => {
     setNotes(getMonumentNotes(monumentId));
@@ -62,7 +72,7 @@ export function MonumentNotesGrid({ monumentId }: MonumentNotesGridProps) {
           className="resize-none overflow-hidden rounded-2xl border border-white/5 bg-[#111520] p-3 text-sm text-[#E7ECF2] placeholder-[#A7B0BD]"
         />
         <div className="flex justify-end">
-          <Button type="submit" size="sm" disabled={!draft.trim()}>
+          <Button type="submit" size="sm" disabled={!draft.trim()} aria-label="Save note">
             Save
           </Button>
         </div>
@@ -79,7 +89,7 @@ export function MonumentNotesGrid({ monumentId }: MonumentNotesGridProps) {
           ))}
         </div>
       ) : (
-        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4">
+        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
           <p className="text-[#A7B0BD]">No notes yet. Capture your first thought here.</p>
         </Card>
       )}

--- a/src/components/ui/GoalCard.tsx
+++ b/src/components/ui/GoalCard.tsx
@@ -2,8 +2,8 @@
 
 import React from "react";
 import Link from "next/link";
-import { Badge } from "../../../components/ui/badge";
-import { Card, CardContent } from "../../../components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 import FlameEmber, { type FlameLevel } from "@/components/FlameEmber";
 import { Trophy, Target } from "lucide-react";
 import type { GoalItem } from "@/types/dashboard";
@@ -54,24 +54,24 @@ export function GoalCard({ goal, showLink = false }: GoalCardProps) {
   };
 
   const cardContent = (
-    <Card className="relative h-full hover:bg-gray-800/50 transition-colors">
-      <CardContent className="p-4">
+    <Card className="relative h-full p-0 rounded-2xl border border-white/5 bg-[#111520] shadow-[0_6px_24px_rgba(0,0,0,0.35)] transition-colors hover:bg-white/5">
+      <CardContent className="p-4 sm:p-5">
         {/* Header with title and optional monument icon */}
-        <div className="flex items-start justify-between mb-3">
-          <h3 className="font-medium text-white text-sm leading-tight flex-1 pr-2">
+        <div className="flex items-start justify-between mb-4">
+          <h3 className="flex-1 pr-2 text-sm font-medium leading-tight text-[#E7ECF2]">
             {goal.name}
           </h3>
-          <div className="flex-shrink-0">
+          <div className="flex-shrink-0 text-[#A7B0BD]">
             {goal.monument_id ? (
-              <Trophy className="w-4 h-4 text-yellow-500" />
+              <Trophy className="h-4 w-4" aria-hidden="true" />
             ) : (
-              <Target className="w-4 h-4 text-gray-500" />
+              <Target className="h-4 w-4" aria-hidden="true" />
             )}
           </div>
         </div>
 
         {/* Priority and Energy badges */}
-        <div className="flex gap-2 mb-3">
+        <div className="mb-4 flex gap-2">
           <Badge
             variant={getPriorityVariant(goal.priority)}
             className="text-xs"
@@ -84,11 +84,11 @@ export function GoalCard({ goal, showLink = false }: GoalCardProps) {
         </div>
 
         {/* Created date */}
-        <div className="text-xs text-gray-400">
+        <div className="text-xs text-[#A7B0BD]">
           Created {formatDate(goal.created_at)}
         </div>
       </CardContent>
-      <div className="absolute right-2 top-2 pointer-events-none">
+      <div className="pointer-events-none absolute right-4 top-4">
         <FlameEmber level={goal.energy as FlameLevel} size="sm" />
       </div>
     </Card>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,3 +50,5 @@ html,body{ background:var(--bg); color:var(--text); font-weight:600; touch-actio
   from{background-position:200% 0;}
   to{background-position:-200% 0;}
 }
+
+body.modal-open [data-bottom-nav] { display: none !important; }


### PR DESCRIPTION
## Summary
- polish monument overlay, hide bottom nav when modal is open
- add compact hero, milestones, goals, notes and activity panels with dark empty states
- replace ad-hoc loading and empty states with skeletons and cards

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68c02439460c832cb416cbc3d0039234