### PR TITLE
Schedule only projects

### DIFF
--- a/src/lib/scheduler/instanceRepo.ts
+++ b/src/lib/scheduler/instanceRepo.ts
@@ -33,7 +33,6 @@ export async function fetchInstancesForRange(
 export async function createInstance(
   input: {
     userId: string
-    sourceType: 'PROJECT' | 'TASK'
     sourceId: string
     windowId?: string | null
     startUTC: string
@@ -49,7 +48,7 @@ export async function createInstance(
     .from('schedule_instances')
     .insert({
       user_id: input.userId,
-      source_type: input.sourceType,
+      source_type: 'PROJECT',
       source_id: input.sourceId,
       window_id: input.windowId ?? null,
       start_utc: input.startUTC,

--- a/src/lib/scheduler/placement.ts
+++ b/src/lib/scheduler/placement.ts
@@ -14,7 +14,6 @@ type PlaceParams = {
   userId: string
   item: {
     id: string
-    sourceType: 'PROJECT' | 'TASK'
     duration_min: number
     energy: string
     weight: number
@@ -56,7 +55,6 @@ export async function placeItemInWindows(params: PlaceParams): Promise<Placement
         return await createInstance(
           {
             userId,
-            sourceType: item.sourceType,
             sourceId: item.id,
             windowId: w.id,
             startUTC,
@@ -79,7 +77,6 @@ export async function placeItemInWindows(params: PlaceParams): Promise<Placement
       return await createInstance(
         {
           userId,
-          sourceType: item.sourceType,
           sourceId: item.id,
           windowId: w.id,
           startUTC,

--- a/src/lib/scheduler/projects.ts
+++ b/src/lib/scheduler/projects.ts
@@ -5,6 +5,11 @@ import { taskWeight, projectWeight } from './weight'
 export const DEFAULT_PROJECT_DURATION_MIN = 60
 export const DEFAULT_PROJECT_ENERGY: Energy = 'NO'
 
+const normalizeDuration = (value?: number | null) => {
+  const numeric = Number(value ?? 0)
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null
+}
+
 export type ProjectItem = ProjectLite & {
   name: string
   duration_min: number
@@ -21,9 +26,14 @@ export function buildProjectItems(
   const items: ProjectItem[] = []
   for (const p of projects) {
     const related = tasks.filter(t => t.project_id === p.id)
+    const projectDuration = normalizeDuration(p.duration_min)
+    const tasksDuration = related.reduce(
+      (sum, t) => sum + Math.max(t.duration_min, 0),
+      0
+    )
     const duration_min =
-      related.reduce((sum, t) => sum + t.duration_min, 0) ||
-      DEFAULT_PROJECT_DURATION_MIN
+      projectDuration ??
+      (tasksDuration > 0 ? tasksDuration : DEFAULT_PROJECT_DURATION_MIN)
     const norm = (e?: string | null): Energy | null => {
       const up = (e ?? '').toUpperCase()
       return ENERGY.LIST.includes(up as Energy) ? (up as Energy) : null

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -86,7 +86,7 @@ export async function fetchProjectsMap(
 
   const { data, error } = await supabase
     .from('projects')
-    .select('id, name, priority, stage, energy');
+    .select('id, name, priority, stage, energy, duration_min');
 
   if (error) throw error;
   const map: Record<string, ProjectLite> = {};

--- a/src/lib/scheduler/weight.ts
+++ b/src/lib/scheduler/weight.ts
@@ -24,6 +24,7 @@ export type ProjectLite = {
   priority: string;
   stage: string;
   energy?: string | null;
+  duration_min?: number | null;
 };
 
 export type GoalLite = {


### PR DESCRIPTION
## Summary
- ensure the Supabase scheduler only enqueues project backlog and derives durations from each project's duration_min with sensible fallbacks
- update shared scheduler utilities to build project items from project durations and to skip creating task schedule instances
- simplify placement instance creation so schedule_instances are always written with a PROJECT source type

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68cc5d109530832cb03417f0fb4dc9cc