### PR TITLE
Refine dashboard to grayscale palette

### DIFF
--- a/components/BottomBarNav.tsx
+++ b/components/BottomBarNav.tsx
@@ -35,7 +35,7 @@ export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavPro
       >
         <div
           className={`flex flex-col items-center gap-1 px-3 py-1 text-xs transition-colors ${
-            isActive ? "text-white" : "hover:text-white"
+            isActive ? "text-gray-100" : "text-gray-400 hover:text-gray-200"
           }`}
         >
           <div
@@ -65,7 +65,7 @@ export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavPro
   const leftItems = items.slice(0, mid);
   const rightItems = items.slice(mid);
   return (
-    <nav className="w-full bg-gray-900 text-gray-400">
+    <nav className="w-full bg-black/80 text-gray-400 border-t border-white/10 backdrop-blur">
       <div className="grid h-16 w-full grid-cols-[1fr_3.5rem_1fr] items-center">
         <div className="flex h-full min-w-0 items-center justify-evenly">
           {leftItems.map(renderItem)}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -31,11 +31,11 @@ export default function TopNav() {
   }, [supabase]);
 
   return (
-    <nav className="w-full flex items-center justify-between px-4 py-2 bg-gray-900 text-white">
+    <nav className="w-full flex items-center justify-between px-4 py-2 bg-black/80 text-white border-b border-white/10 backdrop-blur">
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            className="h-11 w-11 p-2 hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-[#9966CC]"
+            className="h-11 w-11 p-2 hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6" />
@@ -43,7 +43,7 @@ export default function TopNav() {
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="start"
-          className="bg-[#1C1F22] border-[#2F343A] text-[#E6E6E6]"
+          className="bg-[#111111] border-[#2A2A2A] text-[#E6E6E6]"
         >
           <DropdownMenuItem asChild>
             <Link href="/analytics">Analytics</Link>

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -29,15 +29,15 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
     }
   };
 
-  const priorityColor =
+  const priorityStyles =
     goal.priority === "High"
-      ? "bg-red-600"
+      ? "bg-gray-200 text-gray-900"
       : goal.priority === "Medium"
-      ? "bg-yellow-600"
-      : "bg-green-600";
+      ? "bg-gray-400 text-gray-900"
+      : "bg-gray-600 text-gray-100";
 
   return (
-    <div className="bg-gray-800 rounded-lg shadow text-left">
+    <div className="rounded-lg border border-white/10 bg-black/70 shadow text-left">
       <div className="relative">
         <button
           onClick={toggle}
@@ -55,7 +55,7 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
             <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-300">
               <div className="w-10 h-2 bg-gray-700 rounded-full overflow-hidden">
                 <div
-                  className="h-full bg-blue-500"
+                  className="h-full bg-gray-200"
                   style={{ width: `${goal.progress}%` }}
                 />
               </div>
@@ -64,7 +64,7 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
                   {new Date(goal.dueDate).toLocaleDateString()}
                 </span>
               )}
-              <span className={`px-2 py-0.5 rounded-full ${priorityColor}`}>
+              <span className={`px-2 py-0.5 rounded-full ${priorityStyles}`}>
                 {goal.priority}
               </span>
               <span className="px-2 py-0.5 bg-gray-700 rounded-full">

--- a/src/app/(app)/goals/components/ProjectRow.tsx
+++ b/src/app/(app)/goals/components/ProjectRow.tsx
@@ -33,7 +33,7 @@ export function ProjectRow({ project }: ProjectRowProps) {
         <div className="flex items-center gap-2">
           <div className="w-16 h-2 bg-gray-700 rounded-full overflow-hidden">
             <div
-              className="h-full bg-blue-500"
+              className="h-full bg-gray-200"
               style={{ width: `${project.progress}%` }}
             />
           </div>

--- a/src/app/(app)/goals/components/ProjectsDropdown.tsx
+++ b/src/app/(app)/goals/components/ProjectsDropdown.tsx
@@ -39,7 +39,7 @@ export function ProjectsDropdown({
               value={100}
               className="mb-2"
               trackClass="bg-gray-700"
-              barClass="bg-blue-500 animate-pulse"
+              barClass="bg-gray-300 animate-pulse"
             />
           ) : projects.length > 0 ? (
             <div className="space-y-2">
@@ -50,12 +50,12 @@ export function ProjectsDropdown({
           ) : (
             <div className="text-sm text-gray-400">
               No projects linked yet
-              <button className="ml-2 text-blue-400">Add Project</button>
+              <button className="ml-2 text-gray-200 hover:text-gray-100">Add Project</button>
             </div>
           )}
           <Link
             href="/projects"
-            className="mt-3 inline-block text-xs text-blue-400"
+            className="mt-3 inline-block text-xs text-gray-300 hover:text-gray-100"
           >
             View all projects
           </Link>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -10,10 +10,10 @@
 
 :root{
   /* calendar design tokens */
-  --surface:#0E0E10;
-  --surface-elevated:#151517;
-  --text-primary:#EFEFF2;
-  --text-muted:#9A9AA2;
+  --surface:#050505;
+  --surface-elevated:#111111;
+  --text-primary:#F5F5F5;
+  --text-muted:#A3A3A3;
   --accent-red:#FF453A;
   --hairline:rgba(255,255,255,0.08);
   --dot:rgba(200,200,205,0.85);
@@ -25,7 +25,7 @@
   --surface-2:var(--surface-elevated);
   --text:var(--text-primary);
   --muted:var(--text-muted);
-  --accent:#6ea8ff;
+  --accent:#8E8E8E;
   --radius:16px; --radius-sm:12px;
   --popover:var(--surface); --popover-foreground:var(--text);
 }


### PR DESCRIPTION
## Summary
- retune global surface and accent tokens to a neutral black and gray palette to remove blue tinting
- restyle dashboard goal cards, progress bars, and project links to use monochromatic grays instead of blue accents
- refresh the top and bottom navigation bars with translucent black backgrounds and gray hover states for a cohesive chrome

## Testing
- `pnpm lint`
- `pnpm test:env`


------
https://chatgpt.com/codex/tasks/task_e_68c87dc80e78832cabd2c49bf41c5ed3