### PR TITLE
feat: add month view to schedule

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -17,6 +17,7 @@ import { DayTimeline } from '@/components/schedule/DayTimeline'
 import { FocusTimeline } from '@/components/schedule/FocusTimeline'
 import FlameEmber, { FlameLevel } from '@/components/FlameEmber'
 import { YearView } from '@/components/schedule/YearView'
+import { MonthView } from '@/components/schedule/MonthView'
 import { ScheduleTopBar } from '@/components/schedule/ScheduleTopBar'
 import EnergyPager from '@/components/schedule/EnergyPager'
 import {
@@ -62,7 +63,7 @@ export default function SchedulePage() {
 
   const initialViewParam = searchParams.get('view') as ScheduleView | null
   const initialView: ScheduleView =
-    initialViewParam && ['year', 'day', 'focus'].includes(initialViewParam)
+    initialViewParam && ['year', 'month', 'day', 'focus'].includes(initialViewParam)
       ? initialViewParam
       : 'year'
   const initialDate = searchParams.get('date')
@@ -251,7 +252,7 @@ export default function SchedulePage() {
 
         <div className="space-y-2">
           <EnergyPager
-            activeIndex={{ year: 0, day: 1, focus: 2 }[view]}
+            activeIndex={{ year: 0, month: 1, day: 2, focus: 3 }[view]}
             className="justify-center"
           />
         </div>
@@ -269,6 +270,16 @@ export default function SchedulePage() {
             {view === 'year' && (
               <ScheduleViewShell key="year">
                 <YearView
+                  energies={dayEnergies}
+                  selectedDate={currentDate}
+                  onSelectDate={handleDrillDown}
+                />
+              </ScheduleViewShell>
+            )}
+            {view === 'month' && (
+              <ScheduleViewShell key="month">
+                <MonthView
+                  date={currentDate}
                   energies={dayEnergies}
                   selectedDate={currentDate}
                   onSelectDate={handleDrillDown}

--- a/src/components/schedule/MiniMonth.tsx
+++ b/src/components/schedule/MiniMonth.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface MiniMonthProps {
+  year: number;
+  month: number; // 0-based
+  selectedDate?: Date;
+  onSelect?: (date: Date) => void;
+}
+
+/** A compact month grid used in the year view */
+export function MiniMonth({ year, month, selectedDate, onSelect }: MiniMonthProps) {
+  const date = new Date(year, month, 1);
+  const monthName = date.toLocaleString(undefined, { month: "short" });
+  const firstWeekday = date.getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const isSelectedMonth =
+    selectedDate &&
+    selectedDate.getFullYear() === year &&
+    selectedDate.getMonth() === month;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect?.(date)}
+      className="text-center text-[10px] p-1 rounded hover:bg-[var(--surface)]"
+    >
+      <div
+        className={cn(
+          "mb-1",
+          isSelectedMonth && "text-[var(--accent-red)] font-semibold"
+        )}
+      >
+        {monthName}
+      </div>
+      <div className="grid grid-cols-7 gap-[1px]">
+        {cells.map((d, i) => (
+          <div
+            key={i}
+            className="h-4 w-4 flex items-center justify-center"
+          >
+            {d ?? ""}
+          </div>
+        ))}
+      </div>
+    </button>
+  );
+}
+
+export default MiniMonth;
+

--- a/src/components/schedule/YearView.tsx
+++ b/src/components/schedule/YearView.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { MonthView } from "./MonthView";
 import type { FlameLevel } from "@/components/FlameEmber";
+import MiniMonth from "./MiniMonth";
 
 interface YearViewProps {
   events?: Record<string, number>;
@@ -13,30 +13,29 @@ interface YearViewProps {
 }
 
 /**
- * Scrollable list of months centered on the current month.
- * Uses virtualization to only render visible months and
- * dynamically load more as the user scrolls.
+ * Virtualized scrollable list of years. Each year displays a grid of months
+ * similar to the iOS calendar year view.
  */
 export function YearView({
-  events,
-  energies,
+  events: _events,
+  energies: _energies,
   selectedDate,
   onSelectDate,
 }: YearViewProps) {
   const today = useMemo(() => new Date(), []);
-  const totalMonths = 2400; // ~200 years
-  const currentIndex = Math.floor(totalMonths / 2);
+  const totalYears = 400; // ~200 years back and forward
+  const currentIndex = Math.floor(totalYears / 2);
 
   const parentRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
-    count: totalMonths,
+    count: totalYears,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => 360,
+    estimateSize: () => 420,
     overscan: 2,
   });
 
   useEffect(() => {
-    virtualizer.scrollToIndex(currentIndex, { align: "start" });
+    virtualizer.scrollToIndex(currentIndex, { align: "center" });
   }, [virtualizer, currentIndex]);
 
   return (
@@ -49,33 +48,28 @@ export function YearView({
         }}
       >
         {virtualizer.getVirtualItems().map((item) => {
-          const date = new Date(
-            today.getFullYear(),
-            today.getMonth() + item.index - currentIndex,
-            1
-          );
+          const year = today.getFullYear() + item.index - currentIndex;
           return (
             <div
               key={item.key}
               ref={virtualizer.measureElement}
-              className="absolute top-0 left-0 w-full mb-4 space-y-2"
+              className="absolute top-0 left-0 w-full mb-4"
               style={{ transform: `translateY(${item.start}px)` }}
             >
-              <h2 className="px-2 text-sm font-semibold text-[var(--text-primary)]">
-                {date.toLocaleDateString(undefined, {
-                  month: "long",
-                  year: "numeric",
-                })}
+              <h2 className="px-2 text-lg font-semibold text-[var(--text-primary)] mb-2">
+                {year}
               </h2>
-              <MonthView
-                date={date}
-                events={events}
-                energies={energies}
-                selectedDate={selectedDate}
-                onSelectDate={onSelectDate}
-                showAdjacentMonths={false}
-                showMonthLabel={false}
-              />
+              <div className="grid grid-cols-3 gap-2 px-2">
+                {Array.from({ length: 12 }).map((_, m) => (
+                  <MiniMonth
+                    key={m}
+                    year={year}
+                    month={m}
+                    selectedDate={selectedDate}
+                    onSelect={onSelectDate}
+                  />
+                ))}
+              </div>
             </div>
           );
         })}

--- a/src/components/schedule/viewUtils.ts
+++ b/src/components/schedule/viewUtils.ts
@@ -1,10 +1,12 @@
-export type ScheduleView = 'year' | 'day' | 'focus';
+export type ScheduleView = 'year' | 'month' | 'day' | 'focus';
 
 export function getParentView(view: ScheduleView): ScheduleView {
   switch (view) {
     case 'focus':
       return 'day';
     case 'day':
+      return 'month';
+    case 'month':
       return 'year';
     default:
       return view;
@@ -17,6 +19,8 @@ export function getChildView(
 ): { view: ScheduleView; date: Date } {
   switch (view) {
     case 'year':
+      return { view: 'month', date: payload };
+    case 'month':
       return { view: 'day', date: payload };
     case 'day':
       return { view: 'focus', date: payload };
@@ -24,3 +28,4 @@ export function getChildView(
       return { view, date: payload };
   }
 }
+


### PR DESCRIPTION
## Summary
- add virtualized year grid with compact months
- support month-level navigation between year and day views
- expose new month view on schedule page

## Testing
- `pnpm test:run`

------
https://chatgpt.com/codex/tasks/task_e_68c19f18b8c0832c862d69f4e5dd6e5a