### PR TITLE
Switch to monochrome accent palette

### DIFF
--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -31,11 +31,11 @@ export default function TopNav() {
   }, [supabase]);
 
   return (
-    <nav className="w-full flex items-center justify-between px-4 py-2 bg-gray-900 text-white">
+    <nav className="w-full flex items-center justify-between px-4 py-2 bg-surface text-surface-foreground">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            className="h-11 w-11 p-2 hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-[#9966CC]"
+            className="h-11 w-11 p-2 hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6" />
@@ -43,7 +43,7 @@ export default function TopNav() {
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          className="bg-[#1C1F22] border-[#2F343A] text-[#E6E6E6]"
+          className="bg-surface-elevated border-border text-surface-foreground"
         >
           <DropdownMenuItem asChild>
             <Link href="/analytics">Analytics</Link>

--- a/components/TopNavAvatar.tsx
+++ b/components/TopNavAvatar.tsx
@@ -98,7 +98,7 @@ export default function TopNavAvatar({ profile, userId }: TopNavAvatarProps) {
       <DropdownMenuTrigger asChild>
         <button
           onClick={handleAvatarClick}
-          className="h-8 w-8 rounded-full overflow-hidden hover:ring-2 hover:ring-blue-400 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          className="h-8 w-8 rounded-full overflow-hidden hover:ring-2 hover:ring-accent transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-accent"
           data-testid="topnav-avatar"
         >
           <Avatar className="h-8 w-8">

--- a/components/ui/CreateSheet.tsx
+++ b/components/ui/CreateSheet.tsx
@@ -10,10 +10,10 @@ interface CreateSheetProps {
 }
 
 const createActions = [
-  { name: 'Add Goal', icon: Target, href: '/goals/new', color: 'bg-blue-500' },
-  { name: 'Add Project', icon: FolderOpen, href: '/projects/new', color: 'bg-purple-500' },
-  { name: 'Add Task', icon: CheckSquare, href: '/tasks/new', color: 'bg-green-500' },
-  { name: 'Add Habit', icon: Repeat, href: '/habits/new', color: 'bg-orange-500' }
+  { name: 'Add Goal', icon: Target, href: '/goals/new', color: 'bg-primary' },
+  { name: 'Add Project', icon: FolderOpen, href: '/projects/new', color: 'bg-accent' },
+  { name: 'Add Task', icon: CheckSquare, href: '/tasks/new', color: 'bg-primary/80' },
+  { name: 'Add Habit', icon: Repeat, href: '/habits/new', color: 'bg-accent/80' }
 ]
 
 export function CreateSheet({ isOpen, onClose, selectedTime }: CreateSheetProps) {

--- a/components/ui/EventModal.tsx
+++ b/components/ui/EventModal.tsx
@@ -756,7 +756,7 @@ export function EventModal({ isOpen, onClose, eventType }: EventModalProps) {
                 (eventType === "PROJECT" && !formData.goal_id) ||
                 (eventType === "TASK" && !formData.project_id)
               }
-              className="flex-1 bg-blue-600 hover:bg-blue-700 h-10 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 bg-primary hover:bg-primary/90 h-10 text-sm disabled:opacity-50 disabled:cursor-not-allowed text-primary-foreground"
             >
               {loading ? "Creating..." : `Create ${eventType}`}
             </Button>

--- a/components/ui/QuickPeek.tsx
+++ b/components/ui/QuickPeek.tsx
@@ -68,10 +68,10 @@ export function QuickPeek({ event, isOpen, onClose, onEdit, onDelete, onMarkDone
           
           <button
             onClick={onEdit}
-            className="w-full flex items-center gap-3 p-3 rounded-xl bg-blue-500/10 hover:bg-blue-500/20 border border-blue-500/20 transition-colors text-left"
+            className="w-full flex items-center gap-3 p-3 rounded-xl bg-accent/10 hover:bg-accent/20 border border-accent/20 transition-colors text-left"
           >
-            <Edit className="w-5 h-5 text-blue-400" />
-            <span className="text-blue-400 font-medium">Edit</span>
+            <Edit className="w-5 h-5 text-accent" />
+            <span className="text-accent font-medium">Edit</span>
           </button>
           
           <button

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -45,7 +45,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
         <button
           type="button"
           onClick={() => setIsOpen(!isOpen)}
-          className="flex h-10 w-full items-center justify-between rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white ring-offset-background placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          className="flex h-10 w-full items-center justify-between rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white ring-offset-background placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <span className="block truncate">
             {selectedLabel || "Select option..."}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -95,7 +95,7 @@ function Toast({
       case "warning":
         return <AlertTriangle className="h-5 w-5 text-yellow-500" />;
       case "info":
-        return <Info className="h-5 w-5 text-blue-500" />;
+        return <Info className="h-5 w-5 text-accent" />;
     }
   };
 
@@ -108,7 +108,7 @@ function Toast({
       case "warning":
         return "border-yellow-200 bg-yellow-50";
       case "info":
-        return "border-blue-200 bg-blue-50";
+        return "border-highlight bg-highlight/20";
     }
   };
 
@@ -129,7 +129,7 @@ function Toast({
           {toast.action && (
             <button
               onClick={toast.action.onClick}
-              className="text-sm font-medium text-blue-600 hover:text-blue-500"
+              className="text-sm font-medium text-accent hover:text-primary"
             >
               {toast.action.label}
             </button>

--- a/lib/db/profile-management.ts
+++ b/lib/db/profile-management.ts
@@ -404,25 +404,25 @@ export function getPlatformIcon(platform: string): string {
 
 export function getPlatformColor(platform: string): string {
   const platformColors: Record<string, string> = {
-    instagram: "bg-gradient-to-r from-purple-500 to-pink-500",
-    facebook: "bg-blue-600",
-    twitter: "bg-blue-400",
+    instagram: "bg-gradient-to-r from-highlight to-primary",
+    facebook: "bg-primary",
+    twitter: "bg-accent",
     x: "bg-black",
-    linkedin: "bg-blue-700",
-    youtube: "bg-red-600",
+    linkedin: "bg-primary",
+    youtube: "bg-primary",
     tiktok: "bg-black",
-    email: "bg-gray-600",
-    website: "bg-blue-500",
-    github: "bg-gray-800",
-    discord: "bg-indigo-600",
-    snapchat: "bg-yellow-400",
-    pinterest: "bg-red-500",
-    reddit: "bg-orange-500",
-    twitch: "bg-purple-600",
-    spotify: "bg-green-500",
-    apple: "bg-gray-900",
-    google: "bg-blue-500",
+    email: "bg-surface-elevated",
+    website: "bg-accent",
+    github: "bg-surface",
+    discord: "bg-accent",
+    snapchat: "bg-accent",
+    pinterest: "bg-accent",
+    reddit: "bg-accent",
+    twitch: "bg-accent",
+    spotify: "bg-accent",
+    apple: "bg-surface",
+    google: "bg-primary",
   };
 
-  return platformColors[platform.toLowerCase()] || "bg-gray-600";
+  return platformColors[platform.toLowerCase()] || "bg-primary";
 }

--- a/src/app/(app)/dashboard/test-views/page.tsx
+++ b/src/app/(app)/dashboard/test-views/page.tsx
@@ -126,8 +126,8 @@ export default async function TestViewsPage() {
           </li>
         </ul>
 
-        <div className="mt-4 p-4 bg-blue-900/20 rounded-lg border border-blue-500/30">
-          <div className="text-blue-300 text-sm">
+        <div className="mt-4 p-4 bg-accent/20 rounded-lg border border-accent/30">
+          <div className="text-accent text-sm">
             <strong>Note:</strong> This page must be accessed by an
             authenticated user to properly test RLS policies. If you see
             authentication errors, ensure you&apos;re logged in.

--- a/src/app/(app)/debug/css/page.tsx
+++ b/src/app/(app)/debug/css/page.tsx
@@ -4,7 +4,7 @@ export default function Page() {
       <div className="text-3xl font-bold">CSS Debug</div>
       <div className="grid grid-cols-3 gap-4">
         <div className="bg-emerald-500 h-10 rounded" />
-        <div className="bg-blue-500 h-10 rounded" />
+        <div className="bg-primary h-10 rounded" />
         <div className="bg-rose-500 h-10 rounded" />
       </div>
       <button className="px-4 py-2 rounded-md bg-zinc-900 text-white data-[state=open]:bg-zinc-700">

--- a/src/app/(app)/debug/env/page.tsx
+++ b/src/app/(app)/debug/env/page.tsx
@@ -126,7 +126,7 @@ export default function DebugEnvPage() {
         {/* Quick Summary */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
           <div className="bg-gray-800 p-4 rounded-lg">
-            <h3 className="font-semibold text-blue-400">Environment</h3>
+            <h3 className="font-semibold text-accent">Environment</h3>
             <p className="text-2xl font-bold">{envInfo.environment}</p>
           </div>
           <div className="bg-gray-800 p-4 rounded-lg">
@@ -143,7 +143,7 @@ export default function DebugEnvPage() {
         <div className="space-y-6">
           {/* Build Information */}
           <div className="bg-gray-800 p-6 rounded-lg">
-            <h2 className="text-xl font-bold mb-4 text-blue-400">
+            <h2 className="text-xl font-bold mb-4 text-accent">
               🚀 Build Information
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -286,7 +286,7 @@ export default function DebugEnvPage() {
         <div className="mt-8 flex flex-wrap gap-4">
           <button
             onClick={() => window.location.reload()}
-            className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg font-semibold"
+            className="bg-primary hover:bg-primary/90 px-4 py-2 rounded-lg font-semibold text-primary-foreground"
           >
             🔄 Refresh Data
           </button>

--- a/src/app/(app)/goals/components/EmptyState.tsx
+++ b/src/app/(app)/goals/components/EmptyState.tsx
@@ -13,7 +13,7 @@ export function EmptyState({ onCreate }: EmptyStateProps) {
       <p className="text-gray-400">No goals yet</p>
       <button
         onClick={onCreate}
-        className="bg-blue-600 hover:bg-blue-500 px-4 py-2 rounded-md text-sm"
+        className="bg-primary hover:bg-primary/90 px-4 py-2 rounded-md text-sm text-primary-foreground"
       >
         Create Goal
       </button>

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -55,7 +55,7 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
             <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-300">
               <div className="w-10 h-2 bg-gray-700 rounded-full overflow-hidden">
                 <div
-                  className="h-full bg-blue-500"
+                  className="h-full bg-primary"
                   style={{ width: `${goal.progress}%` }}
                 />
               </div>

--- a/src/app/(app)/goals/components/GoalDrawer.tsx
+++ b/src/app/(app)/goals/components/GoalDrawer.tsx
@@ -136,7 +136,10 @@ export function GoalDrawer({
             <button type="button" onClick={onClose} className="px-3 py-2 rounded bg-gray-700">
               Cancel
             </button>
-            <button type="submit" className="px-3 py-2 rounded bg-blue-600">
+            <button
+              type="submit"
+              className="px-3 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90"
+            >
               {editing ? "Save" : "Add"}
             </button>
           </div>

--- a/src/app/(app)/goals/components/GoalsHeader.tsx
+++ b/src/app/(app)/goals/components/GoalsHeader.tsx
@@ -8,14 +8,14 @@ interface GoalsHeaderProps {
 
 export function GoalsHeader({ onCreate }: GoalsHeaderProps) {
   return (
-    <header className="px-4 py-4 flex items-center justify-between bg-gray-900">
+    <header className="px-4 py-4 flex items-center justify-between bg-surface text-surface-foreground">
       <div>
         <h1 className="text-2xl font-bold">Goals</h1>
         <p className="text-sm text-gray-400">Track and manage your goals</p>
       </div>
       <button
         onClick={onCreate}
-        className="flex items-center gap-2 bg-blue-600 hover:bg-blue-500 active:bg-blue-700 px-3 py-2 rounded-md text-sm"
+        className="flex items-center gap-2 bg-primary hover:bg-primary/90 active:bg-primary/80 px-3 py-2 rounded-md text-sm text-primary-foreground"
       >
         <Plus className="w-4 h-4" /> Create Goal
       </button>

--- a/src/app/(app)/goals/components/ProjectRow.tsx
+++ b/src/app/(app)/goals/components/ProjectRow.tsx
@@ -33,7 +33,7 @@ export function ProjectRow({ project }: ProjectRowProps) {
         <div className="flex items-center gap-2">
           <div className="w-16 h-2 bg-gray-700 rounded-full overflow-hidden">
             <div
-              className="h-full bg-blue-500"
+              className="h-full bg-primary"
               style={{ width: `${project.progress}%` }}
             />
           </div>

--- a/src/app/(app)/goals/components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/components/ProjectsDropdown.tsx
@@ -39,7 +39,7 @@ export function ProjectsDropdown({
               value={100}
               className="mb-2"
               trackClass="bg-gray-700"
-              barClass="bg-blue-500 animate-pulse"
+              barClass="bg-primary animate-pulse"
             />
           ) : projects.length > 0 ? (
             <div className="space-y-2">
@@ -50,12 +50,12 @@ export function ProjectsDropdown({
           ) : (
             <div className="text-sm text-gray-400">
               No projects linked yet
-              <button className="ml-2 text-blue-400">Add Project</button>
+              <button className="ml-2 text-accent">Add Project</button>
             </div>
           )}
           <Link
             href="/projects"
-            className="mt-3 inline-block text-xs text-blue-400"
+            className="mt-3 inline-block text-xs text-accent"
           >
             View all projects
           </Link>

--- a/src/app/(app)/profile/LinkMeProfile.tsx
+++ b/src/app/(app)/profile/LinkMeProfile.tsx
@@ -130,7 +130,7 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
   const displayCards = contentCards.length > 0 ? contentCards : defaultContentCards;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-highlight/40 via-highlight/20 to-white">
       {/* Top Navigation Bar */}
       <div className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-200">
         <div className="flex items-center justify-between px-4 py-3">
@@ -161,12 +161,12 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
       <div className="max-w-md mx-auto px-4 py-6">
         <Card className="overflow-hidden shadow-xl border-0">
           {/* Background Image Section */}
-          <div 
-            className="relative h-48 bg-gradient-to-br from-blue-600 to-purple-700"
+          <div
+            className="relative h-48 bg-gradient-to-br from-primary to-accent"
             style={{
-              background: profile.banner_url 
+              background: profile.banner_url
                 ? `linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(${profile.banner_url})`
-                : `linear-gradient(135deg, ${profile.theme_color || '#3B82F6'} 0%, ${profile.accent_color || '#8B5CF6'} 100%)`,
+                : `linear-gradient(135deg, ${profile.theme_color || '#2F2F33'} 0%, ${profile.accent_color || '#51515A'} 100%)`,
               backgroundSize: 'cover',
               backgroundPosition: 'center'
             }}
@@ -180,7 +180,7 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
               <div className="flex items-center space-x-2 mb-2">
                 <h1 className="text-2xl font-bold">{profile.name || "Your Name"}</h1>
                 {profile.verified && (
-                  <div className="w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
+                  <div className="w-5 h-5 bg-accent rounded-full flex items-center justify-center">
                     <span className="text-xs font-bold text-white">✓</span>
                   </div>
                 )}
@@ -235,13 +235,13 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
               ) : (
                 // Default social icons if none exist
                 [
-                  { platform: "instagram", icon: "📷", color: "bg-gradient-to-r from-purple-500 to-pink-500" },
-                  { platform: "facebook", icon: "📘", color: "bg-blue-600" },
-                  { platform: "twitter", icon: "🐦", color: "bg-blue-400" },
-                  { platform: "linkedin", icon: "💼", color: "bg-blue-700" },
-                  { platform: "youtube", icon: "📺", color: "bg-red-600" },
+                  { platform: "instagram", icon: "📷", color: "bg-gradient-to-r from-highlight to-primary" },
+                  { platform: "facebook", icon: "📘", color: "bg-primary" },
+                  { platform: "twitter", icon: "🐦", color: "bg-accent" },
+                  { platform: "linkedin", icon: "💼", color: "bg-primary" },
+                  { platform: "youtube", icon: "📺", color: "bg-primary" },
                   { platform: "tiktok", icon: "🎵", color: "bg-black" },
-                  { platform: "email", icon: "✉️", color: "bg-gray-600" },
+                  { platform: "email", icon: "✉️", color: "bg-surface-elevated" },
                 ].map((social) => (
                   <div
                     key={social.platform}
@@ -264,21 +264,21 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
                   rel="noopener noreferrer"
                   className="block group"
                 >
-                  <div className="relative overflow-hidden rounded-lg border border-gray-200 hover:border-blue-300 transition-all duration-200 hover:shadow-lg">
+                  <div className="relative overflow-hidden rounded-lg border border-gray-200 hover:border-accent transition-all duration-200 hover:shadow-lg">
                     {item.thumbnail_url ? (
                       <div className="aspect-video bg-cover bg-center" style={{ backgroundImage: `url(${item.thumbnail_url})` }} />
                     ) : (
                       <div className="aspect-video bg-gradient-to-br from-gray-100 to-gray-200 flex items-center justify-center">
                         <div className="text-center">
-                          <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-2">
-                            <ExternalLink className="h-8 w-8 text-blue-600" />
+                          <div className="w-16 h-16 bg-highlight/40 rounded-full flex items-center justify-center mx-auto mb-2">
+                            <ExternalLink className="h-8 w-8 text-accent" />
                           </div>
                           <p className="text-sm text-gray-500">{item.category || "Link"}</p>
                         </div>
                       </div>
                     )}
                     <div className="p-4">
-                      <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+                      <h3 className="font-semibold text-gray-900 group-hover:text-accent transition-colors">
                         {item.title}
                       </h3>
                       {item.description && (
@@ -295,7 +295,7 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
             {/* Add Content Button */}
             <div className="mt-6 text-center">
               <Link href="/profile/edit">
-                <Button variant="outline" className="w-full border-dashed border-2 border-gray-300 hover:border-blue-400 hover:bg-blue-50">
+                <Button variant="outline" className="w-full border-dashed border-2 border-gray-300 hover:border-accent hover:bg-highlight/20">
                   <Plus className="h-5 w-5 mr-2" />
                   Add More Content
                 </Button>
@@ -305,7 +305,7 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
             {/* Edit Profile Button */}
             <div className="mt-8 text-center">
               <Link href="/profile/edit">
-                <Button className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white px-8 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200">
+                <Button className="bg-gradient-to-r from-primary to-accent hover:from-primary/90 hover:to-accent/90 text-white px-8 py-3 rounded-full shadow-lg hover:shadow-xl transition-all duration-200">
                   <Edit3 className="h-5 w-5 mr-2" />
                   Edit Profile
                 </Button>

--- a/src/app/(app)/profile/edit/ProfileEditForm.tsx
+++ b/src/app/(app)/profile/edit/ProfileEditForm.tsx
@@ -270,7 +270,7 @@ export default function ProfileEditForm({
                     {initials}
                   </AvatarFallback>
                 </Avatar>
-                <label className="absolute bottom-0 right-0 bg-blue-600 text-white rounded-full p-2 cursor-pointer hover:bg-blue-700 transition-colors">
+                <label className="absolute bottom-0 right-0 bg-primary text-primary-foreground rounded-full p-2 cursor-pointer hover:bg-primary/90 transition-colors">
                   <Camera className="h-4 w-4" />
                   <input
                     type="file"

--- a/src/app/(app)/profile/edit/page.tsx
+++ b/src/app/(app)/profile/edit/page.tsx
@@ -169,7 +169,7 @@ export default function ProfileEditPage() {
     return (
       <div className="min-h-screen bg-[#0F0F12] flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
           <p className="text-zinc-400">Loading profile...</p>
         </div>
       </div>
@@ -183,7 +183,7 @@ export default function ProfileEditPage() {
           <p className="text-red-400 mb-4">{error}</p>
           <button
             onClick={() => router.push("/dashboard")}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90"
           >
             Back to Dashboard
           </button>
@@ -285,7 +285,7 @@ export default function ProfileEditPage() {
               {/* Name */}
               <div className="space-y-2">
                 <Label htmlFor="name" className="flex items-center space-x-2">
-                  <User className="h-4 w-4 text-blue-600" />
+                  <User className="h-4 w-4 text-accent" />
                   <span>Full Name</span>
                 </Label>
                 <Input
@@ -371,7 +371,7 @@ export default function ProfileEditPage() {
                 <Button
                   type="submit"
                   disabled={saving}
-                  className="w-full h-14 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white text-lg font-semibold rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"
+                  className="w-full h-14 bg-gradient-to-r from-primary to-accent hover:from-primary/90 hover:to-accent/90 text-white text-lg font-semibold rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"
                 >
                   {saving ? (
                     <div className="flex items-center space-x-2">

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -37,9 +37,9 @@ export default function ProfilePage() {
 
   // Show loading while redirecting
   return (
-    <div className="min-h-screen bg-slate-900 flex items-center justify-center">
+    <div className="min-h-screen bg-surface flex items-center justify-center">
       <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-accent mx-auto mb-4"></div>
         <p className="text-white/70">Loading your profile...</p>
       </div>
     </div>

--- a/src/app/(app)/skills/components/SkillDrawer.tsx
+++ b/src/app/(app)/skills/components/SkillDrawer.tsx
@@ -168,7 +168,10 @@ export function SkillDrawer({
             >
               Cancel
             </button>
-            <button type="submit" className="px-3 py-2 rounded bg-blue-600">
+            <button
+              type="submit"
+              className="px-3 py-2 rounded bg-primary text-primary-foreground hover:bg-primary/90"
+            >
               {editing ? "Save" : "Add"}
             </button>
           </div>

--- a/src/app/dev/cats-skills/page.tsx
+++ b/src/app/dev/cats-skills/page.tsx
@@ -125,7 +125,7 @@ export default function CatsSkillsDebugPage() {
   }
 
   return (
-    <div className="p-6 text-white max-w-4xl mx-auto">
+    <div className="p-6 text-surface-foreground max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold mb-6">CATs & Skills Debug</h1>
       
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -134,7 +134,7 @@ export default function CatsSkillsDebugPage() {
           <h2 className="text-xl font-semibold mb-4">Summary</h2>
           <div className="space-y-2">
             <div>User ID: <code className="text-sm bg-slate-700 px-2 py-1 rounded">{debugData.userId}</code></div>
-            <div>Total CATs: <span className="text-2xl font-bold text-blue-400">{debugData.catsCount}</span></div>
+            <div>Total CATs: <span className="text-2xl font-bold text-accent">{debugData.catsCount}</span></div>
             <div>Total Skills: <span className="text-2xl font-bold text-green-400">{debugData.skillsCount}</span></div>
             <div>Uncategorized Skills: <span className="text-2xl font-bold text-yellow-400">{debugData.uncategorizedSkillsCount}</span></div>
           </div>
@@ -175,7 +175,7 @@ export default function CatsSkillsDebugPage() {
       <div className="mt-6 text-center">
         <button
           onClick={fetchDebugData}
-          className="bg-blue-600 hover:bg-blue-700 px-6 py-3 rounded-lg font-medium"
+          className="bg-primary hover:bg-primary/90 px-6 py-3 rounded-lg font-medium text-primary-foreground"
         >
           Refresh Data
         </button>

--- a/src/app/dev/schedule/day-timeline/page.tsx
+++ b/src/app/dev/schedule/day-timeline/page.tsx
@@ -10,12 +10,12 @@ export default function DayTimelinePreview() {
     { id: 3, start: 15 * 60 + 15, end: 16 * 60, title: "Deep work" },
   ];
   return (
-    <div className="p-4 text-white">
+    <div className="p-4 text-surface-foreground">
       <DayTimeline startHour={startHour} endHour={20} date={new Date()}>
         {events.map((e) => (
           <div
             key={e.id}
-            className="absolute left-16 right-2 rounded bg-blue-600/60 px-3 py-1 text-xs"
+            className="absolute left-16 right-2 rounded bg-primary/60 px-3 py-1 text-xs"
             style={{
               top: (e.start - startHour * 60) * 2,
               height: (e.end - e.start) * 2,

--- a/src/app/dev/schedule/focus-timeline/page.tsx
+++ b/src/app/dev/schedule/focus-timeline/page.tsx
@@ -10,12 +10,12 @@ export default function FocusTimelinePreview() {
     { id: 2, start: start + 60, end: start + 90, title: "Second task" },
   ];
   return (
-    <div className="p-4 text-white">
+    <div className="p-4 text-surface-foreground">
       <FocusTimeline>
         {events.map((e) => (
           <div
             key={e.id}
-            className="absolute left-16 right-2 rounded bg-blue-600/60 px-3 py-1 text-xs"
+            className="absolute left-16 right-2 rounded bg-primary/60 px-3 py-1 text-xs"
             style={{ top: (e.start - start) * 2, height: (e.end - e.start) * 2 }}
           >
             {e.title}

--- a/src/app/dev/skills-check/page.tsx
+++ b/src/app/dev/skills-check/page.tsx
@@ -116,20 +116,20 @@ export default function SkillsCheckPage() {
         </table>
       </div>
 
-      <div className="mt-6 p-4 bg-blue-50 rounded-lg">
-        <h3 className="text-lg font-medium text-blue-900 mb-2">Summary</h3>
-        <p className="text-blue-700">
+      <div className="mt-6 p-4 bg-highlight/20 rounded-lg">
+        <h3 className="text-lg font-medium text-surface mb-2">Summary</h3>
+        <p className="text-accent">
           Total skills: <strong>{skills.length}</strong>
         </p>
-        <p className="text-blue-700">
+        <p className="text-accent">
           Skills with icons:{" "}
           <strong>{skills.filter((s) => s.icon).length}</strong>
         </p>
-        <p className="text-blue-700">
+        <p className="text-accent">
           Skills with names:{" "}
           <strong>{skills.filter((s) => s.name).length}</strong>
         </p>
-        <p className="text-blue-700">
+        <p className="text-accent">
           Skills with categories:{" "}
           <strong>{skills.filter((s) => s.cat_id).length}</strong>
         </p>

--- a/src/components/FlameEmber.tsx
+++ b/src/components/FlameEmber.tsx
@@ -186,10 +186,10 @@ function LevelFlame({ level, profile, palette }: { level: FlameLevel; profile: P
   );
 }
 
-/** ————— ULTRA: Blue outer, red middle, white highlights ————— */
+/** ————— ULTRA: Monochrome outer, red middle, white highlights ————— */
 function UltraFlameBlue() {
   return (
-    <svg viewBox="0 0 100 120" width="100%" height="100%" role="img" aria-label="Ultra energy flame (blue/red)">
+    <svg viewBox="0 0 100 120" width="100%" height="100%" role="img" aria-label="Ultra energy flame (monochrome)">
       <defs>
         {/* Soft glow */}
         <filter id="glowUltra" x="-40%" y="-40%" width="180%" height="180%">
@@ -197,10 +197,10 @@ function UltraFlameBlue() {
           <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
         </filter>
 
-        {/* Blue outer gradient */}
+        {/* Monochrome outer gradient */}
         <linearGradient id="outerBlue" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%"  stopColor="#2196f3"/>
-          <stop offset="100%" stopColor="#0d47a1"/>
+          <stop offset="0%"  stopColor="#6b6b72"/>
+          <stop offset="100%" stopColor="#1f1f24"/>
         </linearGradient>
 
         {/* Red middle swirl */}
@@ -234,7 +234,7 @@ function UltraFlameBlue() {
              C59,27 57,34 58,39 C63,38 68,40 71,45
              C74,49 74,56 72,60 C80,64 84,70 84,79
              C84,92 73,110 50,114 Z"
-          stroke="#e3f2fd" strokeWidth="1.2" opacity="0.95"
+          stroke="#e5e5ea" strokeWidth="1.2" opacity="0.95"
         />
 
         {/* Middle red swirl */}
@@ -272,16 +272,16 @@ function UltraFlameBlue() {
           fill="#ffffff" opacity="0.55"
         />
 
-        {/* Optional tiny side nubs (blue) */}
-        <path className="nub" fill="#1976d2" d="M28,86 C26,85 25,83 26,81 C27,79 30,78 32,79 C31,82 30,84 28,86 Z" />
-        <path className="nub" fill="#1976d2" d="M76,86 C78,85 79,83 78,81 C77,79 74,78 72,79 C73,82 74,84 76,86 Z" />
+        {/* Optional tiny side nubs (monochrome) */}
+        <path className="nub" fill="#52525b" d="M28,86 C26,85 25,83 26,81 C27,79 30,78 32,79 C31,82 30,84 28,86 Z" />
+        <path className="nub" fill="#52525b" d="M76,86 C78,85 79,83 78,81 C77,79 74,78 72,79 C73,82 74,84 76,86 Z" />
       </g>
 
-      {/* Light blue specks (whispy) outside flame */}
+      {/* Soft grey specks (wispy) outside flame */}
       <g className="specks" filter="url(#speckBlurUltra)">
-        <circle className="speck" cx="34" cy="24" r="1.8" fill="#bbdefb" />
-        <circle className="speck d1" cx="68" cy="21" r="1.6" fill="#e3f2fd" />
-        <circle className="speck d2" cx="57" cy="18" r="1.4" fill="#cfe8ff" />
+        <circle className="speck" cx="34" cy="24" r="1.8" fill="#dcdce1" />
+        <circle className="speck d1" cx="68" cy="21" r="1.6" fill="#f1f1f4" />
+        <circle className="speck d2" cx="57" cy="18" r="1.4" fill="#e5e5ea" />
       </g>
 
       <style>{`

--- a/src/components/profile/HeroHeader.tsx
+++ b/src/components/profile/HeroHeader.tsx
@@ -109,7 +109,7 @@ export default function HeroHeader({
               {profile.name || profile.username}
             </h1>
             {profile.verified && (
-              <div className="w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
+              <div className="w-5 h-5 bg-accent rounded-full flex items-center justify-center">
                 <svg
                   className="w-3 h-3 text-white"
                   fill="currentColor"

--- a/src/components/profile/LinkTile.tsx
+++ b/src/components/profile/LinkTile.tsx
@@ -90,7 +90,7 @@ export default function LinkTile({
         <div
           className="
           absolute inset-0 
-          bg-gradient-to-t from-blue-500/10 to-transparent
+          bg-gradient-to-t from-accent/10 to-transparent
           opacity-0 group-hover:opacity-100
           transition-opacity duration-200
         "

--- a/src/components/profile/ProfileSkeleton.tsx
+++ b/src/components/profile/ProfileSkeleton.tsx
@@ -31,7 +31,7 @@ export function ProfileSkeleton() {
           <div className="text-center mb-3">
             <div className="flex items-center justify-center space-x-2 mb-1">
               <div className="w-32 h-8 bg-white/20 rounded animate-pulse" />
-              <div className="w-5 h-5 rounded-full bg-blue-500 animate-pulse" />
+              <div className="w-5 h-5 rounded-full bg-accent animate-pulse" />
             </div>
             <div className="w-24 h-6 bg-white/20 rounded animate-pulse mx-auto" />
           </div>

--- a/src/components/profile/SocialPillsRow.tsx
+++ b/src/components/profile/SocialPillsRow.tsx
@@ -22,7 +22,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   const platformConfig = {
     instagram: {
       icon: Instagram,
-      color: "bg-gradient-to-r from-purple-500 to-pink-500",
+      color: "bg-gradient-to-r from-highlight to-primary",
       label: "Instagram",
     },
     x: {
@@ -32,12 +32,12 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     twitter: {
       icon: Twitter,
-      color: "bg-blue-400",
+      color: "bg-accent",
       label: "Twitter",
     },
     youtube: {
       icon: Youtube,
-      color: "bg-red-600",
+      color: "bg-primary",
       label: "YouTube",
     },
     tiktok: {
@@ -47,17 +47,17 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     linkedin: {
       icon: Linkedin,
-      color: "bg-blue-700",
+      color: "bg-primary",
       label: "LinkedIn",
     },
     email: {
       icon: Mail,
-      color: "bg-gray-600",
+      color: "bg-surface-elevated",
       label: "Email",
     },
     website: {
       icon: Globe,
-      color: "bg-blue-500",
+      color: "bg-accent",
       label: "Website",
     },
     github: {
@@ -67,7 +67,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     discord: {
       icon: MessageCircle,
-      color: "bg-indigo-600",
+      color: "bg-accent",
       label: "Discord",
     },
   };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,9 +25,21 @@
   --surface-2:var(--surface-elevated);
   --text:var(--text-primary);
   --muted:var(--text-muted);
-  --accent:#6ea8ff;
+  --accent:#8E8E93;
   --radius:16px; --radius-sm:12px;
   --popover:var(--surface); --popover-foreground:var(--text);
+
+  /* monochrome palette for Tailwind aliases */
+  --color-surface:14 14 16;
+  --color-surface-foreground:239 239 242;
+  --color-surface-elevated:21 21 23;
+  --color-primary:60 60 65;
+  --color-primary-foreground:245 245 247;
+  --color-accent:90 90 96;
+  --color-accent-foreground:244 244 245;
+  --color-muted:154 154 162;
+  --color-border:58 58 64;
+  --color-highlight:209 209 214;
 }
 html,body{ background:var(--bg); color:var(--text); font-weight:600; touch-action:pan-y; overflow-x:hidden; }
 .section{ padding:20px 16px 8px; }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -8,7 +8,7 @@
     --radius-xl: 20px;
     --event-bg: var(--surface-2);
     --event-border: rgba(255,255,255,.08);
-    --timeline-now: var(--accent, #A020F0);
+    --timeline-now: var(--accent, #8E8E93);
     --noise-texture: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='3' height='3' viewBox='0 0 3 3'%3E%3Crect width='1' height='1' fill='rgba(255,255,255,0.15)'/%3E%3Crect x='1' y='2' width='1' height='1' fill='rgba(255,255,255,0.15)'/%3E%3Crect x='2' y='1' width='1' height='1' fill='rgba(255,255,255,0.15)'/%3E%3C/svg%3E");
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,9 +1,34 @@
 import type { Config } from "tailwindcss";
 
+const withOpacityValue = (variable: string) =>
+  `rgb(var(${variable}) / <alpha-value>)`;
+
 export default {
   content: [
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
   ],
+  theme: {
+    extend: {
+      colors: {
+        surface: {
+          DEFAULT: withOpacityValue("--color-surface"),
+          foreground: withOpacityValue("--color-surface-foreground"),
+          elevated: withOpacityValue("--color-surface-elevated"),
+        },
+        primary: {
+          DEFAULT: withOpacityValue("--color-primary"),
+          foreground: withOpacityValue("--color-primary-foreground"),
+        },
+        accent: {
+          DEFAULT: withOpacityValue("--color-accent"),
+          foreground: withOpacityValue("--color-accent-foreground"),
+        },
+        muted: withOpacityValue("--color-muted"),
+        border: withOpacityValue("--color-border"),
+        highlight: withOpacityValue("--color-highlight"),
+      },
+    },
+  },
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add monochrome CSS variables and extend Tailwind with surface/primary/accent aliases
- swap hard-coded blue utility classes across UI components for the new grey tokens and gradients
- refresh profile and badge color fallbacks to use neutral defaults instead of blues

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68c7c05ab2fc832c8bfe66015c259753