### PR TITLE
Preserve schedule placements by persisting to Supabase

### DIFF
--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -85,3 +85,209 @@ export async function fetchProjectsMap(): Promise<
   return map;
 }
 
+const AUTO_SCHEDULE_CATEGORY = 'auto_schedule';
+const AUTO_SCHEDULE_MARKER = '__auto_schedule__';
+
+type AutoScheduleDescription = {
+  [AUTO_SCHEDULE_MARKER]: true;
+  taskId: string;
+  windowId: string | null;
+};
+
+export type SchedulePlacement = {
+  id: string;
+  taskId: string;
+  windowId: string | null;
+  start: Date;
+  end: Date;
+  title: string;
+};
+
+export type SchedulePlacementInput = {
+  id?: string;
+  taskId: string;
+  windowId: string | null;
+  start: Date;
+  end: Date;
+  title: string;
+};
+
+function parseAutoDescription(value: string | null): {
+  taskId: string;
+  windowId: string | null;
+} | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<AutoScheduleDescription> | null;
+    if (!parsed || parsed[AUTO_SCHEDULE_MARKER] !== true) return null;
+    const taskId = typeof parsed.taskId === 'string' ? parsed.taskId : null;
+    if (!taskId) return null;
+    const windowId = typeof parsed.windowId === 'string' ? parsed.windowId : null;
+    return { taskId, windowId };
+  } catch {
+    return null;
+  }
+}
+
+function buildAutoDescription(taskId: string, windowId: string | null) {
+  const payload: AutoScheduleDescription = {
+    [AUTO_SCHEDULE_MARKER]: true,
+    taskId,
+    windowId: windowId ?? null,
+  };
+  return JSON.stringify(payload);
+}
+
+function getDateRange(date: Date) {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return { start, end };
+}
+
+export async function fetchSchedulePlacements(
+  date: Date
+): Promise<SchedulePlacement[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error('Supabase client not available');
+
+  const { start, end } = getDateRange(date);
+  const { data, error } = await supabase
+    .from('schedule_items')
+    .select('id, title, description, start_time, end_time, category')
+    .eq('category', AUTO_SCHEDULE_CATEGORY)
+    .gte('end_time', start.toISOString())
+    .lt('start_time', end.toISOString())
+    .order('start_time', { ascending: true });
+
+  if (error) throw error;
+
+  const placements: SchedulePlacement[] = [];
+  for (const row of data ?? []) {
+    const meta = parseAutoDescription(row.description);
+    if (!meta) continue;
+    placements.push({
+      id: row.id,
+      taskId: meta.taskId,
+      windowId: meta.windowId ?? null,
+      start: new Date(row.start_time),
+      end: new Date(row.end_time),
+      title: row.title ?? '',
+    });
+  }
+  return placements;
+}
+
+export async function syncSchedulePlacements(
+  date: Date,
+  placements: SchedulePlacementInput[],
+  existing: SchedulePlacement[] = []
+): Promise<SchedulePlacement[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) throw new Error('Supabase client not available');
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError) throw authError;
+  if (!user) throw new Error('User not authenticated');
+
+  const currentExisting = existing.length
+    ? existing
+    : await fetchSchedulePlacements(date);
+  const existingByTask = new Map(currentExisting.map(item => [item.taskId, item]));
+
+  const nowIso = new Date().toISOString();
+  const seenTasks = new Set<string>();
+
+  const inserts: Array<{
+    user_id: string;
+    title: string;
+    description: string;
+    start_time: string;
+    end_time: string;
+    category: string;
+    priority: string;
+    updated_at: string;
+  }> = [];
+  const updates: Array<{
+    id: string;
+    payload: {
+      title: string;
+      description: string;
+      start_time: string;
+      end_time: string;
+      category: string;
+      priority: string;
+      updated_at: string;
+    };
+  }> = [];
+
+  for (const placement of placements) {
+    seenTasks.add(placement.taskId);
+    const description = buildAutoDescription(
+      placement.taskId,
+      placement.windowId
+    );
+    const startIso = placement.start.toISOString();
+    const endIso = placement.end.toISOString();
+    const existingItem = existingByTask.get(placement.taskId);
+    if (existingItem) {
+      updates.push({
+        id: existingItem.id,
+        payload: {
+          title: placement.title,
+          description,
+          start_time: startIso,
+          end_time: endIso,
+          category: AUTO_SCHEDULE_CATEGORY,
+          priority: 'medium',
+          updated_at: nowIso,
+        },
+      });
+    } else {
+      inserts.push({
+        user_id: user.id,
+        title: placement.title,
+        description,
+        start_time: startIso,
+        end_time: endIso,
+        category: AUTO_SCHEDULE_CATEGORY,
+        priority: 'medium',
+        updated_at: nowIso,
+      });
+    }
+  }
+
+  const deleteIds = currentExisting
+    .filter(item => !seenTasks.has(item.taskId))
+    .map(item => item.id);
+
+  if (inserts.length) {
+    const { error } = await supabase.from('schedule_items').insert(inserts);
+    if (error) throw error;
+  }
+
+  if (updates.length) {
+    for (const { id, payload } of updates) {
+      const { error } = await supabase
+        .from('schedule_items')
+        .update(payload)
+        .eq('id', id);
+      if (error) throw error;
+    }
+  }
+
+  if (deleteIds.length) {
+    const { error } = await supabase
+      .from('schedule_items')
+      .delete()
+      .in('id', deleteIds);
+    if (error) throw error;
+  }
+
+  return fetchSchedulePlacements(date);
+}
+


### PR DESCRIPTION
## Summary
- load schedule data sequentially so partial failures don’t clear existing state and surface inline error messaging
- merge persisted placements with new suggestions and keep them in Supabase instead of resetting on each refresh
- add Supabase helpers for reading and writing schedule_items records used by the scheduler

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68c896eaa64c832c9bab9865b45d445a