### PR TITLE
Make bottom nav background opaque

### DIFF
--- a/components/BottomBarNav.tsx
+++ b/components/BottomBarNav.tsx
@@ -65,7 +65,7 @@ export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavPro
   const leftItems = items.slice(0, mid);
   const rightItems = items.slice(mid);
   return (
-    <nav className="w-full bg-black/80 text-gray-400 border-t border-white/10 backdrop-blur">
+    <nav className="w-full bg-black text-gray-400 border-t border-white/10 backdrop-blur">
       <div className="grid h-16 w-full grid-cols-[1fr_3.5rem_1fr] items-center">
         <div className="flex h-full min-w-0 items-center justify-evenly">
           {leftItems.map(renderItem)}


### PR DESCRIPTION
## Summary
- update the bottom navigation background to use a solid fill instead of a translucent one so it is no longer transparent

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb9a6347c832cb444cd88f52c45ee