### PR TITLE
Add dark gradient background to app

### DIFF
--- a/components/SettingsPage.tsx
+++ b/components/SettingsPage.tsx
@@ -23,7 +23,13 @@ export default function SettingsPage() {
   const initials = getInitials(profile?.name || null, email);
 
   return (
-    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+    <div
+      className="min-h-screen text-[var(--text)]"
+      style={{
+        backgroundColor: "var(--bg)",
+        backgroundImage: "var(--bg-gradient)",
+      }}
+    >
       <header className="sticky top-0 z-10 backdrop-blur bg-[var(--bg)]/80 border-b border-white/10">
         <div className="flex items-center gap-3 px-4 py-3">
           <button

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -28,8 +28,21 @@
   --accent:#8E8E8E;
   --radius:16px; --radius-sm:12px;
   --popover:var(--surface); --popover-foreground:var(--text);
+  --bg-gradient:radial-gradient(120% 120% at 50% 0%, #1c1d22 0%, #0c0d11 48%, #020203 100%);
 }
-html,body{ background:var(--bg); color:var(--text); font-weight:600; touch-action:pan-y; overflow-x:hidden; }
+html,
+body { min-height:100%; }
+html,body{
+  background-color:var(--bg);
+  background-image:var(--bg-gradient);
+  background-attachment:fixed;
+  background-repeat:no-repeat;
+  background-size:cover;
+  color:var(--text);
+  font-weight:600;
+  touch-action:pan-y;
+  overflow-x:hidden;
+}
 .section{ padding:20px 16px 8px; }
 .h-label{ letter-spacing:.12em; text-transform:uppercase; font-weight:700; color:var(--muted); font-size:12px; }
 .card{ background:linear-gradient(180deg,var(--surface),var(--surface-2));


### PR DESCRIPTION
## Summary
- add a reusable dark gradient token for the application background
- apply the gradient to the global html/body styles to replace the flat black
- update the settings page wrapper to respect the new gradient theme

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb57a85ce8832ca33a78ad61dc1e75