### PR TITLE
Use goal folders for related goals on skill pages

### DIFF
--- a/lib/hooks/useFilteredGoals.ts
+++ b/lib/hooks/useFilteredGoals.ts
@@ -24,6 +24,8 @@ export function useFilteredGoals({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const supabase = getSupabaseBrowser();
+  const goalSelectFields =
+    "id,name,priority,energy,emoji,monument_id,status,active,due_date,created_at,updated_at";
 
   const fetchGoals = async () => {
     if (!supabase || !id) return;
@@ -40,7 +42,7 @@ export function useFilteredGoals({
         // Direct query for monument goals
         const { data, error } = await supabase
           .from("goals")
-          .select("id,name,priority,energy,monument_id,created_at")
+          .select(goalSelectFields)
           .eq("user_id", (await supabase.auth.getUser()).data.user?.id)
           .eq("monument_id", id)
           .order("priority", { ascending: false })
@@ -118,7 +120,7 @@ export function useFilteredGoals({
           const goalIdsArray = Array.from(goalIds);
           const { data: goalsDataResult, error: goalsError } = await supabase
             .from("goals")
-            .select("id,name,priority,energy,monument_id,created_at")
+            .select(goalSelectFields)
             .eq("user_id", userId)
             .in("id", goalIdsArray)
             .order("priority", { ascending: false })

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -27,6 +27,11 @@ export type GoalItem = {
   name: string;
   priority: "NO" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL" | "ULTRA-CRITICAL";
   energy: "NO" | "LOW" | "MEDIUM" | "HIGH" | "ULTRA" | "EXTREME";
+  status?: string | null;
+  active?: boolean | null;
+  emoji?: string | null;
+  due_date?: string | null;
+  updated_at?: string | null;
   monument_id?: string | null;
   created_at: string;
 };


### PR DESCRIPTION
## Summary
- update the filtered goals grid to reuse the goal folder card layout when showing related goals
- load additional goal metadata (emoji, status, activity, due date, updated time) so the folders can reflect real goal state
- adjust goal filtering and empty states to better match the skill and monument contexts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccb9eeef34832ca887bb107bcf7295