### PR TITLE
Revamp monument detail experience

### DIFF
--- a/src/components/monuments/ActivityPanel.tsx
+++ b/src/components/monuments/ActivityPanel.tsx
@@ -2,11 +2,23 @@ import { Card } from "@/components/ui/card";
 
 export default function ActivityPanel() {
   return (
-    <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
-      <h3 className="text-[#E7ECF2] font-medium mb-3">Activity</h3>
-      <div className="relative pl-6">
-        <div className="absolute left-2 top-0 bottom-0 w-px bg-white/10" />
-        <p className="text-[#A7B0BD]">No activity yet. Progress will appear here once milestones or goals are updated.</p>
+    <Card className="rounded-3xl border border-white/8 bg-[#101725] px-6 py-6 shadow-[0_18px_48px_rgba(3,7,18,0.55)]">
+      <div className="flex flex-col gap-2">
+        <p className="text-xs uppercase tracking-wide text-white/60">Activity</p>
+        <h3 className="text-xl font-semibold text-white">Recent progress</h3>
+        <p className="text-sm text-white/60">
+          As you add milestones, notes, or goals, we&apos;ll surface the latest updates so you can see momentum at a glance.
+        </p>
+      </div>
+      <div className="relative mt-6 rounded-2xl border border-dashed border-white/15 bg-white/5 px-5 py-6 text-white/70">
+        <div className="absolute left-5 top-6 bottom-6 w-px bg-white/10" aria-hidden="true" />
+        <div className="relative pl-8">
+          <span className="absolute left-0 top-1 size-3 rounded-full bg-white/40" aria-hidden="true" />
+          <p className="text-base font-medium text-white">No activity yet</p>
+          <p className="mt-1 text-sm text-white/70">
+            Make your first update to start this timeline of wins.
+          </p>
+        </div>
       </div>
     </Card>
   );

--- a/src/components/monuments/MilestonesPanel.tsx
+++ b/src/components/monuments/MilestonesPanel.tsx
@@ -3,6 +3,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useState, useCallback, type Ref } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getSupabaseBrowser } from "@/lib/supabase";
 
 interface Milestone {
@@ -71,35 +72,70 @@ function MilestonesPanelInternal(
   return (
     <Card
       id="monument-milestones"
-      className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]"
+      className="rounded-3xl border border-white/8 bg-[#101725] px-6 py-6 shadow-[0_18px_48px_rgba(3,7,18,0.55)]"
     >
-      <h3 className="text-[#E7ECF2] font-medium mb-3">Milestones</h3>
-      {loading ? (
-        <p className="text-[#A7B0BD] mb-4">Loading...</p>
-      ) : hasMilestones ? (
-        <ul className="mb-4 space-y-2">
-          {milestones.map((m) => (
-            <li key={m.id} className="text-[#E7ECF2]">
-              {m.title}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="text-[#A7B0BD] mb-4">
-          No milestones yet. Add your first milestone to start tracking progress.
-        </p>
-      )}
-      <div className="flex gap-2">
-        <Button onClick={handleAdd} aria-label="Add milestone">
-          + Milestone
-        </Button>
-        <Button
-          variant="outline"
-          onClick={onAutoSplit}
-          aria-label="Auto split milestones"
-        >
-          Auto Split
-        </Button>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wide text-white/60">Milestones</p>
+          <h3 className="text-xl font-semibold text-white">Break the work down</h3>
+          <p className="text-sm text-white/60">
+            Outline the critical wins that will move this monument forward.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleAdd}
+            aria-label="Add milestone"
+            className="rounded-full border-white/20 bg-white/5 text-white hover:border-white/30 hover:bg-white/15"
+          >
+            + Milestone
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onAutoSplit}
+            aria-label="Auto split milestones"
+            className="rounded-full border-white/15 bg-transparent text-white/80 hover:border-white/25 hover:bg-white/10"
+          >
+            Auto split
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-3">
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <Skeleton
+                key={index}
+                className="h-14 rounded-2xl border border-white/10 bg-white/5"
+              />
+            ))}
+          </div>
+        ) : hasMilestones ? (
+          <ul className="space-y-3">
+            {milestones.map((m, index) => (
+              <li
+                key={m.id}
+                className="group flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white transition hover:border-white/20 hover:bg-white/10"
+              >
+                <span className="flex size-8 items-center justify-center rounded-full bg-white/10 text-xs font-semibold text-white/70">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="flex-1 text-base font-medium">{m.title}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-2xl border border-dashed border-white/15 bg-white/5 px-4 py-6 text-white/70">
+            <p className="text-base font-medium text-white">No milestones yet</p>
+            <p className="mt-1 text-sm text-white/60">
+              Start by adding the key steps that will move this monument forward.
+            </p>
+          </div>
+        )}
       </div>
     </Card>
   );

--- a/src/components/monuments/MonumentDetail.tsx
+++ b/src/components/monuments/MonumentDetail.tsx
@@ -3,9 +3,15 @@
 import { useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  BatteryCharging,
+  Flame,
+  Sparkles,
+} from "lucide-react";
+
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import MilestonesPanel, { MilestonesPanelHandle } from "./MilestonesPanel";
@@ -68,34 +74,63 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
 
   if (loading) {
     return (
-      <main className="p-4 flex flex-col gap-4 sm:gap-5">
-        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5">
-          <div className="flex items-center gap-4">
-            <Skeleton className="h-14 w-14 rounded-full" />
-            <div className="flex-1 space-y-2">
-              <Skeleton className="h-5 w-1/2" />
-              <Skeleton className="h-4 w-1/3" />
+      <main className="px-4 pb-12 pt-6 sm:px-6 lg:px-8">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+          <Skeleton className="h-9 w-40 rounded-full bg-white/10" />
+          <div className="overflow-hidden rounded-3xl border border-white/5 bg-[#111520] p-6 sm:p-8">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-start gap-4">
+                <Skeleton className="h-20 w-20 rounded-2xl" />
+                <div className="space-y-3">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-4 w-52" />
+                  <Skeleton className="h-4 w-32" />
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Skeleton className="h-9 w-32 rounded-full" />
+                <Skeleton className="h-9 w-32 rounded-full" />
+                <Skeleton className="h-9 w-32 rounded-full" />
+              </div>
+            </div>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-2xl border border-white/10 bg-white/5 p-4"
+                >
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="mt-3 h-5 w-32" />
+                  <Skeleton className="mt-2 h-4 w-3/4" />
+                </div>
+              ))}
             </div>
           </div>
