### PR TITLE
Separate month view weeks

### DIFF
--- a/src/components/schedule/MonthView.tsx
+++ b/src/components/schedule/MonthView.tsx
@@ -257,7 +257,6 @@ const DayCell = React.memo(function DayCell({
   const isWeekend = dayDate
     ? dayDate.getDay() === 0 || dayDate.getDay() === 6
     : false;
-  const inMonth = cell ? cell.offset === 0 : false;
   const dotOpacity = isWeekend ? 0.85 : 1;
 
   const dots = useMemo(() => {
@@ -285,7 +284,7 @@ const DayCell = React.memo(function DayCell({
     return <div className="mt-1 flex justify-center gap-[4px]">{items}</div>;
   }, [count, dotOpacity]);
 
-  if (!cell || !dayDate) return <div className="min-h-[48px]" />;
+  if (!cell || !dayDate || cell.offset !== 0) return <div className="min-h-[48px]" />;
 
   return (
     <button
@@ -294,8 +293,7 @@ const DayCell = React.memo(function DayCell({
       aria-current={isSelected ? "date" : undefined}
       className={cn(
         "relative flex min-h-[48px] flex-col items-center justify-center text-[var(--text-primary)] focus:outline-none",
-        isWeekend && !isSelected && "text-[var(--weekend-dim)]",
-        !inMonth && !isSelected && !isToday && "text-[var(--text-muted)]"
+        isWeekend && !isSelected && "text-[var(--weekend-dim)]"
       )}
     >
       <div

--- a/src/components/schedule/MonthView.tsx
+++ b/src/components/schedule/MonthView.tsx
@@ -123,17 +123,18 @@ function MonthGrid({
     const startWeekday = first.getDay();
     const daysInMonth = new Date(year, month + 1, 0).getDate();
     const cells: Cell[] = [];
-    const prevMonthDays = new Date(year, month, 0).getDate();
 
+    // Fill leading days with empty cells to keep weeks separate
     for (let i = startWeekday - 1; i >= 0; i--) {
-      cells.push({ day: prevMonthDays - i, offset: -1 });
+      cells.push(null);
     }
+    // Add all days of the current month
     for (let d = 1; d <= daysInMonth; d++) {
       cells.push({ day: d, offset: 0 });
     }
-    let nextDay = 1;
+    // Fill trailing days with empty cells
     while (cells.length % 7 !== 0) {
-      cells.push({ day: nextDay++, offset: 1 });
+      cells.push(null);
     }
     const weeks: Week[] = [];
     for (let i = 0; i < cells.length; i += 7) {


### PR DESCRIPTION
## Summary
- Avoid showing adjacent months' days in month view grids
- Fill leading and trailing weeks with empty cells

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c1e313c364832c96ac87ce49a74f16