### PR TITLE
Persist schedule instances and reschedule missed

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -14,6 +14,7 @@ import {
 import { useRouter, usePathname, useSearchParams } from 'next/navigation'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { ProtectedRoute } from '@/components/auth/ProtectedRoute'
+import { useAuth } from '@/components/auth/AuthProvider'
 import { DayTimeline } from '@/components/schedule/DayTimeline'
 import { FocusTimeline } from '@/components/schedule/FocusTimeline'
 import FlameEmber, { FlameLevel } from '@/components/FlameEmber'
@@ -32,14 +33,12 @@ import {
   fetchProjectsMap,
   type WindowLite as RepoWindow,
 } from '@/lib/scheduler/repo'
-import {
-  placeByEnergyWeight,
-  type WindowLite as PlacerWindow,
-} from '@/lib/scheduler/placer'
-import { TaskLite, ProjectLite, taskWeight } from '@/lib/scheduler/weight'
+import { fetchInstancesForRange, type ScheduleInstance } from '@/lib/scheduler/instanceRepo'
+import { TaskLite, ProjectLite } from '@/lib/scheduler/weight'
 import { buildProjectItems } from '@/lib/scheduler/projects'
 import { windowRect } from '@/lib/scheduler/windowRect'
 import { ENERGY } from '@/lib/scheduler/config'
+import { toLocal } from '@/lib/time/tz'
 
 function ScheduleViewShell({ children }: { children: ReactNode }) {
   const prefersReducedMotion = useReducedMotion()
@@ -104,11 +103,25 @@ function WindowLabel({
   )
 }
 
+function startOfDay(date: Date) {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function endOfDay(date: Date) {
+  const d = new Date(date)
+  d.setHours(23, 59, 59, 999)
+  return d
+}
+
 export default function SchedulePage() {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const prefersReducedMotion = useReducedMotion()
+  const { session } = useAuth()
+  const userId = session?.user.id ?? null
 
   const initialViewParam = searchParams.get('view') as ScheduleView | null
   const initialView: ScheduleView =
@@ -124,12 +137,7 @@ export default function SchedulePage() {
   const [tasks, setTasks] = useState<TaskLite[]>([])
   const [projects, setProjects] = useState<ProjectLite[]>([])
   const [windows, setWindows] = useState<RepoWindow[]>([])
-  const [placements, setPlacements] = useState<
-    ReturnType<typeof placeByEnergyWeight>['placements']
-  >([])
-  const [unplaced, setUnplaced] = useState<
-    ReturnType<typeof placeByEnergyWeight>['unplaced']
-  >([])
+  const [instances, setInstances] = useState<ScheduleInstance[]>([])
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set())
   const touchStartX = useRef<number | null>(null)
   const navLock = useRef(false)
@@ -165,23 +173,16 @@ export default function SchedulePage() {
     }
     load()
   }, [currentDate])
-
-
-  const weightedTasks = useMemo(
-    () => tasks.map(t => ({ ...t, weight: taskWeight(t) })),
-    [tasks]
-  )
-
   const projectItems = useMemo(
     () => buildProjectItems(projects, tasks),
     [projects, tasks]
   )
 
   const taskMap = useMemo(() => {
-    const map: Record<string, typeof weightedTasks[number]> = {}
-    for (const t of weightedTasks) map[t.id] = t
+    const map: Record<string, TaskLite> = {}
+    for (const t of tasks) map[t.id] = t
     return map
-  }, [weightedTasks])
+  }, [tasks])
 
   const projectMap = useMemo(() => {
     const map: Record<string, typeof projectItems[number]> = {}
@@ -191,35 +192,97 @@ export default function SchedulePage() {
 
   const dayEnergies = useMemo(() => {
     const map: Record<string, FlameLevel> = {}
-    for (const p of placements) {
-      const key = p.start.toISOString().slice(0, 10)
-      const item = projectMap[p.taskId]
-      const level = (item?.energy?.toUpperCase() as FlameLevel) || 'NO'
+    for (const inst of instances) {
+      const start = toLocal(inst.start_utc)
+      const key = start.toISOString().slice(0, 10)
+      const level = (inst.energy_resolved?.toUpperCase() as FlameLevel) || 'NO'
       const current = map[key]
       if (!current || ENERGY.LIST.indexOf(level) > ENERGY.LIST.indexOf(current)) {
         map[key] = level
       }
     }
     return map
-  }, [placements, projectMap])
+  }, [instances])
 
-  const taskPlacementsByProject = useMemo(() => {
-    const map: Record<string, ReturnType<typeof placeByEnergyWeight>['placements']> = {}
-    for (const p of placements) {
-      const tasksForProj = weightedTasks.filter(t => t.project_id === p.taskId)
-      if (tasksForProj.length === 0) continue
-      const proj = projectMap[p.taskId]
-      const win: PlacerWindow = {
-        id: p.taskId,
-        label: proj?.name ?? '',
-        energy: proj?.energy ?? '',
-        start_local: p.start.toTimeString().slice(0, 5),
-        end_local: p.end.toTimeString().slice(0, 5),
-      }
-      map[p.taskId] = placeByEnergyWeight(tasksForProj, [win], p.start).placements
+  const projectInstances = useMemo(() => {
+    return instances
+      .filter(inst => inst.source_type === 'PROJECT')
+      .map(inst => {
+        const project = projectMap[inst.source_id]
+        if (!project) return null
+        return {
+          instance: inst,
+          project,
+          start: toLocal(inst.start_utc),
+          end: toLocal(inst.end_utc),
+        }
+      })
+      .filter((value): value is {
+        instance: ScheduleInstance
+        project: typeof projectItems[number]
+        start: Date
+        end: Date
+      } => value !== null)
+      .sort((a, b) => a.start.getTime() - b.start.getTime())
+  }, [instances, projectMap, projectItems])
+
+  const projectInstanceIds = useMemo(() => {
+    const set = new Set<string>()
+    for (const item of projectInstances) {
+      set.add(item.project.id)
+    }
+    return set
+  }, [projectInstances])
+
+  const taskInstancesByProject = useMemo(() => {
+    const map: Record<
+      string,
+      Array<{ instance: ScheduleInstance; task: TaskLite; start: Date; end: Date }>
+    > = {}
+    for (const inst of instances) {
+      if (inst.source_type !== 'TASK') continue
+      const task = taskMap[inst.source_id]
+      const projectId = task?.project_id ?? null
+      if (!task || !projectId) continue
+      if (!projectInstanceIds.has(projectId)) continue
+      const bucket = map[projectId] ?? []
+      bucket.push({
+        instance: inst,
+        task,
+        start: toLocal(inst.start_utc),
+        end: toLocal(inst.end_utc),
+      })
+      map[projectId] = bucket
+    }
+    for (const key of Object.keys(map)) {
+      map[key].sort((a, b) => a.start.getTime() - b.start.getTime())
     }
     return map
-  }, [placements, weightedTasks, projectMap])
+  }, [instances, taskMap, projectInstanceIds])
+
+  const standaloneTaskInstances = useMemo(() => {
+    const items: Array<{
+      instance: ScheduleInstance
+      task: TaskLite
+      start: Date
+      end: Date
+    }> = []
+    for (const inst of instances) {
+      if (inst.source_type !== 'TASK') continue
+      const task = taskMap[inst.source_id]
+      if (!task) continue
+      const projectId = task.project_id ?? undefined
+      if (projectId && projectInstanceIds.has(projectId)) continue
+      items.push({
+        instance: inst,
+        task,
+        start: toLocal(inst.start_utc),
+        end: toLocal(inst.end_utc),
+      })
+    }
+    items.sort((a, b) => a.start.getTime() - b.start.getTime())
+    return items
+  }, [instances, taskMap, projectInstanceIds])
 
   function navigate(next: ScheduleView) {
     if (navLock.current) return
@@ -245,20 +308,41 @@ export default function SchedulePage() {
     setCurrentDate(new Date())
     navigate('day')
   }
-
-
   useEffect(() => {
-    function run() {
-      if (windows.length === 0) return
-      const date = currentDate
-      const projResult = placeByEnergyWeight(projectItems, windows, date)
-      setPlacements(projResult.placements)
-      setUnplaced(projResult.unplaced)
+    if (!userId) {
+      setInstances([])
+      return
     }
-    run()
-    const id = setInterval(run, 5 * 60 * 1000)
-    return () => clearInterval(id)
-  }, [projectItems, windows, currentDate])
+    let active = true
+    const load = async () => {
+      try {
+        const start = startOfDay(currentDate)
+        const end = endOfDay(currentDate)
+        const { data, error } = await fetchInstancesForRange(
+          userId,
+          start.toISOString(),
+          end.toISOString()
+        )
+        if (!active) return
+        if (error) {
+          console.error(error)
+          setInstances([])
+          return
+        }
+        setInstances(data ?? [])
+      } catch (e) {
+        if (!active) return
+        console.error(e)
+        setInstances([])
+      }
+    }
+    load()
+    const id = setInterval(load, 5 * 60 * 1000)
+    return () => {
+      active = false
+      clearInterval(id)
+    }
+  }, [userId, currentDate])
 
   function handleTouchStart(e: React.TouchEvent) {
     touchStartX.current = e.touches[0].clientX
@@ -361,16 +445,14 @@ export default function SchedulePage() {
                       </div>
                     )
                   })}
-                  {placements.map((p, i) => {
-                    const item = projectMap[p.taskId]
-                    if (!item) return null
-                    const startMin =
-                      p.start.getHours() * 60 + p.start.getMinutes()
+                  {projectInstances.map(({ instance, project, start, end }, index) => {
+                    const projectId = project.id
+                    const startMin = start.getHours() * 60 + start.getMinutes()
                     const top = (startMin - startHour * 60) * pxPerMin
                     const height =
-                      ((p.end.getTime() - p.start.getTime()) / 60000) * pxPerMin
-                    const isExpanded = expandedProjects.has(p.taskId)
-                    const taskPs = taskPlacementsByProject[p.taskId] || []
+                      ((end.getTime() - start.getTime()) / 60000) * pxPerMin
+                    const isExpanded = expandedProjects.has(projectId)
+                    const tasksForProject = taskInstancesByProject[projectId] || []
                     const style: CSSProperties = {
                       top,
                       height,
@@ -379,17 +461,17 @@ export default function SchedulePage() {
                       outlineOffset: '-1px',
                     }
                     return (
-                      <AnimatePresence key={p.taskId} initial={false}>
-                        {!isExpanded || taskPs.length === 0 ? (
+                      <AnimatePresence key={instance.id} initial={false}>
+                        {!isExpanded || tasksForProject.length === 0 ? (
                           <motion.div
                             key="project"
-                            aria-label={`Project ${item.name}`}
+                            aria-label={`Project ${project.name}`}
                             onClick={() => {
-                              if (taskPs.length === 0) return
+                              if (tasksForProject.length === 0) return
                               setExpandedProjects(prev => {
                                 const next = new Set(prev)
-                                if (next.has(p.taskId)) next.delete(p.taskId)
-                                else next.add(p.taskId)
+                                if (next.has(projectId)) next.delete(projectId)
+                                else next.add(projectId)
                                 return next
                               })
                             }}
@@ -407,43 +489,49 @@ export default function SchedulePage() {
                                 : { opacity: 0, y: 4 }
                             }
                             transition={
-                              prefersReducedMotion ? undefined : { delay: i * 0.02 }
+                              prefersReducedMotion
+                                ? undefined
+                                : { delay: index * 0.02 }
                             }
                           >
                             <div className="flex flex-col">
                               <span className="truncate text-sm font-medium">
-                                {item.name}
+                                {project.name}
                               </span>
                               <div className="text-xs text-zinc-200/70">
-                                {item.duration_min}m
-                                {"taskCount" in item && (
-                                  <span> · {item.taskCount} tasks</span>
+                                {Math.round(
+                                  (end.getTime() - start.getTime()) / 60000
+                                )}
+                                m
+                                {project.taskCount > 0 && (
+                                  <span> · {project.taskCount} tasks</span>
                                 )}
                               </div>
                             </div>
-                            {item.skill_icon && (
+                            {project.skill_icon && (
                               <span
                                 className="ml-2 text-lg leading-none flex-shrink-0"
                                 aria-hidden
                               >
-                                {item.skill_icon}
+                                {project.skill_icon}
                               </span>
                             )}
                             <FlameEmber
-                              level={(item.energy as FlameLevel) || "NO"}
+                              level={
+                                (instance.energy_resolved?.toUpperCase() as FlameLevel) ||
+                                'NO'
+                              }
                               size="sm"
                               className="absolute -top-1 -right-1"
                             />
                           </motion.div>
                         ) : (
-                          taskPs.map(tp => {
-                            const tItem = taskMap[tp.taskId]
-                            if (!tItem) return null
-                            const tStartMin =
-                              tp.start.getHours() * 60 + tp.start.getMinutes()
+                          tasksForProject.map(taskInfo => {
+                            const { instance: taskInstance, task, start, end } = taskInfo
+                            const tStartMin = start.getHours() * 60 + start.getMinutes()
                             const tTop = (tStartMin - startHour * 60) * pxPerMin
                             const tHeight =
-                              ((tp.end.getTime() - tp.start.getTime()) / 60000) * pxPerMin
+                              ((end.getTime() - start.getTime()) / 60000) * pxPerMin
                             const tStyle: CSSProperties = {
                               top: tTop,
                               height: tHeight,
@@ -452,17 +540,17 @@ export default function SchedulePage() {
                               outlineOffset: '-1px',
                             }
                             const progress =
-                              (tItem as { progress?: number }).progress ?? 0
+                              (task as { progress?: number }).progress ?? 0
                             return (
                               <motion.div
-                                key={tp.taskId}
-                                aria-label={`Task ${tItem.name}`}
+                                key={taskInstance.id}
+                                aria-label={`Task ${task.name}`}
                                 className="absolute left-16 right-2 flex items-center justify-between rounded-[var(--radius-lg)] bg-stone-700 px-3 py-2 text-white"
                                 style={tStyle}
                                 onClick={() =>
                                   setExpandedProjects(prev => {
                                     const next = new Set(prev)
-                                    next.delete(p.taskId)
+                                    next.delete(projectId)
                                     return next
                                   })
                                 }
@@ -484,22 +572,25 @@ export default function SchedulePage() {
                               >
                                 <div className="flex flex-col">
                                   <span className="truncate text-sm font-medium">
-                                    {tItem.name}
+                                    {task.name}
                                   </span>
                                   <div className="text-xs text-zinc-200/70">
-                                    {tItem.duration_min}m
+                                    {Math.round(
+                                      (end.getTime() - start.getTime()) / 60000
+                                    )}
+                                    m
                                   </div>
                                 </div>
-                                {tItem.skill_icon && (
+                                {task.skill_icon && (
                                   <span
                                     className="ml-2 text-lg leading-none flex-shrink-0"
                                     aria-hidden
                                   >
-                                    {tItem.skill_icon}
+                                    {task.skill_icon}
                                   </span>
                                 )}
                                 <FlameEmber
-                                  level={(tItem.energy as FlameLevel) || "NO"}
+                                  level={(task.energy as FlameLevel) || 'NO'}
                                   size="sm"
                                   className="absolute -top-1 -right-1"
                                 />
@@ -514,6 +605,63 @@ export default function SchedulePage() {
                       </AnimatePresence>
                     )
                   })}
+                  {standaloneTaskInstances.map(({ instance, task, start, end }) => {
+                    const startMin = start.getHours() * 60 + start.getMinutes()
+                    const top = (startMin - startHour * 60) * pxPerMin
+                    const height =
+                      ((end.getTime() - start.getTime()) / 60000) * pxPerMin
+                    const style: CSSProperties = {
+                      top,
+                      height,
+                      boxShadow: 'var(--elev-card)',
+                      outline: '1px solid var(--event-border)',
+                      outlineOffset: '-1px',
+                    }
+                    const progress = (task as { progress?: number }).progress ?? 0
+                    return (
+                      <motion.div
+                        key={instance.id}
+                        aria-label={`Task ${task.name}`}
+                        className="absolute left-16 right-2 flex items-center justify-between rounded-[var(--radius-lg)] bg-stone-700 px-3 py-2 text-white"
+                        style={style}
+                        initial={
+                          prefersReducedMotion ? false : { opacity: 0, y: 4 }
+                        }
+                        animate={
+                          prefersReducedMotion ? undefined : { opacity: 1, y: 0 }
+                        }
+                        exit={
+                          prefersReducedMotion ? undefined : { opacity: 0, y: 4 }
+                        }
+                      >
+                        <div className="flex flex-col">
+                          <span className="truncate text-sm font-medium">
+                            {task.name}
+                          </span>
+                          <div className="text-xs text-zinc-200/70">
+                            {Math.round((end.getTime() - start.getTime()) / 60000)}m
+                          </div>
+                        </div>
+                        {task.skill_icon && (
+                          <span
+                            className="ml-2 text-lg leading-none flex-shrink-0"
+                            aria-hidden
+                          >
+                            {task.skill_icon}
+                          </span>
+                        )}
+                        <FlameEmber
+                          level={(task.energy as FlameLevel) || 'NO'}
+                          size="sm"
+                          className="absolute -top-1 -right-1"
+                        />
+                        <div
+                          className="absolute left-0 bottom-0 h-[3px] bg-white/30"
+                          style={{ width: `${progress}%` }}
+                        />
+                      </motion.div>
+                    )
+                  })}
                 </DayTimeline>
               </ScheduleViewShell>
             )}
@@ -524,31 +672,6 @@ export default function SchedulePage() {
             )}
           </AnimatePresence>
         </div>
-
-        {unplaced.length > 0 && (
-          <div className="space-y-2">
-            <h2 className="text-sm font-semibold text-zinc-200">Unplaced</h2>
-            <ul className="space-y-2">
-              {unplaced.map(u => {
-                const item = projectMap[u.taskId]
-                const reason =
-                  u.reason === 'no-window'
-                    ? 'No window fits'
-                    : 'No slot available'
-                return (
-                  <li
-                    key={u.taskId}
-                    aria-label={`Project ${item?.name ?? u.taskId} unplaced: ${reason}`}
-                    className="flex items-center justify-between rounded-xl border border-zinc-700 bg-zinc-800 p-3 text-sm text-white"
-                  >
-                    <span>{item?.name ?? u.taskId}</span>
-                    <span className="text-zinc-400">{reason}</span>
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        )}
       </div>
     </ProtectedRoute>
   )

--- a/src/lib/scheduler/instanceRepo.ts
+++ b/src/lib/scheduler/instanceRepo.ts
@@ -1,0 +1,93 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getSupabaseBrowser } from '../../../lib/supabase'
+import type { Database } from '../../../types/supabase'
+
+export type ScheduleInstance = Database['public']['Tables']['schedule_instances']['Row']
+export type ScheduleInstanceStatus = Database['public']['Enums']['schedule_instance_status']
+
+type Client = SupabaseClient<Database>
+
+async function ensureClient(client?: Client): Promise<Client> {
+  if (client) return client
+  const supabase = getSupabaseBrowser()
+  if (!supabase) throw new Error('Supabase client not available')
+  return supabase as Client
+}
+
+export async function fetchInstancesForRange(
+  userId: string,
+  startUTC: string,
+  endUTC: string,
+  client?: Client
+) {
+  const supabase = await ensureClient(client)
+  return await supabase
+    .from('schedule_instances')
+    .select('*')
+    .eq('user_id', userId)
+    .lt('start_utc', endUTC)
+    .gt('end_utc', startUTC)
+    .neq('status', 'canceled')
+}
+
+export async function createInstance(
+  input: {
+    userId: string
+    sourceType: 'PROJECT' | 'TASK'
+    sourceId: string
+    windowId?: string | null
+    startUTC: string
+    endUTC: string
+    durationMin: number
+    weightSnapshot: number
+    energyResolved: string
+  },
+  client?: Client
+) {
+  const supabase = await ensureClient(client)
+  return await supabase
+    .from('schedule_instances')
+    .insert({
+      user_id: input.userId,
+      source_type: input.sourceType,
+      source_id: input.sourceId,
+      window_id: input.windowId ?? null,
+      start_utc: input.startUTC,
+      end_utc: input.endUTC,
+      duration_min: input.durationMin,
+      status: 'scheduled',
+      weight_snapshot: input.weightSnapshot,
+      energy_resolved: input.energyResolved,
+    })
+    .select('*')
+    .single()
+}
+
+export async function updateInstanceStatus(
+  id: string,
+  status: 'scheduled' | 'completed' | 'missed' | 'canceled',
+  completedAtUTC?: string,
+  client?: Client
+) {
+  const supabase = await ensureClient(client)
+  return await supabase
+    .from('schedule_instances')
+    .update({
+      status,
+      completed_at: completedAtUTC ?? null,
+    })
+    .eq('id', id)
+}
+
+export async function fetchBacklogNeedingSchedule(
+  userId: string,
+  client?: Client
+) {
+  const supabase = await ensureClient(client)
+  return await supabase
+    .from('schedule_instances')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('status', 'missed')
+    .order('weight_snapshot', { ascending: false })
+}

--- a/src/lib/scheduler/placement.ts
+++ b/src/lib/scheduler/placement.ts
@@ -1,0 +1,101 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { PostgrestSingleResponse } from '@supabase/supabase-js'
+import type { Database } from '../../../types/supabase'
+import { fetchInstancesForRange, createInstance, type ScheduleInstance } from './instanceRepo'
+import { addMin } from './placer'
+
+type Client = SupabaseClient<Database>
+
+type PlacementResult =
+  | PostgrestSingleResponse<ScheduleInstance>
+  | { error: 'NO_FIT' | Error }
+
+type PlaceParams = {
+  userId: string
+  item: {
+    id: string
+    sourceType: 'PROJECT' | 'TASK'
+    duration_min: number
+    energy: string
+    weight: number
+  }
+  windows: Array<{ id: string; startLocal: Date; endLocal: Date }>
+  date: Date
+  client?: Client
+}
+
+export async function placeItemInWindows(params: PlaceParams): Promise<PlacementResult> {
+  const { userId, item, windows, client } = params
+  for (const w of windows) {
+    const start = new Date(w.startLocal)
+    const end = new Date(w.endLocal)
+
+    const { data: taken, error } = await fetchInstancesForRange(
+      userId,
+      start.toISOString(),
+      end.toISOString(),
+      client
+    )
+    if (error) {
+      return { error }
+    }
+
+    const sorted = (taken ?? []).sort(
+      (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime()
+    )
+
+    let cursor = start
+    const durMin = item.duration_min
+
+    for (const block of sorted) {
+      const blockStart = new Date(block.start_utc)
+      const blockEnd = new Date(block.end_utc)
+      if (diffMin(cursor, blockStart) >= durMin) {
+        const startUTC = cursor.toISOString()
+        const endUTC = addMin(cursor, durMin).toISOString()
+        return await createInstance(
+          {
+            userId,
+            sourceType: item.sourceType,
+            sourceId: item.id,
+            windowId: w.id,
+            startUTC,
+            endUTC,
+            durationMin: durMin,
+            weightSnapshot: item.weight,
+            energyResolved: item.energy,
+          },
+          client
+        )
+      }
+      if (blockEnd > cursor) {
+        cursor = blockEnd
+      }
+    }
+
+    if (diffMin(cursor, end) >= durMin) {
+      const startUTC = cursor.toISOString()
+      const endUTC = addMin(cursor, durMin).toISOString()
+      return await createInstance(
+        {
+          userId,
+          sourceType: item.sourceType,
+          sourceId: item.id,
+          windowId: w.id,
+          startUTC,
+          endUTC,
+          durationMin: durMin,
+          weightSnapshot: item.weight,
+          energyResolved: item.energy,
+        },
+        client
+      )
+    }
+  }
+
+  return { error: 'NO_FIT' }
+}
+
+function diffMin(a: Date, b: Date) {
+  return Math.floor((b.getTime() - a.getTime()) / 60000)
+}

--- a/src/lib/scheduler/reschedule.ts
+++ b/src/lib/scheduler/reschedule.ts
@@ -1,0 +1,214 @@
+import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js'
+import type { Database } from '../../../types/supabase'
+import { fetchBacklogNeedingSchedule, type ScheduleInstance } from './instanceRepo'
+import { buildProjectItems } from './projects'
+import {
+  fetchReadyTasks,
+  fetchWindowsForDate,
+  fetchProjectsMap,
+  type WindowLite,
+} from './repo'
+import { placeItemInWindows } from './placement'
+import { ENERGY } from './config'
+import type { TaskLite } from './weight'
+import { taskWeight } from './weight'
+
+type Client = SupabaseClient<Database>
+
+const GRACE_MIN = 60
+
+type ScheduleFailure = {
+  itemId: string
+  reason: string
+  detail?: unknown
+}
+
+type ScheduleBacklogResult = {
+  placed: ScheduleInstance[]
+  failures: ScheduleFailure[]
+  error?: PostgrestError | null
+}
+
+function ensureClient(client?: Client): Client {
+  if (client) return client
+  throw new Error('Supabase client not available')
+}
+
+export async function markMissedAndQueue(
+  userId: string,
+  now = new Date(),
+  client?: Client
+) {
+  const supabase = ensureClient(client)
+  const cutoff = new Date(now.getTime() - GRACE_MIN * 60000).toISOString()
+  return await supabase
+    .from('schedule_instances')
+    .update({ status: 'missed' })
+    .eq('user_id', userId)
+    .eq('status', 'scheduled')
+    .lt('end_utc', cutoff)
+}
+
+export async function scheduleBacklog(
+  userId: string,
+  baseDate = new Date(),
+  client?: Client
+): Promise<ScheduleBacklogResult> {
+  const supabase = ensureClient(client)
+  const result: ScheduleBacklogResult = { placed: [], failures: [] }
+
+  const missed = await fetchBacklogNeedingSchedule(userId, supabase)
+  if (missed.error) {
+    result.error = missed.error
+    return result
+  }
+
+  const tasks = await fetchReadyTasks(supabase)
+  const projectsMap = await fetchProjectsMap(supabase)
+  const projectItems = buildProjectItems(Object.values(projectsMap), tasks)
+
+  const taskMap: Record<string, TaskLite> = {}
+  for (const task of tasks) taskMap[task.id] = task
+  const projectItemMap: Record<string, (typeof projectItems)[number]> = {}
+  for (const item of projectItems) projectItemMap[item.id] = item
+
+  type QueueItem = {
+    id: string
+    sourceType: 'PROJECT' | 'TASK'
+    duration_min: number
+    energy: string
+    weight: number
+  }
+
+  const queue: QueueItem[] = []
+
+  for (const m of missed.data ?? []) {
+    const def =
+      m.source_type === 'PROJECT'
+        ? projectItemMap[m.source_id]
+        : taskMap[m.source_id]
+    if (!def) continue
+
+    const duration =
+      'duration_min' in def && typeof def.duration_min === 'number'
+        ? def.duration_min
+        : m.duration_min ?? 0
+    if (!duration) continue
+
+    const resolvedEnergy =
+      ('energy' in def && def.energy)
+        ? String(def.energy)
+        : m.energy_resolved
+    const weight =
+      typeof m.weight_snapshot === 'number'
+        ? m.weight_snapshot
+        : m.source_type === 'PROJECT'
+          ? (def as { weight?: number }).weight ?? 0
+          : taskWeight(def as TaskLite)
+
+    queue.push({
+      id: def.id,
+      sourceType: m.source_type,
+      duration_min: duration,
+      energy: (resolvedEnergy ?? 'NO').toUpperCase(),
+      weight,
+    })
+  }
+
+  queue.sort((a, b) => b.weight - a.weight)
+
+  const baseStart = startOfDay(baseDate)
+
+  for (const item of queue) {
+    let scheduled = false
+    for (let offset = 0; offset < 28 && !scheduled; offset += 1) {
+      const day = addDays(baseStart, offset)
+      const windows = await fetchCompatibleWindowsForItem(supabase, day, item)
+      if (windows.length === 0) continue
+
+      const placed = await placeItemInWindows({
+        userId,
+        item,
+        windows,
+        date: day,
+        client: supabase,
+      })
+
+      if (!('status' in placed)) {
+        if (placed.error !== 'NO_FIT') {
+          result.failures.push({ itemId: item.id, reason: 'error', detail: placed.error })
+        }
+        continue
+      }
+
+      if (placed.error) {
+        result.failures.push({ itemId: item.id, reason: 'error', detail: placed.error })
+        continue
+      }
+
+      if (placed.data) {
+        result.placed.push(placed.data)
+        scheduled = true
+      }
+    }
+
+    if (!scheduled) {
+      result.failures.push({ itemId: item.id, reason: 'NO_WINDOW' })
+    }
+  }
+
+  return result
+}
+
+async function fetchCompatibleWindowsForItem(
+  supabase: Client,
+  date: Date,
+  item: { energy: string; duration_min: number }
+) {
+  const windows = await fetchWindowsForDate(date, supabase)
+  const itemIdx = energyIndex(item.energy)
+  const compatible = windows.filter(w => energyIndex(w.energy) >= itemIdx)
+  return compatible.map(w => ({
+    id: w.id,
+    startLocal: resolveWindowStart(w, date),
+    endLocal: resolveWindowEnd(w, date),
+  }))
+}
+
+function energyIndex(level?: string | null) {
+  if (!level) return -1
+  const up = level.toUpperCase()
+  return ENERGY.LIST.indexOf(up as (typeof ENERGY.LIST)[number])
+}
+
+function resolveWindowStart(win: WindowLite, date: Date) {
+  const [hour = 0, minute = 0] = win.start_local.split(':').map(Number)
+  const start = startOfDay(date)
+  if (win.fromPrevDay) start.setDate(start.getDate() - 1)
+  start.setHours(hour, minute, 0, 0)
+  return start
+}
+
+function resolveWindowEnd(win: WindowLite, date: Date) {
+  const [hour = 0, minute = 0] = win.end_local.split(':').map(Number)
+  const base = win.fromPrevDay ? startOfDay(date) : startOfDay(date)
+  const end = new Date(base)
+  end.setHours(hour, minute, 0, 0)
+  const start = resolveWindowStart(win, date)
+  if (end <= start) {
+    end.setDate(end.getDate() + 1)
+  }
+  return end
+}
+
+function startOfDay(date: Date) {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function addDays(date: Date, amount: number) {
+  const d = new Date(date)
+  d.setDate(d.getDate() + amount)
+  return d
+}

--- a/src/lib/time/tz.ts
+++ b/src/lib/time/tz.ts
@@ -1,0 +1,14 @@
+export function localWindowToUTC(dateLocalISO: string): string {
+  if (!dateLocalISO) throw new Error('Expected local ISO string')
+  const [datePart, timePart = '00:00:00'] = dateLocalISO.split('T')
+  const [year, month, day] = datePart.split('-').map(Number)
+  const [hour = 0, minute = 0, second = 0] = timePart
+    .split(':')
+    .map(value => Number(value))
+  const localDate = new Date(year, (month ?? 1) - 1, day ?? 1, hour, minute, second)
+  return localDate.toISOString()
+}
+
+export function toLocal(isoUTC: string): Date {
+  return new Date(isoUTC)
+}

--- a/supabase/functions/scheduler_cron/index.ts
+++ b/supabase/functions/scheduler_cron/index.ts
@@ -1,0 +1,34 @@
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import type { Database } from '../../../types/supabase.ts'
+import {
+  markMissedAndQueue,
+  scheduleBacklog,
+} from '../../../src/lib/scheduler/reschedule.ts'
+
+const SUPABASE_URL =
+  Deno.env.get('DENO_ENV_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? ''
+const SUPABASE_KEY =
+  Deno.env.get('DENO_ENV_SUPABASE_SERVICE_ROLE_KEY') ??
+  Deno.env.get('DENO_ENV_SUPABASE_ANON_KEY') ??
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
+  ''
+
+serve(async req => {
+  const { searchParams } = new URL(req.url)
+  const userId = searchParams.get('userId')
+  if (!userId) {
+    return new Response('missing userId', { status: 400 })
+  }
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    return new Response('missing supabase credentials', { status: 500 })
+  }
+
+  const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_KEY)
+  const now = new Date()
+
+  await markMissedAndQueue(userId, now, supabase)
+  await scheduleBacklog(userId, now, supabase)
+
+  return new Response('ok', { status: 200 })
+})

--- a/supabase/functions/scheduler_cron/index.ts
+++ b/supabase/functions/scheduler_cron/index.ts
@@ -1,34 +1,508 @@
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts'
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import type { Database } from '../../../types/supabase.ts'
 import {
-  markMissedAndQueue,
-  scheduleBacklog,
-} from '../../../src/lib/scheduler/reschedule.ts'
+  createClient,
+  type SupabaseClient,
+} from 'https://esm.sh/@supabase/supabase-js@2?dts'
+import type { Database } from '../../../types/supabase.ts'
 
-const SUPABASE_URL =
-  Deno.env.get('DENO_ENV_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? ''
-const SUPABASE_KEY =
-  Deno.env.get('DENO_ENV_SUPABASE_SERVICE_ROLE_KEY') ??
-  Deno.env.get('DENO_ENV_SUPABASE_ANON_KEY') ??
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
-  ''
+type Client = SupabaseClient<Database>
+type ScheduleInstance = Database['public']['Tables']['schedule_instances']['Row']
+
+const GRACE_MIN = 60
+const ENERGY_ORDER = ['NO', 'LOW', 'MEDIUM', 'HIGH', 'ULTRA', 'EXTREME'] as const
 
 serve(async req => {
-  const { searchParams } = new URL(req.url)
-  const userId = searchParams.get('userId')
-  if (!userId) {
-    return new Response('missing userId', { status: 400 })
+  try {
+    const { searchParams } = new URL(req.url)
+    const userId = searchParams.get('userId')
+    if (!userId) {
+      return new Response('missing userId', { status: 400 })
+    }
+
+    const supabaseUrl =
+      Deno.env.get('DENO_ENV_SUPABASE_URL') ??
+      Deno.env.get('SUPABASE_URL') ??
+      ''
+    const supabaseKey =
+      Deno.env.get('DENO_ENV_SUPABASE_SERVICE_ROLE_KEY') ??
+      Deno.env.get('DENO_ENV_SUPABASE_ANON_KEY') ??
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ??
+      ''
+
+    if (!supabaseUrl || !supabaseKey) {
+      return new Response('missing supabase credentials', { status: 500 })
+    }
+
+    const supabase = createClient<Database>(supabaseUrl, supabaseKey)
+    const now = new Date()
+
+    const missedResult = await markMissedAndQueue(supabase, userId, now)
+    if (missedResult.error) {
+      console.error('markMissedAndQueue error', missedResult.error)
+      return new Response(JSON.stringify(missedResult), { status: 500 })
+    }
+
+    const scheduleResult = await scheduleBacklog(supabase, userId, now)
+    if (scheduleResult.error) {
+      console.error('scheduleBacklog error', scheduleResult.error)
+      return new Response(JSON.stringify(scheduleResult), { status: 500 })
+    }
+
+    return new Response(JSON.stringify(scheduleResult), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  } catch (error) {
+    console.error('scheduler_cron failure', error)
+    return new Response('internal error', { status: 500 })
   }
-  if (!SUPABASE_URL || !SUPABASE_KEY) {
-    return new Response('missing supabase credentials', { status: 500 })
-  }
-
-  const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_KEY)
-  const now = new Date()
-
-  await markMissedAndQueue(userId, now, supabase)
-  await scheduleBacklog(userId, now, supabase)
-
-  return new Response('ok', { status: 200 })
 })
+
+async function markMissedAndQueue(client: Client, userId: string, now: Date) {
+  const cutoff = new Date(now.getTime() - GRACE_MIN * 60_000).toISOString()
+  return await client
+    .from('schedule_instances')
+    .update({ status: 'missed' })
+    .eq('user_id', userId)
+    .eq('status', 'scheduled')
+    .lt('end_utc', cutoff)
+}
+
+async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
+  const missed = await fetchMissedInstances(client, userId)
+  if (missed.error) return { placed: [], failures: [], error: missed.error }
+
+  const tasks = await fetchReadyTasks(client, userId)
+  const projects = await fetchProjectsMap(client, userId)
+  const projectItems = buildProjectItems(Object.values(projects), tasks)
+
+  const taskMap = new Map(tasks.map(task => [task.id, task]))
+  const projectMap = new Map(projectItems.map(project => [project.id, project]))
+
+  type QueueItem = {
+    id: string
+    sourceType: 'PROJECT' | 'TASK'
+    duration_min: number
+    energy: string
+    weight: number
+  }
+
+  const queue: QueueItem[] = []
+
+  for (const instance of missed.data ?? []) {
+    const def =
+      instance.source_type === 'PROJECT'
+        ? projectMap.get(instance.source_id)
+        : taskMap.get(instance.source_id)
+    if (!def) continue
+
+    const duration =
+      'duration_min' in def && typeof def.duration_min === 'number'
+        ? def.duration_min
+        : instance.duration_min ?? 0
+    if (!duration) continue
+
+    const resolvedEnergy =
+      ('energy' in def && def.energy)
+        ? String(def.energy)
+        : instance.energy_resolved ?? 'NO'
+
+    const weight =
+      typeof instance.weight_snapshot === 'number'
+        ? instance.weight_snapshot
+        : instance.source_type === 'PROJECT'
+          ? (projectMap.get(instance.source_id)?.weight ?? 0)
+          : taskMap.get(instance.source_id)
+            ? taskWeight(taskMap.get(instance.source_id)!)
+            : 0
+
+    queue.push({
+      id: def.id,
+      sourceType: instance.source_type,
+      duration_min: duration,
+      energy: resolvedEnergy ?? 'NO',
+      weight,
+    })
+  }
+
+  queue.sort((a, b) => b.weight - a.weight)
+
+  const baseStart = startOfDay(baseDate)
+  const placed: ScheduleInstance[] = []
+  const failures: { itemId: string; reason: string; detail?: unknown }[] = []
+
+  for (const item of queue) {
+    let scheduled = false
+    for (let offset = 0; offset < 28 && !scheduled; offset += 1) {
+      const day = addDays(baseStart, offset)
+      const windows = await fetchCompatibleWindowsForItem(client, userId, day, item)
+      if (windows.length === 0) continue
+
+      const placedInstance = await placeItemInWindows(client, userId, item, windows)
+      if (placedInstance) {
+        placed.push(placedInstance)
+        scheduled = true
+      }
+    }
+
+    if (!scheduled) {
+      failures.push({ itemId: item.id, reason: 'NO_WINDOW' })
+    }
+  }
+
+  return { placed, failures, error: null as const }
+}
+
+async function fetchMissedInstances(client: Client, userId: string) {
+  return await client
+    .from('schedule_instances')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('status', 'missed')
+    .order('weight_snapshot', { ascending: false })
+}
+
+type TaskLite = {
+  id: string
+  name: string
+  priority: string
+  stage: string
+  duration_min: number
+  energy: string | null
+  project_id?: string | null
+  skill_icon?: string | null
+}
+
+type ProjectLite = {
+  id: string
+  name?: string
+  priority: string
+  stage: string
+  energy?: string | null
+}
+
+type ProjectItem = ProjectLite & {
+  name: string
+  duration_min: number
+  energy: string
+  weight: number
+  taskCount: number
+  skill_icon?: string | null
+}
+
+async function fetchReadyTasks(client: Client, userId: string): Promise<TaskLite[]> {
+  const { data, error } = await client
+    .from('tasks')
+    .select('id, name, priority, stage, duration_min, energy, project_id, skills(icon)')
+    .eq('user_id', userId)
+
+  if (error) {
+    console.error('fetchReadyTasks error', error)
+    return []
+  }
+
+  return (data ?? []).map(task => ({
+    id: task.id,
+    name: task.name ?? '',
+    priority: task.priority ?? 'NO',
+    stage: task.stage ?? 'PREPARE',
+    duration_min: task.duration_min ?? 0,
+    energy: task.energy ?? 'NO',
+    project_id: task.project_id ?? null,
+    skill_icon: ((task.skills as { icon?: string | null } | null)?.icon ?? null) as
+      | string
+      | null,
+  }))
+}
+
+async function fetchProjectsMap(client: Client, userId: string): Promise<Record<string, ProjectLite>> {
+  const { data, error } = await client
+    .from('projects')
+    .select('id, name, priority, stage, energy')
+    .eq('user_id', userId)
+
+  if (error) {
+    console.error('fetchProjectsMap error', error)
+    return {}
+  }
+
+  const map: Record<string, ProjectLite> = {}
+  for (const project of data ?? []) {
+    map[project.id] = {
+      id: project.id,
+      name: project.name ?? '',
+      priority: project.priority ?? 'NO',
+      stage: project.stage ?? 'RESEARCH',
+      energy: project.energy ?? 'NO',
+    }
+  }
+  return map
+}
+
+function buildProjectItems(projects: ProjectLite[], tasks: TaskLite[]): ProjectItem[] {
+  const items: ProjectItem[] = []
+  for (const project of projects) {
+    const related = tasks.filter(task => task.project_id === project.id)
+    const duration = related.reduce((sum, task) => sum + task.duration_min, 0) || 60
+
+    const normalizeEnergy = (value?: string | null) => {
+      const upper = (value ?? '').toUpperCase()
+      return ENERGY_ORDER.includes(upper as (typeof ENERGY_ORDER)[number])
+        ? (upper as string)
+        : 'NO'
+    }
+
+    const energy = related.reduce<string>((current, task) => {
+      const candidate = normalizeEnergy(task.energy)
+      if (!current) return candidate
+      return energyIndex(candidate) > energyIndex(current) ? candidate : current
+    }, normalizeEnergy(project.energy))
+
+    const weight = projectWeight(project, related.reduce((sum, task) => sum + taskWeight(task), 0))
+
+    const skill_icon = related.find(task => task.skill_icon)?.skill_icon ?? null
+
+    items.push({
+      ...project,
+      name: project.name ?? '',
+      duration_min: duration,
+      energy,
+      weight,
+      taskCount: related.length,
+      skill_icon,
+    })
+  }
+  return items
+}
+
+async function fetchCompatibleWindowsForItem(
+  client: Client,
+  userId: string,
+  date: Date,
+  item: { energy: string; duration_min: number }
+) {
+  const windows = await fetchWindowsForDate(client, userId, date)
+  const itemIdx = energyIndex(item.energy)
+  const compatible = windows.filter(window => energyIndex(window.energy) >= itemIdx)
+  return compatible.map(window => ({
+    id: window.id,
+    startLocal: resolveWindowStart(window, date),
+    endLocal: resolveWindowEnd(window, date),
+  }))
+}
+
+type WindowRecord = {
+  id: string
+  label: string
+  energy: string
+  start_local: string
+  end_local: string
+  days: number[] | null
+  fromPrevDay?: boolean
+}
+
+async function fetchWindowsForDate(client: Client, userId: string, date: Date) {
+  const weekday = date.getDay()
+  const prevWeekday = (weekday + 6) % 7
+
+  const [{ data: today, error: errToday }, { data: prev, error: errPrev }] = await Promise.all([
+    client
+      .from('windows')
+      .select('id, label, energy, start_local, end_local, days')
+      .eq('user_id', userId)
+      .contains('days', [weekday]),
+    client
+      .from('windows')
+      .select('id, label, energy, start_local, end_local, days')
+      .eq('user_id', userId)
+      .contains('days', [prevWeekday]),
+  ])
+
+  if (errToday) console.error('fetchWindowsForDate error (today)', errToday)
+  if (errPrev) console.error('fetchWindowsForDate error (prev)', errPrev)
+
+  const crosses = (window: WindowRecord) => {
+    const [sh = 0, sm = 0] = window.start_local.split(':').map(Number)
+    const [eh = 0, em = 0] = window.end_local.split(':').map(Number)
+    return eh < sh || (eh === sh && em < sm)
+  }
+
+  const prevCross = (prev ?? [])
+    .filter(crosses)
+    .map(window => ({ ...window, fromPrevDay: true as const }))
+
+  return [...(today ?? []), ...prevCross]
+}
+
+async function placeItemInWindows(
+  client: Client,
+  userId: string,
+  item: { id: string; sourceType: 'PROJECT' | 'TASK'; duration_min: number; energy: string; weight: number },
+  windows: Array<{ id: string; startLocal: Date; endLocal: Date }>
+): Promise<ScheduleInstance | null> {
+  for (const window of windows) {
+    const start = new Date(window.startLocal)
+    const end = new Date(window.endLocal)
+
+    const { data: taken, error } = await client
+      .from('schedule_instances')
+      .select('*')
+      .eq('user_id', userId)
+      .lt('start_utc', end.toISOString())
+      .gt('end_utc', start.toISOString())
+      .neq('status', 'canceled')
+
+    if (error) {
+      console.error('fetchInstancesForRange error', error)
+      continue
+    }
+
+    const sorted = (taken ?? []).sort(
+      (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime()
+    )
+
+    let cursor = start
+    const durMin = item.duration_min
+
+    for (const block of sorted) {
+      const blockStart = new Date(block.start_utc)
+      const blockEnd = new Date(block.end_utc)
+      if (diffMin(cursor, blockStart) >= durMin) {
+        return await createInstance(client, userId, item, window.id, cursor, durMin)
+      }
+      if (blockEnd > cursor) cursor = blockEnd
+    }
+
+    if (diffMin(cursor, end) >= durMin) {
+      return await createInstance(client, userId, item, window.id, cursor, durMin)
+    }
+  }
+
+  return null
+}
+
+async function createInstance(
+  client: Client,
+  userId: string,
+  item: { id: string; sourceType: 'PROJECT' | 'TASK'; duration_min: number; energy: string; weight: number },
+  windowId: string,
+  start: Date,
+  durationMin: number
+) {
+  const startUTC = start.toISOString()
+  const endUTC = addMin(start, durationMin).toISOString()
+
+  const { data, error } = await client
+    .from('schedule_instances')
+    .insert({
+      user_id: userId,
+      source_type: item.sourceType,
+      source_id: item.id,
+      window_id: windowId,
+      start_utc: startUTC,
+      end_utc: endUTC,
+      duration_min: durationMin,
+      status: 'scheduled',
+      weight_snapshot: item.weight,
+      energy_resolved: item.energy,
+    })
+    .select('*')
+    .single()
+
+  if (error) {
+    console.error('createInstance error', error)
+    return null
+  }
+
+  return data
+}
+
+function resolveWindowStart(window: WindowRecord, date: Date) {
+  const [hour = 0, minute = 0] = window.start_local.split(':').map(Number)
+  const base = startOfDay(date)
+  if (window.fromPrevDay) base.setDate(base.getDate() - 1)
+  const start = new Date(base)
+  start.setHours(hour, minute, 0, 0)
+  return start
+}
+
+function resolveWindowEnd(window: WindowRecord, date: Date) {
+  const [hour = 0, minute = 0] = window.end_local.split(':').map(Number)
+  const end = startOfDay(date)
+  end.setHours(hour, minute, 0, 0)
+  const start = resolveWindowStart(window, date)
+  if (end <= start) {
+    end.setDate(end.getDate() + 1)
+  }
+  return end
+}
+
+function startOfDay(date: Date) {
+  const copy = new Date(date)
+  copy.setHours(0, 0, 0, 0)
+  return copy
+}
+
+function addDays(date: Date, amount: number) {
+  const copy = new Date(date)
+  copy.setDate(copy.getDate() + amount)
+  return copy
+}
+
+function addMin(date: Date, minutes: number) {
+  return new Date(date.getTime() + minutes * 60_000)
+}
+
+function diffMin(a: Date, b: Date) {
+  return Math.floor((b.getTime() - a.getTime()) / 60_000)
+}
+
+function energyIndex(level?: string | null) {
+  if (!level) return -1
+  const upper = level.toUpperCase()
+  return ENERGY_ORDER.indexOf(upper as (typeof ENERGY_ORDER)[number])
+}
+
+const TASK_PRIORITY_WEIGHT: Record<string, number> = {
+  NO: 0,
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+  Critical: 4,
+  'Ultra-Critical': 5,
+}
+
+const TASK_STAGE_WEIGHT: Record<string, number> = {
+  Prepare: 30,
+  Produce: 20,
+  Perfect: 10,
+}
+
+const PROJECT_PRIORITY_WEIGHT: Record<string, number> = {
+  NO: 0,
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+  Critical: 4,
+  'Ultra-Critical': 5,
+}
+
+const PROJECT_STAGE_WEIGHT: Record<string, number> = {
+  RESEARCH: 50,
+  TEST: 40,
+  BUILD: 30,
+  REFINE: 20,
+  RELEASE: 10,
+}
+
+function taskWeight(task: TaskLite) {
+  const priority = TASK_PRIORITY_WEIGHT[task.priority] ?? 0
+  const stage = TASK_STAGE_WEIGHT[task.stage] ?? 0
+  return priority + stage
+}
+
+function projectWeight(project: ProjectLite, relatedTaskWeightsSum: number) {
+  const priority = PROJECT_PRIORITY_WEIGHT[project.priority] ?? 0
+  const stage = PROJECT_STAGE_WEIGHT[project.stage] ?? 0
+  return relatedTaskWeightsSum / 1000 + priority + stage
+}

--- a/supabase/migrations/20250917_add_schedule_instances.sql
+++ b/supabase/migrations/20250917_add_schedule_instances.sql
@@ -1,0 +1,50 @@
+-- Create schedule_instances table to persist scheduled placements
+CREATE TYPE IF NOT EXISTS public.schedule_instance_source_type AS ENUM ('PROJECT', 'TASK');
+CREATE TYPE IF NOT EXISTS public.schedule_instance_status AS ENUM ('scheduled', 'completed', 'missed', 'canceled');
+
+CREATE TABLE IF NOT EXISTS public.schedule_instances (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    source_type public.schedule_instance_source_type NOT NULL,
+    source_id uuid NOT NULL,
+    window_id uuid REFERENCES public.windows(id) ON DELETE SET NULL,
+    start_utc timestamptz NOT NULL,
+    end_utc timestamptz NOT NULL,
+    duration_min integer NOT NULL CHECK (duration_min > 0),
+    status public.schedule_instance_status NOT NULL DEFAULT 'scheduled',
+    weight_snapshot integer NOT NULL,
+    energy_resolved text NOT NULL,
+    completed_at timestamptz,
+    CONSTRAINT schedule_instances_start_before_end CHECK (start_utc < end_utc)
+);
+
+CREATE INDEX IF NOT EXISTS schedule_instances_user_start_idx
+    ON public.schedule_instances (user_id, start_utc);
+CREATE INDEX IF NOT EXISTS schedule_instances_user_status_idx
+    ON public.schedule_instances (user_id, status);
+CREATE INDEX IF NOT EXISTS schedule_instances_window_idx
+    ON public.schedule_instances (window_id);
+
+ALTER TABLE public.schedule_instances ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "schedule_instances_select_own" ON public.schedule_instances;
+DROP POLICY IF EXISTS "schedule_instances_insert_own" ON public.schedule_instances;
+DROP POLICY IF EXISTS "schedule_instances_update_own" ON public.schedule_instances;
+DROP POLICY IF EXISTS "schedule_instances_delete_own" ON public.schedule_instances;
+
+CREATE POLICY "schedule_instances_select_own" ON public.schedule_instances
+    FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "schedule_instances_insert_own" ON public.schedule_instances
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "schedule_instances_update_own" ON public.schedule_instances
+    FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "schedule_instances_delete_own" ON public.schedule_instances
+    FOR DELETE USING (auth.uid() = user_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON public.schedule_instances TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -508,10 +508,63 @@ export interface Database {
           energy?: string;
         };
       };
+      schedule_instances: {
+        Row: {
+          id: string;
+          created_at: string;
+          updated_at: string;
+          user_id: string;
+          source_type: Database['public']['Enums']['schedule_instance_source_type'];
+          source_id: string;
+          window_id: string | null;
+          start_utc: string;
+          end_utc: string;
+          duration_min: number;
+          status: Database['public']['Enums']['schedule_instance_status'];
+          weight_snapshot: number;
+          energy_resolved: string;
+          completed_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          updated_at?: string;
+          user_id: string;
+          source_type: Database['public']['Enums']['schedule_instance_source_type'];
+          source_id: string;
+          window_id?: string | null;
+          start_utc: string;
+          end_utc: string;
+          duration_min: number;
+          status?: Database['public']['Enums']['schedule_instance_status'];
+          weight_snapshot: number;
+          energy_resolved: string;
+          completed_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          updated_at?: string;
+          user_id?: string;
+          source_type?: Database['public']['Enums']['schedule_instance_source_type'];
+          source_id?: string;
+          window_id?: string | null;
+          start_utc?: string;
+          end_utc?: string;
+          duration_min?: number;
+          status?: Database['public']['Enums']['schedule_instance_status'];
+          weight_snapshot?: number;
+          energy_resolved?: string;
+          completed_at?: string | null;
+        };
+      };
     };
     Views: Record<string, unknown>;
     Functions: Record<string, unknown>;
-    Enums: Record<string, unknown>;
+    Enums: {
+      schedule_instance_source_type: 'PROJECT' | 'TASK';
+      schedule_instance_status: 'scheduled' | 'completed' | 'missed' | 'canceled';
+    };
     CompositeTypes: Record<string, unknown>;
   };
 }


### PR DESCRIPTION
## Summary
- add a persisted `schedule_instances` table with Supabase types plus repo helpers for CRUD and backlog queries
- extend scheduler utilities to respect existing instances, detect missed work, and reschedule into compatible windows
- refactor the schedule page and cron function to render stored instances and trigger hourly catch-up

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cb5a586a2c832cb8bb1efb41dfb111