### PR TITLE
Add animated folder hero to goal cards

### DIFF
--- a/components/Folder.css
+++ b/components/Folder.css
@@ -1,0 +1,272 @@
+.folder {
+  --folder-size: 1;
+  --folder-color: #5227ff;
+  --folder-back-color: #4621d9;
+  --paper-1: #ffffff;
+  --paper-2: #f6f7ff;
+  --paper-3: #eff1ff;
+  --paper-translate-x: 0px;
+  --paper-translate-y: 0px;
+  position: relative;
+  width: calc(132px * var(--folder-size));
+  height: calc(96px * var(--folder-size));
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: flex-end;
+  justify-content: center;
+  transform-style: preserve-3d;
+  touch-action: manipulation;
+  transition: filter 180ms ease;
+  will-change: transform;
+}
+
+.folder:focus-visible {
+  outline: 2px solid var(--folder-color);
+  outline-offset: calc(4px * var(--folder-size));
+}
+
+.folder[data-reduced-motion="true"] {
+  transition: none;
+}
+
+.folder__back,
+.folder__front,
+.folder__front.right,
+.paper {
+  pointer-events: none;
+}
+
+.folder__back {
+  position: absolute;
+  inset: 0;
+  border-radius: calc(18px * var(--folder-size));
+  background: linear-gradient(160deg, var(--folder-back-color), var(--folder-color));
+  box-shadow: 0 calc(10px * var(--folder-size)) calc(26px * var(--folder-size)) rgba(0, 0, 0, 0.28);
+  will-change: transform;
+}
+
+.folder__back::after {
+  content: "";
+  position: absolute;
+  top: calc(10px * var(--folder-size));
+  left: calc(18px * var(--folder-size));
+  right: calc(26px * var(--folder-size));
+  height: calc(12px * var(--folder-size));
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: calc(12px * var(--folder-size));
+  filter: blur(calc(6px * var(--folder-size)));
+  opacity: 0.6;
+}
+
+.folder__front {
+  position: absolute;
+  left: calc(8px * var(--folder-size));
+  right: calc(24px * var(--folder-size));
+  bottom: calc(6px * var(--folder-size));
+  height: calc(54px * var(--folder-size));
+  border-radius: calc(16px * var(--folder-size)) calc(16px * var(--folder-size))
+    calc(22px * var(--folder-size)) calc(22px * var(--folder-size));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.1)),
+    var(--folder-color);
+  transform-origin: bottom left;
+  transform: rotateX(0deg);
+  box-shadow: 0 calc(6px * var(--folder-size)) calc(12px * var(--folder-size)) rgba(0, 0, 0, 0.24);
+  transition: transform 220ms cubic-bezier(0.18, 0.82, 0.23, 1),
+    box-shadow 220ms ease;
+  will-change: transform;
+}
+
+.folder__front::after {
+  content: "";
+  position: absolute;
+  top: calc(-8px * var(--folder-size));
+  left: calc(12px * var(--folder-size));
+  width: calc(46px * var(--folder-size));
+  height: calc(10px * var(--folder-size));
+  border-radius: calc(10px * var(--folder-size));
+  background: rgba(255, 255, 255, 0.3);
+  filter: blur(calc(8px * var(--folder-size)));
+  opacity: 0.35;
+}
+
+.folder__front.right {
+  position: absolute;
+  top: calc(28px * var(--folder-size));
+  bottom: calc(10px * var(--folder-size));
+  right: calc(4px * var(--folder-size));
+  width: calc(20px * var(--folder-size));
+  border-radius: calc(12px * var(--folder-size));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.1)),
+    var(--folder-back-color);
+  box-shadow: inset calc(-4px * var(--folder-size)) 0 calc(8px * var(--folder-size))
+    rgba(0, 0, 0, 0.14);
+  transition: transform 220ms cubic-bezier(0.18, 0.82, 0.23, 1);
+  will-change: transform;
+}
+
+.folder__papers {
+  position: absolute;
+  left: calc(18px * var(--folder-size));
+  right: calc(36px * var(--folder-size));
+  bottom: calc(20px * var(--folder-size));
+  display: flex;
+  flex-direction: column;
+  gap: calc(6px * var(--folder-size));
+}
+
+.paper {
+  position: relative;
+  z-index: 2;
+  min-height: calc(30px * var(--folder-size));
+  border-radius: calc(10px * var(--folder-size));
+  background: var(--paper-1);
+  box-shadow: 0 calc(6px * var(--folder-size)) calc(16px * var(--folder-size)) rgba(0, 0, 0, 0.18);
+  transform: translate3d(0, calc(18px * var(--folder-size)), 0);
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 200ms ease,
+    opacity 180ms ease;
+  overflow: hidden;
+  opacity: 0;
+  will-change: transform, opacity;
+}
+
+.paper-1 {
+  background: var(--paper-1);
+  z-index: 3;
+}
+
+.paper-2 {
+  background: var(--paper-2);
+  z-index: 2;
+  transform: translate3d(0, calc(24px * var(--folder-size)), 0);
+}
+
+.paper-3 {
+  background: var(--paper-3);
+  z-index: 1;
+  transform: translate3d(0, calc(30px * var(--folder-size)), 0);
+}
+
+.paper__content {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(6px * var(--folder-size));
+  padding: calc(6px * var(--folder-size)) calc(10px * var(--folder-size));
+  font-size: calc(11px * var(--folder-size));
+  font-weight: 500;
+  color: rgba(23, 30, 43, 0.92);
+  line-height: 1.1;
+  width: 100%;
+  overflow: hidden;
+}
+
+.paper__content > * {
+  min-width: 0;
+}
+
+.paper__content svg {
+  width: calc(12px * var(--folder-size));
+  height: calc(12px * var(--folder-size));
+  flex-shrink: 0;
+  color: rgba(59, 66, 81, 0.85);
+}
+
+.paper__content span,
+.paper__content time {
+  display: inline-block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder.open .paper {
+  opacity: 1;
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(-6px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder.open .paper-2 {
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(-2px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder.open .paper-3 {
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(2px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder.open .folder__front {
+  transform: rotateX(-122deg)
+    translate3d(0, calc(-6px * var(--folder-size)), calc(2px * var(--folder-size)));
+  box-shadow: 0 calc(10px * var(--folder-size)) calc(22px * var(--folder-size))
+    rgba(0, 0, 0, 0.28);
+}
+
+.folder.open .folder__front.right {
+  transform: translate3d(calc(-2px * var(--folder-size)), calc(-4px * var(--folder-size)), 0);
+}
+
+.folder[data-pressed="true"] .paper {
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(-2px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder[data-pressed="true"].open .paper {
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(-8px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder[data-pressed="true"].open .paper-2 {
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(-4px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder[data-pressed="true"].open .paper-3 {
+  transform: translate3d(
+    var(--paper-translate-x),
+    calc(-1px * var(--folder-size) + var(--paper-translate-y)),
+    0
+  );
+}
+
+.folder:hover {
+  filter: brightness(1.02);
+}
+
+.folder:active {
+  filter: brightness(0.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .folder,
+  .folder__front,
+  .folder__front.right,
+  .paper {
+    transition: none !important;
+  }
+
+  .folder.open .folder__front {
+    transform: rotateX(-110deg);
+  }
+}

--- a/components/Folder.tsx
+++ b/components/Folder.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import React, {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/lib/utils";
+
+import "./Folder.css";
+
+const DEFAULT_COLOR = "#5227FF";
+
+interface FolderProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "color"> {
+  color?: string;
+  size?: number;
+  items: (React.ReactNode | null | undefined)[];
+  className?: string;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeHex(color: string | undefined) {
+  if (!color) return DEFAULT_COLOR;
+  const trimmed = color.trim();
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (/^[0-9a-fA-F]{3}$/.test(hex)) {
+    return (
+      "#" +
+      hex
+        .split("")
+        .map((char) => char + char)
+        .join("")
+        .toLowerCase()
+    );
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(hex)) {
+    return `#${hex.toLowerCase()}`;
+  }
+  return DEFAULT_COLOR;
+}
+
+function darkenHex(color: string, amount: number) {
+  const normalized = normalizeHex(color);
+  const hex = normalized.slice(1);
+  const value = parseInt(hex, 16);
+  if (Number.isNaN(value)) {
+    return DEFAULT_COLOR;
+  }
+  const factor = clamp(1 - amount / 100, 0, 1);
+  const r = clamp(Math.round(((value >> 16) & 0xff) * factor), 0, 255);
+  const g = clamp(Math.round(((value >> 8) & 0xff) * factor), 0, 255);
+  const b = clamp(Math.round((value & 0xff) * factor), 0, 255);
+  const next = (r << 16) | (g << 8) | b;
+  return `#${next.toString(16).padStart(6, "0")}`;
+}
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+const Folder = forwardRef<HTMLButtonElement, FolderProps>((props, forwardedRef) => {
+  const {
+    color = DEFAULT_COLOR,
+    size = 1,
+    items,
+    className,
+    open: controlledOpen,
+    defaultOpen = false,
+    onOpenChange,
+    onClick,
+    onPointerDown,
+    onPointerUp,
+    onPointerMove,
+    onPointerLeave,
+    onPointerCancel,
+    style: styleProp,
+    ...rest
+  } = props;
+
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const folderRef = useRef<HTMLButtonElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const pointerOffset = useRef({ x: 0, y: 0 });
+
+  useImperativeHandle(forwardedRef, () => folderRef.current as HTMLButtonElement, []);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const node = folderRef.current;
+    if (!node) return;
+    node.setAttribute("data-pressed", "false");
+  }, []);
+
+  useEffect(() => {
+    const node = folderRef.current;
+    if (!node) return;
+    node.setAttribute("data-reduced-motion", prefersReducedMotion ? "true" : "false");
+  }, [prefersReducedMotion]);
+
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? Boolean(controlledOpen) : uncontrolledOpen;
+
+  const colors = useMemo(() => {
+    const base = normalizeHex(color);
+    const back = darkenHex(base, 8);
+    return { base, back };
+  }, [color]);
+
+  const style = useMemo<React.CSSProperties>(() => {
+    const baseVariables: Record<string, string> = {
+      "--folder-size": size.toString(),
+      "--folder-color": colors.base,
+      "--folder-back-color": colors.back,
+      "--paper-1": "rgba(255, 255, 255, 1)",
+      "--paper-2": "rgba(246, 247, 255, 1)",
+      "--paper-3": "rgba(239, 241, 255, 1)",
+      "--paper-translate-x": "0px",
+      "--paper-translate-y": "0px",
+    };
+    return { ...baseVariables, ...(styleProp as React.CSSProperties) };
+  }, [colors.base, colors.back, size, styleProp]);
+
+  const schedulePointerUpdate = () => {
+    if (prefersReducedMotion) return;
+    if (rafRef.current !== null) return;
+    rafRef.current = window.requestAnimationFrame(() => {
+      const node = folderRef.current;
+      rafRef.current = null;
+      if (!node) return;
+      node.style.setProperty("--paper-translate-x", `${pointerOffset.current.x}px`);
+      node.style.setProperty("--paper-translate-y", `${pointerOffset.current.y}px`);
+    });
+  };
+
+  const resetPointer = () => {
+    pointerOffset.current = { x: 0, y: 0 };
+    schedulePointerUpdate();
+  };
+
+  const commitOpenChange = (nextOpen: boolean) => {
+    if (!isControlled) {
+      setUncontrolledOpen(nextOpen);
+    }
+    onOpenChange?.(nextOpen);
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!rest.disabled) {
+      commitOpenChange(!open);
+    }
+    onClick?.(event);
+  };
+
+  const handlePointerMoveInternal = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (!folderRef.current || prefersReducedMotion) {
+      onPointerMove?.(event);
+      return;
+    }
+    const rect = folderRef.current.getBoundingClientRect();
+    const relativeX = ((event.clientX - rect.left) / rect.width - 0.5) * 10 * size;
+    const relativeY = ((event.clientY - rect.top) / rect.height - 0.5) * 8 * size;
+    pointerOffset.current = { x: relativeX, y: relativeY };
+    schedulePointerUpdate();
+    onPointerMove?.(event);
+  };
+
+  const setPressed = (pressed: boolean) => {
+    const node = folderRef.current;
+    if (!node) return;
+    node.setAttribute("data-pressed", pressed ? "true" : "false");
+  };
+
+  const handlePointerDownInternal = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (!prefersReducedMotion) {
+      setPressed(true);
+    }
+    onPointerDown?.(event);
+  };
+
+  const handlePointerUpInternal = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (!prefersReducedMotion) {
+      setPressed(false);
+      resetPointer();
+    }
+    onPointerUp?.(event);
+  };
+
+  const handlePointerLeaveInternal = (
+    event: React.PointerEvent<HTMLButtonElement>
+  ) => {
+    if (!prefersReducedMotion) {
+      setPressed(false);
+      resetPointer();
+    }
+    onPointerLeave?.(event);
+  };
+
+  const handlePointerCancelInternal = (
+    event: React.PointerEvent<HTMLButtonElement>
+  ) => {
+    if (!prefersReducedMotion) {
+      setPressed(false);
+      resetPointer();
+    }
+    onPointerCancel?.(event);
+  };
+
+  const papers = items
+    .slice(0, 3)
+    .map((item, index) => {
+      if (item === null || item === undefined || item === false) {
+        return null;
+      }
+      return (
+        <div key={index} className={cn("paper", `paper-${index + 1}`)} aria-hidden>
+          <div className="paper__content">{item}</div>
+        </div>
+      );
+    })
+    .filter(Boolean);
+
+  return (
+    <button
+      {...rest}
+      ref={(node) => {
+        folderRef.current = node;
+        if (typeof forwardedRef === "function") {
+          forwardedRef(node);
+        } else if (forwardedRef) {
+          forwardedRef.current = node;
+        }
+      }}
+      type="button"
+      className={cn("folder", open && "open", className)}
+      aria-expanded={open}
+      onClick={handleClick}
+      onPointerMove={handlePointerMoveInternal}
+      onPointerDown={handlePointerDownInternal}
+      onPointerUp={handlePointerUpInternal}
+      onPointerLeave={handlePointerLeaveInternal}
+      onPointerCancel={handlePointerCancelInternal}
+      style={style}
+      data-reduced-motion={prefersReducedMotion ? "true" : "false"}
+    >
+      <div className="folder__back" aria-hidden />
+      <div className="folder__papers" aria-hidden>
+        {papers.length > 0 ? papers : null}
+      </div>
+      <div className="folder__front" aria-hidden />
+      <div className="folder__front right" aria-hidden />
+    </button>
+  );
+});
+
+Folder.displayName = "Folder";
+
+export default Folder;
+export { Folder };

--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDown, MoreHorizontal } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
+import {
+  Calendar,
+  ChevronDown,
+  Flame,
+  List,
+  MoreHorizontal,
+} from "lucide-react";
 import type { Goal } from "../types";
 import { ProjectsDropdown } from "./ProjectsDropdown";
 import {
@@ -10,6 +17,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import { Folder } from "@/components/Folder";
 
 interface GoalCardProps {
   goal: Goal;
@@ -17,17 +25,217 @@ interface GoalCardProps {
   onToggleActive?: () => void;
 }
 
+const FOLDER_COLOR_FALLBACK = "#5227FF";
+const MOBILE_FOLDER_SIZE = 0.92;
+const DESKTOP_FOLDER_SIZE = 1;
+
+const energyFolderColors: Record<Goal["energy"], string> = {
+  No: "#5227FF",
+  Low: "#4C7DFF",
+  Medium: "#6A5CFF",
+  High: "#FF885D",
+  Ultra: "#FF6FA3",
+  Extreme: "#FF4D6D",
+};
+
 export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [folderOpen, setFolderOpen] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+  const [folderSize, setFolderSize] = useState(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return MOBILE_FOLDER_SIZE;
+    }
+    return window.matchMedia("(min-width: 640px)").matches
+      ? DESKTOP_FOLDER_SIZE
+      : MOBILE_FOLDER_SIZE;
+  });
 
-  const toggle = () => {
-    setOpen((o) => !o);
+  const folderTimeoutRef = useRef<number | null>(null);
+  const loadingTimeoutRef = useRef<number | null>(null);
+  const folderLockRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+      return;
+    }
+
+    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sizeQuery = window.matchMedia("(min-width: 640px)");
+
+    const handleMotionChange = () =>
+      setPrefersReducedMotion(motionQuery.matches);
+    const handleSizeChange = () =>
+      setFolderSize(
+        sizeQuery.matches ? DESKTOP_FOLDER_SIZE : MOBILE_FOLDER_SIZE
+      );
+
+    handleMotionChange();
+    handleSizeChange();
+
+    motionQuery.addEventListener("change", handleMotionChange);
+    sizeQuery.addEventListener("change", handleSizeChange);
+
+    return () => {
+      motionQuery.removeEventListener("change", handleMotionChange);
+      sizeQuery.removeEventListener("change", handleSizeChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (folderTimeoutRef.current !== null) {
+        window.clearTimeout(folderTimeoutRef.current);
+      }
+      if (loadingTimeoutRef.current !== null) {
+        window.clearTimeout(loadingTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!open) {
+      setFolderOpen(false);
+    }
+  }, [open]);
+
+  const animationDelay = prefersReducedMotion ? 0 : 200;
+
+  const setCardOpen = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (loadingTimeoutRef.current !== null) {
+      window.clearTimeout(loadingTimeoutRef.current);
+      loadingTimeoutRef.current = null;
+    }
+    if (nextOpen) {
       setLoading(true);
-      setTimeout(() => setLoading(false), 500);
+      loadingTimeoutRef.current = window.setTimeout(() => {
+        setLoading(false);
+        loadingTimeoutRef.current = null;
+      }, 500);
+    } else {
+      setLoading(false);
     }
   };
+
+  const handleMainActivate = () => {
+    const nextOpen = !open;
+    setFolderOpen(nextOpen);
+    setCardOpen(nextOpen);
+  };
+
+  const handleMainKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleMainActivate();
+    }
+  };
+
+  const handleFolderClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const nextOpen = !open;
+
+    if (folderLockRef.current) {
+      return;
+    }
+
+    setFolderOpen(nextOpen);
+    folderLockRef.current = true;
+
+    if (folderTimeoutRef.current !== null) {
+      window.clearTimeout(folderTimeoutRef.current);
+      folderTimeoutRef.current = null;
+    }
+
+    if (animationDelay === 0) {
+      setCardOpen(nextOpen);
+      folderLockRef.current = false;
+      return;
+    }
+
+    folderTimeoutRef.current = window.setTimeout(() => {
+      setCardOpen(nextOpen);
+      folderLockRef.current = false;
+      folderTimeoutRef.current = null;
+    }, animationDelay);
+  };
+
+  const goalColor = (goal as { color?: string | null }).color;
+  const folderColor = useMemo(() => {
+    const usableColor =
+      typeof goalColor === "string" && goalColor.trim().length > 0
+        ? goalColor
+        : undefined;
+    return (
+      usableColor || energyFolderColors[goal.energy] || FOLDER_COLOR_FALLBACK
+    );
+  }, [goal.energy, goalColor]);
+
+  const totalTasks = useMemo(() => {
+    return goal.projects.reduce((sum, project) => sum + project.tasks.length, 0);
+  }, [goal.projects]);
+
+  const dueDateInfo = useMemo(() => {
+    if (!goal.dueDate) {
+      return { label: "No Due Date", dateTime: undefined as string | undefined };
+    }
+    const parsed = new Date(goal.dueDate);
+    if (Number.isNaN(parsed.getTime())) {
+      return { label: "No Due Date", dateTime: undefined as string | undefined };
+    }
+    return {
+      label: parsed.toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      }),
+      dateTime: goal.dueDate,
+    };
+  }, [goal.dueDate]);
+
+  const tasksLabel = useMemo(() => {
+    return `${totalTasks} ${totalTasks === 1 ? "task" : "tasks"}`;
+  }, [totalTasks]);
+
+  const energyLabel = useMemo(() => {
+    return goal.energy === "No" ? "NO ENERGY" : goal.energy.toUpperCase();
+  }, [goal.energy]);
+
+  const folderItems = useMemo<ReactNode[]>(() => {
+    const dueDateNode = (
+      <span className="inline-flex items-center gap-1.5">
+        <Calendar aria-hidden className="shrink-0" />
+        {dueDateInfo.dateTime ? (
+          <time dateTime={dueDateInfo.dateTime} className="truncate">
+            {dueDateInfo.label}
+          </time>
+        ) : (
+          <span className="truncate">{dueDateInfo.label}</span>
+        )}
+      </span>
+    );
+
+    const tasksNode = (
+      <span className="inline-flex items-center gap-1.5">
+        <List aria-hidden className="shrink-0" />
+        <span className="truncate">{tasksLabel}</span>
+      </span>
+    );
+
+    const energyNode = (
+      <span className="inline-flex items-center gap-1.5 uppercase">
+        <Flame aria-hidden className="shrink-0" />
+        <span className="truncate">{energyLabel}</span>
+      </span>
+    );
+
+    return [dueDateNode, tasksNode, energyNode];
+  }, [dueDateInfo, tasksLabel, energyLabel]);
 
   const priorityStyles =
     goal.priority === "High"
@@ -37,53 +245,80 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
       : "bg-gray-600 text-gray-100";
 
   return (
-    <div className="rounded-lg border border-white/10 bg-[#2c2c2c] shadow text-left">
-      <div className="relative">
-        <button
-          onClick={toggle}
-          aria-expanded={open}
-          aria-controls={`goal-${goal.id}`}
-          className="w-full flex items-start justify-between p-4 active:scale-95 transition-transform motion-safe:duration-150 motion-reduce:transform-none"
-        >
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              {goal.emoji && <span className="text-xl" aria-hidden>{goal.emoji}</span>}
-              <span id={`goal-${goal.id}-label`} className="font-medium truncate">
-                {goal.title}
-              </span>
-            </div>
-            <div className="flex flex-wrap items-center gap-2 mt-2 text-xs text-gray-300">
-              <div className="w-10 h-2 bg-gray-700 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-gray-200"
-                  style={{ width: `${goal.progress}%` }}
-                />
-              </div>
-              {goal.dueDate && (
-                <span className="px-2 py-0.5 bg-gray-700 rounded-full">
-                  {new Date(goal.dueDate).toLocaleDateString()}
-                </span>
-              )}
-              <span className={`px-2 py-0.5 rounded-full ${priorityStyles}`}>
-                {goal.priority}
-              </span>
-              <span className="px-2 py-0.5 bg-gray-700 rounded-full">
-                {goal.projects.length} projects
-              </span>
-            </div>
-          </div>
-          <ChevronDown
-            className={`w-5 h-5 ml-2 transition-transform ${open ? "rotate-180" : ""}`}
+    <div className="rounded-lg border border-white/10 bg-[#2c2c2c] text-left shadow">
+      <div className="relative flex items-start gap-4 p-4 sm:p-5">
+        <div className="flex-shrink-0 pt-1">
+          <Folder
+            color={folderColor}
+            size={folderSize}
+            items={folderItems}
+            open={folderOpen}
+            onClick={handleFolderClick}
+            aria-label={`${goal.title} summary folder`}
+            aria-controls={`goal-${goal.id}`}
+            className="transition-transform"
           />
-        </button>
-        <div className="absolute top-2 right-2">
+        </div>
+        <div
+          role="button"
+          tabIndex={0}
+          aria-controls={`goal-${goal.id}`}
+          aria-expanded={open}
+          onClick={handleMainActivate}
+          onKeyDown={handleMainKeyDown}
+          className="flex-1 min-w-0 cursor-pointer select-none rounded-xl p-1 pr-10 transition-colors duration-150 hover:bg-white/5 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/40"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                {goal.emoji && (
+                  <span className="text-xl" aria-hidden>
+                    {goal.emoji}
+                  </span>
+                )}
+                <span
+                  id={`goal-${goal.id}-label`}
+                  className="truncate font-medium text-white"
+                >
+                  {goal.title}
+                </span>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-300">
+                <div className="h-2 w-16 overflow-hidden rounded-full bg-gray-700">
+                  <div
+                    className="h-full bg-gray-200"
+                    style={{ width: `${goal.progress}%` }}
+                  />
+                </div>
+                {dueDateInfo.dateTime && (
+                  <span className="rounded-full bg-gray-700 px-2 py-0.5">
+                    {dueDateInfo.label}
+                  </span>
+                )}
+                <span className={`rounded-full px-2 py-0.5 ${priorityStyles}`}>
+                  {goal.priority}
+                </span>
+                <span className="rounded-full bg-gray-700 px-2 py-0.5">
+                  {goal.projects.length} projects
+                </span>
+              </div>
+            </div>
+            <ChevronDown
+              className={`mt-1 h-5 w-5 flex-shrink-0 text-gray-400 transition-transform ${
+                open ? "rotate-180" : ""
+              }`}
+              aria-hidden
+            />
+          </div>
+        </div>
+        <div className="absolute right-3 top-3">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
                 aria-label="Goal actions"
-                className="p-1 rounded bg-gray-700"
+                className="rounded bg-gray-700 p-1 transition-colors hover:bg-gray-600"
               >
-                <MoreHorizontal className="w-4 h-4" />
+                <MoreHorizontal className="h-4 w-4" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ export const viewport = {
 };
 
 import "./globals.css";
+import "../../components/Folder.css";
 import ClientProviders from "@/components/ClientProviders";
 import ErrorBoundary from "@/components/debug/ErrorBoundary";
 import AuthProvider from "@/components/auth/AuthProvider";


### PR DESCRIPTION
## Summary
- add a reusable animated Folder component with theming, accessibility state, and pointer parallax support
- replace goal card thumbnails with the Folder hero and coordinate navigation timing with the animation
- load the folder styles globally so the animation renders consistently in all layouts

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68cc429b48f8832ca2d4a5ba3fd0f597