-          <div className="mt-4 flex gap-2">
-            <Skeleton className="h-8 w-20" />
-            <Skeleton className="h-8 w-24" />
-            <Skeleton className="h-8 w-24" />
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+            <Skeleton className="h-72 rounded-3xl bg-[#111520]" />
+            <Skeleton className="h-72 rounded-3xl bg-[#111520]" />
           </div>
-        </Card>
-        {Array.from({ length: 3 }).map((_, i) => (
-          <Skeleton key={i} className="h-32 rounded-2xl" />
-        ))}
+        </div>
       </main>
     );
   }
 
   if (error || !monument) {
     return (
-      <main className="p-4">
-        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 text-center">
-          <p className="text-[#A7B0BD]">{error || "Monument not found"}</p>
-        </Card>
+      <main className="px-4 pb-12 pt-6 sm:px-6 lg:px-8">
+        <div className="mx-auto w-full max-w-3xl">
+          <div className="rounded-3xl border border-white/8 bg-[#111520] p-6 text-center shadow-[0_18px_48px_rgba(3,7,18,0.45)] sm:p-8">
+            <h2 className="text-xl font-semibold text-white">We couldn&apos;t find that monument</h2>
+            <p className="mt-2 text-sm text-[#A7B0BD]">
+              {error || "The monument you&apos;re looking for may have been removed."}
+            </p>
+            <div className="mt-6 flex justify-center">
+              <Button asChild>
+                <Link href="/monuments">Back to Monuments</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
       </main>
     );
   }
@@ -124,42 +159,197 @@ export function MonumentDetail({ id }: MonumentDetailProps) {
     router.push("/goals/new");
   };
 
