### PR TITLE
Adjust schedule window label wrapping

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -295,6 +295,13 @@ export default function SchedulePage() {
                 >
                   {windows.map(w => {
                     const { top, height } = windowRect(w, startHour, pxPerMin)
+                    const windowHeightPx =
+                      typeof height === 'number' ? Math.max(0, height) : 0
+                    const labelLength = Array.from(w.label ?? '').length || 0
+                    const approximateCharHeight = 10
+                    const shouldWrap =
+                      windowHeightPx > 0 &&
+                      windowHeightPx < labelLength * approximateCharHeight
                     return (
                       <div
                         key={w.id}
@@ -304,8 +311,13 @@ export default function SchedulePage() {
                       >
                         <div className="w-0.5 bg-zinc-700 opacity-50" />
                         <span
-                          className="ml-1 text-[10px] text-zinc-500"
-                          style={{ writingMode: 'vertical-rl', textOrientation: 'mixed' }}
+                          className="ml-1 text-[10px] leading-none text-zinc-500"
+                          style={{
+                            writingMode: 'vertical-rl',
+                            textOrientation: 'mixed',
+                            whiteSpace: shouldWrap ? 'normal' : 'nowrap',
+                            lineHeight: `${approximateCharHeight}px`,
+                          }}
                         >
                           {w.label}
                         </span>

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -299,9 +299,13 @@ export default function SchedulePage() {
                       typeof height === 'number' ? Math.max(0, height) : 0
                     const labelLength = Array.from(w.label ?? '').length || 0
                     const approximateCharHeight = 10
+                    const wrapAllowanceMultiplier = 3
+                    const effectiveWindowHeightPx =
+                      windowHeightPx * wrapAllowanceMultiplier
                     const shouldWrap =
-                      windowHeightPx > 0 &&
-                      windowHeightPx < labelLength * approximateCharHeight
+                      effectiveWindowHeightPx > 0 &&
+                      effectiveWindowHeightPx <
+                        labelLength * approximateCharHeight
                     return (
                       <div
                         key={w.id}
@@ -316,6 +320,7 @@ export default function SchedulePage() {
                             writingMode: 'vertical-rl',
                             textOrientation: 'mixed',
                             whiteSpace: shouldWrap ? 'normal' : 'nowrap',
+                            wordBreak: 'keep-all',
                             lineHeight: `${approximateCharHeight}px`,
                           }}
                         >


### PR DESCRIPTION
## Summary
- ensure window labels only wrap when the available timeline height is shorter than the label text
- tighten the label line height to avoid unnecessary multi-column wrapping on the schedule timeline

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68cb561f430c832c838b974f8616ec0e