### PR TITLE
feat: add monument and skill filters

### DIFF
--- a/lib/queries/goals.ts
+++ b/lib/queries/goals.ts
@@ -9,6 +9,7 @@ export interface Goal {
   created_at: string;
   active?: boolean;
   status?: string;
+  monument_id?: string | null;
 }
 
 export async function getGoalsForUser(userId: string): Promise<Goal[]> {
@@ -19,7 +20,9 @@ export async function getGoalsForUser(userId: string): Promise<Goal[]> {
 
   const { data, error } = await supabase
     .from("goals")
-    .select("id, name, priority, energy, why, created_at, active, status")
+    .select(
+      "id, name, priority, energy, why, created_at, active, status, monument_id"
+    )
     .eq("user_id", userId)
     .order("created_at", { ascending: false });
 
@@ -39,7 +42,9 @@ export async function getGoalById(goalId: string): Promise<Goal | null> {
 
   const { data, error } = await supabase
     .from("goals")
-    .select("id, name, priority, energy, why, created_at, active, status")
+    .select(
+      "id, name, priority, energy, why, created_at, active, status, monument_id"
+    )
     .eq("id", goalId)
     .single();
 

--- a/src/app/(app)/goals/components/GoalsUtilityBar.tsx
+++ b/src/app/(app)/goals/components/GoalsUtilityBar.tsx
@@ -22,6 +22,12 @@ interface GoalsUtilityBarProps {
   onPriority(p: PriorityFilter): void;
   sort: SortOption;
   onSort(s: SortOption): void;
+  monuments: { id: string; title: string }[];
+  monument: string;
+  onMonument(id: string): void;
+  skills: { id: string; name: string }[];
+  skill: string;
+  onSkill(id: string): void;
 }
 
 export function GoalsUtilityBar({
@@ -33,6 +39,12 @@ export function GoalsUtilityBar({
   onPriority,
   sort,
   onSort,
+  monuments,
+  monument,
+  onMonument,
+  skills,
+  skill,
+  onSkill,
 }: GoalsUtilityBarProps) {
   const [local, setLocal] = useState(search);
 
@@ -50,7 +62,7 @@ export function GoalsUtilityBar({
           placeholder="Search goals"
           className="w-full px-3 py-2 rounded-md bg-gray-800 text-sm focus:outline-none"
         />
-        <div className="flex items-center gap-1 sm:gap-2">
+        <div className="flex items-center gap-1 sm:gap-2 flex-wrap">
           <select
             value={energy}
             onChange={(e) => onEnergy(e.target.value as EnergyFilter)}
@@ -73,6 +85,30 @@ export function GoalsUtilityBar({
             <option value="Low">Low</option>
             <option value="Medium">Medium</option>
             <option value="High">High</option>
+          </select>
+          <select
+            value={monument}
+            onChange={(e) => onMonument(e.target.value)}
+            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+          >
+            <option value="All">Monument: All</option>
+            {monuments.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.title}
+              </option>
+            ))}
+          </select>
+          <select
+            value={skill}
+            onChange={(e) => onSkill(e.target.value)}
+            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+          >
+            <option value="All">Skill: All</option>
+            {skills.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
           </select>
           <select
             value={sort}

--- a/src/app/(app)/goals/components/GoalsUtilityBar.tsx
+++ b/src/app/(app)/goals/components/GoalsUtilityBar.tsx
@@ -62,11 +62,11 @@ export function GoalsUtilityBar({
           placeholder="Search goals"
           className="w-full px-3 py-2 rounded-md bg-gray-800 text-sm focus:outline-none"
         />
-        <div className="flex items-center gap-1 sm:gap-2 flex-wrap">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2">
           <select
             value={energy}
             onChange={(e) => onEnergy(e.target.value as EnergyFilter)}
-            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="All">Energy: All</option>
             <option value="No">No</option>
@@ -79,7 +79,7 @@ export function GoalsUtilityBar({
           <select
             value={priority}
             onChange={(e) => onPriority(e.target.value as PriorityFilter)}
-            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="All">Priority: All</option>
             <option value="Low">Low</option>
@@ -89,7 +89,7 @@ export function GoalsUtilityBar({
           <select
             value={monument}
             onChange={(e) => onMonument(e.target.value)}
-            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="All">Monument: All</option>
             {monuments.map((m) => (
@@ -101,7 +101,7 @@ export function GoalsUtilityBar({
           <select
             value={skill}
             onChange={(e) => onSkill(e.target.value)}
-            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="All">Skill: All</option>
             {skills.map((s) => (
@@ -113,7 +113,7 @@ export function GoalsUtilityBar({
           <select
             value={sort}
             onChange={(e) => onSort(e.target.value as SortOption)}
-            className="ml-auto bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="A→Z">A→Z</option>
             <option value="Due Soon">Due Soon</option>

--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -26,4 +26,7 @@ export interface Goal {
   active: boolean;
   updatedAt: string;
   projects: Project[];
+  monumentId?: string | null;
+  /** Associated skill IDs */
+  skills?: string[];
 }


### PR DESCRIPTION
## Summary
- expand goal queries and types with monument ID and associated skills
- add monument and skill options to goals utility bar
- filter goals by selected monument or skill on goals page

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c7b9f45020832cb84fb07106dd37b5