### PR TITLE
Fix goal inactivity toggle on dashboard

### DIFF
--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -202,6 +202,33 @@ export default function DashboardClient() {
     setLoadingGoals(false);
   };
 
+  const handleToggleActive = async (goal: Goal) => {
+    const supabase = getSupabaseBrowser();
+    if (!supabase) return;
+
+    const nextActive = !goal.active;
+    const status: Goal["status"] = nextActive ? "Active" : "Inactive";
+
+    const { error } = await supabase
+      .from("goals")
+      .update({ active: nextActive, status })
+      .eq("id", goal.id);
+
+    if (error) {
+      console.error("Failed to toggle goal active state:", error);
+      return;
+    }
+
+    setGoals((gs) => {
+      if (nextActive) {
+        return gs.map((g) =>
+          g.id === goal.id ? { ...g, active: nextActive, status } : g
+        );
+      }
+      return gs.filter((g) => g.id !== goal.id);
+    });
+  };
+
   return (
     <main className="pb-20">
       <LevelBanner level={80} current={3200} total={4000} />
@@ -229,6 +256,7 @@ export default function DashboardClient() {
                 key={goal.id}
                 goal={goal}
                 onEdit={() => router.push(`/goals?edit=${goal.id}`)}
+                onToggleActive={() => handleToggleActive(goal)}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- add a dashboard goal toggle handler that updates Supabase and removes inactive goals from the list
- wire the current goals card menu to the new toggle handler so "Mark Inactive" works

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68cb887ec5f8832cae92c60b566ee082