### PR TITLE
feat: show projects by default with expandable tasks

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -397,7 +397,7 @@ export default function SchedulePage() {
                               <motion.div
                                 key={tp.taskId}
                                 aria-label={`Task ${tItem.name}`}
-                                className="absolute left-16 right-2 flex items-center justify-between rounded-[var(--radius-lg)] bg-[var(--event-bg)] px-3 py-2 text-white"
+                                className="absolute left-16 right-2 flex items-center justify-between rounded-[var(--radius-lg)] bg-stone-700 px-3 py-2 text-white"
                                 style={tStyle}
                                 onClick={() =>
                                   setExpandedProjects(prev => {


### PR DESCRIPTION
## Summary
- remove tasks vs. projects toggle in schedule view
- display projects by default and expand into scheduled tasks on click

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c09faad504832c80832cf6db2975ee