### PR TITLE
feat: add monument and skill filters

### DIFF
--- a/components/BottomBarNav.tsx
+++ b/components/BottomBarNav.tsx
@@ -65,7 +65,7 @@ export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavPro
   const leftItems = items.slice(0, mid);
   const rightItems = items.slice(mid);
   return (
-    <nav className="w-full bg-gray-900 text-gray-400">
+    <nav className="w-full border-t border-[var(--hairline)] bg-[var(--surface-elevated)] text-[var(--muted)]">
       <div className="grid h-16 w-full grid-cols-[1fr_3.5rem_1fr] items-center">
         <div className="flex h-full min-w-0 items-center justify-evenly">
           {leftItems.map(renderItem)}

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -16,8 +16,11 @@ export default function BottomNav() {
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50" data-bottom-nav>
-      <div className="relative">
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50 bg-[var(--surface-elevated)]"
+      data-bottom-nav
+    >
+      <div className="relative pb-[env(safe-area-inset-bottom)]">
         <BottomBarNav
           items={items}
           currentPath={pathname}

--- a/lib/queries/goals.ts
+++ b/lib/queries/goals.ts
@@ -9,6 +9,7 @@ export interface Goal {
   created_at: string;
   active?: boolean;
   status?: string;
+  monument_id?: string | null;
 }
 
 export async function getGoalsForUser(userId: string): Promise<Goal[]> {
@@ -19,7 +20,9 @@ export async function getGoalsForUser(userId: string): Promise<Goal[]> {
 
   const { data, error } = await supabase
     .from("goals")
-    .select("id, name, priority, energy, why, created_at, active, status")
+    .select(
+      "id, name, priority, energy, why, created_at, active, status, monument_id"
+    )
     .eq("user_id", userId)
     .order("created_at", { ascending: false });
 
@@ -39,7 +42,9 @@ export async function getGoalById(goalId: string): Promise<Goal | null> {
 
   const { data, error } = await supabase
     .from("goals")
-    .select("id, name, priority, energy, why, created_at, active, status")
+    .select(
+      "id, name, priority, energy, why, created_at, active, status, monument_id"
+    )
     .eq("id", goalId)
     .single();
 

--- a/src/app/(app)/goals/components/GoalsUtilityBar.tsx
+++ b/src/app/(app)/goals/components/GoalsUtilityBar.tsx
@@ -22,6 +22,12 @@ interface GoalsUtilityBarProps {
   onPriority(p: PriorityFilter): void;
   sort: SortOption;
   onSort(s: SortOption): void;
+  monuments: { id: string; title: string }[];
+  monument: string;
+  onMonument(id: string): void;
+  skills: { id: string; name: string }[];
+  skill: string;
+  onSkill(id: string): void;
 }
 
 export function GoalsUtilityBar({
@@ -33,6 +39,12 @@ export function GoalsUtilityBar({
   onPriority,
   sort,
   onSort,
+  monuments,
+  monument,
+  onMonument,
+  skills,
+  skill,
+  onSkill,
 }: GoalsUtilityBarProps) {
   const [local, setLocal] = useState(search);
 
@@ -50,11 +62,11 @@ export function GoalsUtilityBar({
           placeholder="Search goals"
           className="w-full px-3 py-2 rounded-md bg-gray-800 text-sm focus:outline-none"
         />
-        <div className="flex items-center gap-1 sm:gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2">
           <select
             value={energy}
             onChange={(e) => onEnergy(e.target.value as EnergyFilter)}
-            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="All">Energy: All</option>
             <option value="No">No</option>
@@ -67,7 +79,7 @@ export function GoalsUtilityBar({
           <select
             value={priority}
             onChange={(e) => onPriority(e.target.value as PriorityFilter)}
-            className="bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="All">Priority: All</option>
             <option value="Low">Low</option>
@@ -75,9 +87,33 @@ export function GoalsUtilityBar({
             <option value="High">High</option>
           </select>
           <select
+            value={monument}
+            onChange={(e) => onMonument(e.target.value)}
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
+          >
+            <option value="All">Monument: All</option>
+            {monuments.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.title}
+              </option>
+            ))}
+          </select>
+          <select
+            value={skill}
+            onChange={(e) => onSkill(e.target.value)}
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
+          >
+            <option value="All">Skill: All</option>
+            {skills.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <select
             value={sort}
             onChange={(e) => onSort(e.target.value as SortOption)}
-            className="ml-auto bg-gray-800 text-sm px-2 py-1 rounded-md"
+            className="w-full bg-gray-800 text-sm px-2 py-1 rounded-md"
           >
             <option value="A→Z">A→Z</option>
             <option value="Due Soon">Due Soon</option>

--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -26,4 +26,7 @@ export interface Goal {
   active: boolean;
   updatedAt: string;
   projects: Project[];
+  monumentId?: string | null;
+  /** Associated skill IDs */
+  skills?: string[];
 }


### PR DESCRIPTION
## Summary
- expand goal queries and types with monument ID and associated skills
- add monument and skill options to goals utility bar
- filter goals by selected monument or skill on goals page
- align goal filters in utility bar with responsive grid layout
- give the bottom navigation a solid elevated background so it no longer appears transparent and covers the device safe area

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_68c7b9f45020832cb84fb07106dd37b5