### PR TITLE
Allow schedule back button to return to dashboard

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -8,12 +8,17 @@ import { Fab } from "@/components/ui/Fab";
 export default function BottomNav() {
   const pathname = usePathname();
   const router = useRouter();
+  const shouldHideNav = pathname?.startsWith("/schedule");
   const items = [
     { key: "dashboard", label: "Dashboard", href: "/dashboard", icon: <Home className="h-6 w-6" /> },
     { key: "schedule", label: "Schedule", href: "/schedule", icon: <Calendar className="h-6 w-6" /> },
     { key: "friends", label: "Friends", href: "/friends", icon: <Users className="h-6 w-6" /> },
     { key: "source", label: "Source", href: "/source", icon: <DollarSign className="h-6 w-6" /> },
   ];
+
+  if (shouldHideNav) {
+    return null;
+  }
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-50" data-bottom-nav>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -6,6 +6,7 @@ import { useProfile } from "@/lib/hooks/useProfile";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,21 +15,30 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export default function TopNav() {
+  const pathname = usePathname();
+  const shouldHideNav = pathname?.startsWith("/schedule");
   const { profile, userId } = useProfile();
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const supabase = getSupabaseBrowser();
 
   useEffect(() => {
+    if (!supabase || shouldHideNav) {
+      return;
+    }
+
     const getUserEmail = async () => {
-      if (supabase) {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        setUserEmail(user?.email || null);
-      }
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      setUserEmail(user?.email || null);
     };
+
     getUserEmail();
-  }, [supabase]);
+  }, [shouldHideNav, supabase]);
+
+  if (shouldHideNav) {
+    return null;
+  }
 
   return (
     <nav className="w-full flex items-center justify-between px-4 py-2 bg-black/80 text-white border-b border-white/10 backdrop-blur">

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -20,7 +20,6 @@ import FlameEmber, { FlameLevel } from '@/components/FlameEmber'
 import { YearView } from '@/components/schedule/YearView'
 import { MonthView } from '@/components/schedule/MonthView'
 import { ScheduleTopBar } from '@/components/schedule/ScheduleTopBar'
-import EnergyPager from '@/components/schedule/EnergyPager'
 import {
   getChildView,
   getParentView,
@@ -231,6 +230,11 @@ export default function SchedulePage() {
   }
 
   function handleBack() {
+    if (view === 'year') {
+      router.push('/dashboard')
+      return
+    }
+
     const parent = getParentView(view)
     if (parent !== view) navigate(parent)
   }
@@ -279,15 +283,6 @@ export default function SchedulePage() {
     touchStartX.current = null
   }
 
-  function formatFullDate(d: Date) {
-    return d.toLocaleDateString(undefined, {
-      weekday: 'long',
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric',
-    })
-  }
-
   return (
     <ProtectedRoute>
       <div className="space-y-4 text-zinc-100">
@@ -295,21 +290,7 @@ export default function SchedulePage() {
           year={year}
           onBack={handleBack}
           onToday={handleToday}
-          canGoBack={view !== 'year'}
         />
-        <p className="text-sm text-muted-foreground">Plan and manage your time</p>
-
-        <div className="space-y-2">
-          <EnergyPager
-            activeIndex={{ year: 0, month: 1, day: 2, focus: 3 }[view]}
-            className="justify-center"
-          />
-        </div>
-
-        <div className="text-center text-sm text-gray-200">
-          {formatFullDate(view === 'focus' ? new Date() : currentDate)}
-        </div>
-
         <div
           className="relative bg-[var(--surface)]"
           onTouchStart={handleTouchStart}


### PR DESCRIPTION
## Summary
- remove the schedule page header that showed the energy preview pager and supporting text
- hide the top and bottom navigation when viewing schedule routes
- allow the schedule back button to exit to the dashboard when already on the year view

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68cb88d13920832c9d772f785de99900