+  const quickFacts = [
+    {
+      label: "Momentum streak",
+      value: "0 days",
+      description: "Build consistency to light this up.",
+      icon: Flame,
+    },
+    {
+      label: "Status",
+      value: "Not charging yet",
+      description: "No activity has been recorded for this monument yet.",
+      icon: BatteryCharging,
+    },
+    {
+      label: "Next step",
+      value: "Create a milestone",
+      description: "Break the vision into concrete wins to unlock progress.",
+      icon: Sparkles,
+    },
+  ] as const;
+
   return (
-    <main className="p-4 flex flex-col gap-4 sm:gap-5">
-      <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 sm:p-5 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
-        <div className="flex items-center gap-4">
-          <span className="text-5xl" role="img" aria-label={`Monument: ${monument.title}`}>
-            {monument.emoji || "\uD83D\uDDFC\uFE0F"}
-          </span>
-          <div className="flex flex-col">
-            <h2 className="text-[#E7ECF2] font-bold">{monument.title}</h2>
-            <Badge variant="outline" className="mt-1 self-start px-2 py-0">
-              0 day streak
-            </Badge>
+    <main className="px-4 pb-12 pt-6 sm:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            className="gap-2 rounded-full border border-white/5 bg-white/5 px-3 text-sm text-white/70 hover:border-white/10 hover:bg-white/10 hover:text-white"
+          >
+            <Link href="/monuments">
+              <ArrowLeft className="size-4" aria-hidden="true" />
+              Back to monuments
+            </Link>
+          </Button>
+        </div>
+
+        <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#101725] via-[#0B1220] to-[#05070F] p-6 shadow-[0_24px_64px_rgba(3,7,18,0.65)] sm:p-8">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 -z-10"
+          >
+            <div className="absolute -top-32 right-10 h-72 w-72 rounded-full bg-[rgba(88,122,255,0.25)] blur-3xl" />
+            <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-[rgba(40,221,180,0.2)] blur-3xl" />
+          </div>
+
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex flex-col gap-6">
+              <div className="flex items-start gap-4">
+                <span
+                  className="flex h-20 w-20 items-center justify-center rounded-2xl bg-white/10 text-4xl text-white sm:h-24 sm:w-24 sm:text-5xl"
+                  role="img"
+                  aria-label={`Monument: ${monument.title}`}
+                >
+                  {monument.emoji || "\uD83D\uDDFC\uFE0F"}
+                </span>
+                <div className="flex flex-col gap-3">
+                  <Badge
+                    variant="outline"
+                    className="w-fit rounded-full border-white/25 bg-white/10 px-3 py-1 text-xs uppercase tracking-wide text-white/70"
+                  >
+                    Monument overview
+                  </Badge>
+                  <h1 className="text-3xl font-semibold text-white sm:text-4xl">
+                    {monument.title}
+                  </h1>
+                  <p className="max-w-xl text-sm text-white/70 sm:text-base">
+                    Rally your focus around this monument. Break it into milestones, link supporting goals, and capture notes so future you knows exactly what to do next.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-3 self-start">
+              <Button
+                asChild
+                size="sm"
+                className="rounded-full bg-white text-slate-900 hover:bg-white/90"
+              >
+                <Link href={`/monuments/${id}/edit`}>Edit monument</Link>
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleAddMilestone}
+                aria-label="Add milestone"
+                className="rounded-full border-white/20 bg-white/10 text-white hover:border-white/30 hover:bg-white/20"
+              >
+                + Milestone
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleAddNote}
+                aria-label="Add note"
+                className="rounded-full border-transparent bg-white/5 text-white hover:border-white/20 hover:bg-white/15"
+              >
+                Quick note
+              </Button>
+            </div>
+          </div>
+
+          <dl className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {quickFacts.map(({ label, value, description, icon: Icon }) => (
+              <div
+                key={label}
+                className="flex flex-col gap-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-white"
+              >
+                <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-white/60">
+                  <Icon className="size-4" aria-hidden="true" />
+                  {label}
+                </div>
+                <div className="text-lg font-semibold sm:text-xl">{value}</div>
+                <p className="text-sm text-white/70">{description}</p>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <MilestonesPanel
+              ref={milestonesRef}
+              monumentId={id}
+              onAutoSplit={handleAutoSplit}
+            />
+
+            <section className="rounded-3xl border border-white/8 bg-[rgba(16,23,37,0.9)] p-6 shadow-[0_18px_48px_rgba(3,7,18,0.55)]">
+              <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-white/60">
+                    Goals
+                  </p>
+                  <h2 className="text-xl font-semibold text-white">
+                    Goals connected to this monument
+                  </h2>
+                  <p className="mt-1 text-sm text-white/60">
+                    Keep related goals in view so you always know what feeds this monument.
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCreateGoal}
+                  className="rounded-full border-white/20 bg-white/5 text-white hover:border-white/30 hover:bg-white/15"
+                >
+                  New goal
+                </Button>
+              </header>
+              <div className="mt-6">
+                <FilteredGoalsGrid
+                  entity="monument"
+                  id={id}
+                  onCreateGoal={handleCreateGoal}
+                />
+              </div>
+            </section>
+          </div>
+
+          <div className="space-y-6">
+            <section className="rounded-3xl border border-white/8 bg-[#101725] p-6 shadow-[0_18px_48px_rgba(3,7,18,0.55)]">
+              <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-white/60">
+                    Notes
+                  </p>
+                  <h2 className="text-xl font-semibold text-white">
+                    Capture quick ideas and insights
+                  </h2>
+                  <p className="mt-1 text-sm text-white/60">
+                    Drop thoughts, resources, or learnings as you make progress.
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleAddNote}
+                  className="rounded-full border-white/20 bg-white/5 text-white hover:border-white/30 hover:bg-white/15"
+                >
+                  New note
+                </Button>
+              </header>
+              <div className="mt-6">
+                <MonumentNotesGrid monumentId={id} inputRef={noteInputRef} />
+              </div>
+            </section>
+
+            <ActivityPanel />
           </div>
         </div>
-        <p className="mt-3 text-[#A7B0BD]">Not charging yet.</p>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <Button asChild>
-            <Link href={`/monuments/${id}/edit`}>Edit</Link>
-          </Button>
-          <Button variant="outline" onClick={handleAddMilestone} aria-label="Add milestone">+ Milestone</Button>
-          <Button variant="outline" onClick={handleAddNote} aria-label="Add note">+ Note</Button>
-        </div>
-      </Card>
-
-      <MilestonesPanel
-        ref={milestonesRef}
-        monumentId={id}
-        onAutoSplit={handleAutoSplit}
-      />
-      <FilteredGoalsGrid
-        entity="monument"
-        id={id}
-        onCreateGoal={handleCreateGoal}
-      />
-      <MonumentNotesGrid monumentId={id} inputRef={noteInputRef} />
-      <ActivityPanel />
+      </div>
     </main>
   );
 }

