### PR TITLE
feat(schedule): improve weekend day color

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,7 +17,8 @@
   --accent-red:#FF453A;
   --hairline:rgba(255,255,255,0.08);
   --dot:rgba(200,200,205,0.85);
-  --weekend-dim:rgba(255,255,255,0.12);
+  /* Weekend day numbers use a lighter gray for better readability */
+  --weekend-dim:rgba(255,255,255,0.4);
 
   /* existing aliases */
   --bg:var(--surface);


### PR DESCRIPTION
## Summary
- soften schedule weekend day numbers with lighter gray variable for readability

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c0ddba5118832cb03cf3c2b7f398dd