### PR TITLE
fix: align bottom nav with safe area

### DIFF
--- a/components/BottomBarNav.tsx
+++ b/components/BottomBarNav.tsx
@@ -63,7 +63,7 @@ export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavPro
 
   const mid = Math.ceil(items.length / 2);
   return (
-    <nav className="w-full bg-gray-900 text-gray-400">
+    <nav className="w-full">
       <div
         className="grid h-16 items-center"
         style={{

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -16,7 +16,10 @@ export default function BottomNav() {
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50" data-bottom-nav>
+    <div
+      className="fixed inset-x-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)] bg-gray-900 text-gray-400"
+      data-bottom-nav
+    >
       <div className="relative">
         <BottomBarNav
           items={items}


### PR DESCRIPTION
## Summary
- include safe area padding and background on BottomNav to remove offset
- let BottomBarNav rely on parent for background and text colors

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c19e402d4c832ca09bbf9b1456fb33