--- a/src/components/notes/MonumentNoteCard.tsx
+++ b/src/components/notes/MonumentNoteCard.tsx
@@ -12,11 +12,18 @@ interface MonumentNoteCardProps {
 export function MonumentNoteCard({ note, monumentId }: MonumentNoteCardProps) {
   return (
     <Link href={`/monuments/${monumentId}/notes/${note.id}`}>
-      <Card className="h-full hover:bg-gray-800 transition-colors">
-        <CardContent className="p-4">
-          <h3 className="text-lg font-medium text-white truncate">
-            {note.title || "Untitled"}
-          </h3>
+      <Card className="h-full rounded-2xl border border-white/10 bg-white/5 transition hover:border-white/20 hover:bg-white/10">
+        <CardContent className="flex h-full flex-col gap-3 p-4">
+          <div className="space-y-1">
+            <p className="text-xs uppercase tracking-wide text-white/60">Note</p>
+            <h3 className="text-base font-medium text-white line-clamp-2">
+              {note.title || "Untitled"}
+            </h3>
+          </div>
+          <p className="flex-1 text-sm text-white/70 line-clamp-3">
+            {note.content || "Open this note to add more detail."}
+          </p>
+          <span className="text-xs font-medium text-white/60">Open note →</span>
         </CardContent>
       </Card>
     </Link>

--- a/src/components/notes/MonumentNotesGrid.tsx
+++ b/src/components/notes/MonumentNotesGrid.tsx
@@ -62,24 +62,30 @@ export function MonumentNotesGrid({ monumentId, inputRef }: MonumentNotesGridPro
 
   return (
     <div className="space-y-4">
-      <form onSubmit={handleAdd} className="space-y-2">
+      <form onSubmit={handleAdd} className="space-y-3">
         <Textarea
           ref={textareaRef}
           rows={1}
           value={draft}
           onChange={handleInput}
           placeholder="Quick note..."
-          className="resize-none overflow-hidden rounded-2xl border border-white/5 bg-[#111520] p-3 text-sm text-[#E7ECF2] placeholder-[#A7B0BD]"
+          className="resize-none overflow-hidden rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/60 focus-visible:ring-white/30 focus-visible:ring-offset-0"
         />
         <div className="flex justify-end">
-          <Button type="submit" size="sm" disabled={!draft.trim()} aria-label="Save note">
-            Save
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!draft.trim()}
+            aria-label="Save note"
+            className="rounded-full px-4"
+          >
+            Save note
           </Button>
         </div>
       </form>
 
       {hasNotes ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {notes.map((note) => (
             <MonumentNoteCard
               key={note.id}
@@ -89,8 +95,11 @@ export function MonumentNotesGrid({ monumentId, inputRef }: MonumentNotesGridPro
           ))}
         </div>
       ) : (
-        <Card className="rounded-2xl border border-white/5 bg-[#111520] p-4 shadow-[0_6px_24px_rgba(0,0,0,0.35)]">
-          <p className="text-[#A7B0BD]">No notes yet. Capture your first thought here.</p>
+        <Card className="rounded-3xl border border-white/10 bg-white/5 p-5 text-white/70 shadow-[0_18px_48px_rgba(3,7,18,0.35)]">
+          <p className="text-base font-medium text-white">No notes yet</p>
+          <p className="mt-1 text-sm text-white/70">
+            Capture your first thought here and keep ideas close at hand.
+          </p>
         </Card>
       )}
     </div>


### PR DESCRIPTION
## Summary
- redesign the monument detail hero layout with quick stats, global actions, and sectioned content
- refresh the milestones and activity panels to match the new visual system and provide clearer empty/loading states
- polish the notes entry and card styling so capturing monument notes feels cleaner

## Testing
- pnpm lint
- vitest run test/env.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68cc7850f838832cab829c8db3c588ca