### PR TITLE
Adjust goal folder grid and styling

### DIFF
--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -215,8 +215,8 @@ export default function DashboardClient() {
         className="safe-bottom mt-2 px-4"
       >
         {loadingGoals ? (
-          <div className="grid grid-cols-3 justify-items-center gap-4 sm:grid-cols-4 lg:grid-cols-5">
-            {Array.from({ length: 9 }).map((_, i) => (
+          <div className="grid grid-cols-5 justify-items-center gap-4">
+            {Array.from({ length: 5 }).map((_, i) => (
               <div
                 key={i}
                 className="h-[140px] w-[110px] animate-pulse rounded-[26px] bg-gray-800/70"
@@ -224,7 +224,7 @@ export default function DashboardClient() {
             ))}
           </div>
         ) : goals.length > 0 ? (
-          <div className="grid grid-cols-3 justify-items-center gap-4 sm:grid-cols-4 lg:grid-cols-5">
+          <div className="grid grid-cols-5 justify-items-center gap-4">
             {goals.map((goal) => (
               <GoalFolderCard key={goal.id} goal={goal} />
             ))}

--- a/src/app/(app)/dashboard/components/Folder.module.css
+++ b/src/app/(app)/dashboard/components/Folder.module.css
@@ -121,14 +121,14 @@
   border-radius: clamp(10px, calc(12px * var(--folder-scale, 1)), 16px);
   background: linear-gradient(
     120deg,
-    rgba(222, 215, 255, 0.22),
-    rgba(111, 76, 204, 0.45)
+    rgba(243, 244, 246, 0.88),
+    rgba(209, 213, 219, 0.88)
   );
   box-shadow: 0 calc(14px * var(--folder-scale, 1)) calc(30px * var(--folder-scale, 1))
-      rgba(12, 6, 29, 0.55),
+      rgba(15, 23, 42, 0.28),
     inset 0 calc(1px * var(--folder-scale, 1)) calc(2px * var(--folder-scale, 1))
-      rgba(255, 255, 255, 0.18);
-  color: #fdf4ff;
+      rgba(255, 255, 255, 0.32);
+  color: #1f2937;
   font-weight: 600;
   letter-spacing: 0.02em;
   text-transform: uppercase;
@@ -147,7 +147,7 @@
   backface-visibility: hidden;
   text-shadow: 0 calc(1px * var(--folder-scale, 1))
       calc(4px * var(--folder-scale, 1))
-      rgba(5, 2, 12, 0.65);
+      rgba(15, 23, 42, 0.16);
 }
 
 .folderLabel :global(.folder-label-text) {

--- a/src/app/(app)/dashboard/components/GoalFolderCard.tsx
+++ b/src/app/(app)/dashboard/components/GoalFolderCard.tsx
@@ -10,13 +10,13 @@ type GoalFolderCardProps = {
   onToggleActive?: () => void;
 };
 
-const gemstoneGradient =
-  "linear-gradient(140deg, #16092B 0%, #301352 38%, #4C1E78 66%, #9B55F5 100%)";
+const lightGrayGradient =
+  "linear-gradient(140deg, #F9FAFB 0%, #E5E7EB 48%, #D1D5DB 100%)";
 
 const folderThemes: Record<Goal["priority"], { base: string; gradient: string }> = {
-  High: { base: "#150828", gradient: gemstoneGradient },
-  Medium: { base: "#16092B", gradient: gemstoneGradient },
-  Low: { base: "#150828", gradient: gemstoneGradient },
+  High: { base: "#C3C9D2", gradient: lightGrayGradient },
+  Medium: { base: "#C3C9D2", gradient: lightGrayGradient },
+  Low: { base: "#C3C9D2", gradient: lightGrayGradient },
 };
 
 export function GoalFolderCard({


### PR DESCRIPTION
## Summary
- adjust the dashboard goals layout to use a single-row, five-column grid and matching skeleton placeholders for goal folders
- refresh the goal folder theme to a light gray gradient and update the label styling to fit the new palette

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc9eee992c832cbfa3cee1acb893d7