### PR TITLE
Revamp dashboard layout and styling

### DIFF
--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
-import { Section } from "@/components/ui/Section";
 import { LevelBanner } from "@/components/ui/LevelBanner";
 import { MonumentContainer } from "@/components/ui/MonumentContainer";
 import SkillsCarousel from "./_skills/SkillsCarousel";
@@ -200,39 +199,186 @@ export default function DashboardClient() {
     setLoadingGoals(false);
   };
 
+  const activeGoalsCount = goals.length;
+  const averageProgress = activeGoalsCount
+    ? Math.round(
+        goals.reduce((sum, goal) => sum + goal.progress, 0) / activeGoalsCount
+      )
+    : 0;
+  const linkedProjectsCount = goals.reduce(
+    (total, goal) => total + goal.projects.length,
+    0
+  );
+  const openTasksCount = goals.reduce(
+    (total, goal) =>
+      total +
+      goal.projects.reduce(
+        (projectTotal, project) =>
+          projectTotal +
+          project.tasks.filter((task) => task.stage !== "PERFECT").length,
+        0
+      ),
+    0
+  );
+
+  const overviewStats = [
+    {
+      label: "Active goals",
+      value: activeGoalsCount,
+      hint: "Focus areas on your radar.",
+    },
+    {
+      label: "Avg completion",
+      value: `${averageProgress}%`,
+      hint: "Across all active goals.",
+    },
+    {
+      label: "Linked projects",
+      value: linkedProjectsCount,
+      hint:
+        linkedProjectsCount > 0
+          ? "Projects synced to goals."
+          : "Connect projects to build momentum.",
+    },
+    {
+      label: "Open tasks",
+      value: openTasksCount,
+      hint:
+        openTasksCount > 0
+          ? "Tasks still in motion."
+          : "You're all caught up.",
+    },
+  ];
+
   return (
-    <main className="pb-20">
-      <LevelBanner level={80} current={3200} total={4000} />
+    <main className="pb-24">
+      <div className="relative isolate">
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute left-[6%] top-[-180px] h-[320px] w-[320px] rounded-full bg-emerald-500/20 blur-[140px]" aria-hidden />
+          <div className="absolute right-[12%] top-[180px] h-[420px] w-[420px] rounded-full bg-indigo-500/15 blur-[170px]" aria-hidden />
+        </div>
+        <div className="mx-auto flex max-w-6xl flex-col gap-10 px-4 pb-16 pt-6 sm:px-6 lg:px-8">
+          <section className="card relative overflow-hidden rounded-[32px] border border-white/10 bg-white/[0.02] px-6 py-8 shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur">
+            <div className="absolute inset-y-0 right-[-25%] top-8 hidden h-[420px] w-[420px] rounded-full bg-sky-500/10 blur-3xl sm:block" aria-hidden />
+            <div className="relative grid gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)] lg:items-center">
+              <div className="space-y-6">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-white/60">
+                  Overview
+                </p>
+                <h1 className="text-3xl font-semibold text-white sm:text-[34px] sm:leading-[1.2]">
+                  Your creative command center
+                </h1>
+                <p className="max-w-2xl text-sm text-white/70">
+                  Keep goals, projects, and skill building aligned in one place.
+                </p>
+                <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                  {overviewStats.map(({ label, value, hint }) => (
+                    <div
+                      key={label}
+                      className="rounded-2xl border border-white/10 bg-white/[0.05] p-4 shadow-inner shadow-black/30"
+                    >
+                      <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60">
+                        {label}
+                      </dt>
+                      <dd className="mt-2 text-2xl font-semibold text-white">
+                        {loadingGoals ? (
+                          <span
+                            className="inline-flex h-7 w-16 animate-pulse rounded-full bg-white/20"
+                            aria-hidden
+                          />
+                        ) : (
+                          value
+                        )}
+                      </dd>
+                      <p className="mt-1 text-xs text-white/60">{hint}</p>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+              <div className="flex items-center justify-center">
+                <LevelBanner
+                  level={80}
+                  current={3200}
+                  total={4000}
+                  className="mx-0 mt-0 w-full max-w-sm border border-white/10 bg-gradient-to-br from-white/[0.07] to-white/[0.02] p-6 shadow-[0_18px_40px_rgba(0,0,0,0.55)]"
+                />
+              </div>
+            </div>
+          </section>
 
-      <MonumentContainer />
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
+            <section className="card relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] px-6 py-6 shadow-[0_18px_40px_rgba(0,0,0,0.45)]">
+              <div className="absolute inset-x-16 top-0 h-32 rounded-full bg-emerald-500/10 blur-3xl" aria-hidden />
+              <div className="relative flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-lg font-semibold text-white">Active goals</h2>
+                  <p className="mt-1 text-sm text-white/60">
+                    Tap a folder to peek at linked projects and tasks.
+                  </p>
+                </div>
+                <Link
+                  href="/goals"
+                  className="text-sm font-semibold text-white/70 transition hover:text-white"
+                >
+                  View all
+                </Link>
+              </div>
+              <div className="relative mt-6">
+                {loadingGoals ? (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                    {Array.from({ length: 3 }).map((_, idx) => (
+                      <div
+                        key={idx}
+                        className="h-[220px] animate-pulse rounded-3xl border border-white/10 bg-white/[0.06]"
+                      />
+                    ))}
+                  </div>
+                ) : goals.length > 0 ? (
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                    {goals.map((goal) => (
+                      <GoalFolderCard
+                        key={goal.id}
+                        goal={goal}
+                        size={0.52}
+                        className="items-stretch"
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-white/20 bg-white/[0.04] py-10 text-center text-sm text-white/60">
+                    No active goals yet. Start one to build momentum.
+                  </div>
+                )}
+              </div>
+            </section>
 
-      <Section title={<Link href="/skills">Skills</Link>} className="mt-1 px-4">
-        <SkillsCarousel />
-      </Section>
+            <div className="flex flex-col gap-6">
+              <section className="card relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] px-6 py-6 shadow-[0_18px_40px_rgba(0,0,0,0.45)]">
+                <div className="absolute inset-x-8 top-0 h-32 rounded-full bg-sky-500/10 blur-3xl" aria-hidden />
+                <div className="relative flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-lg font-semibold text-white">Skill focus</h2>
+                    <p className="mt-1 text-sm text-white/60">
+                      Choose a category to explore and practice next.
+                    </p>
+                  </div>
+                  <Link
+                    href="/skills"
+                    className="text-sm font-semibold text-white/70 transition hover:text-white"
+                  >
+                    View skills
+                  </Link>
+                </div>
+                <div className="relative mt-6 -mx-4">
+                  <SkillsCarousel />
+                </div>
+              </section>
 
-      <Section
-        title={<Link href="/goals">Current Goals</Link>}
-        className="safe-bottom mt-2 px-4"
-      >
-        {loadingGoals ? (
-          <div className="grid grid-cols-1 grid-rows-5 justify-items-center gap-4">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-[140px] w-[110px] animate-pulse rounded-[26px] bg-gray-800/70"
-              />
-            ))}
+              <MonumentContainer />
+            </div>
           </div>
-        ) : goals.length > 0 ? (
-          <div className="grid grid-cols-1 grid-rows-5 justify-items-center gap-4">
-            {goals.map((goal) => (
-              <GoalFolderCard key={goal.id} goal={goal} />
-            ))}
-          </div>
-        ) : (
-          <div className="py-8 text-center text-gray-500">No active goals.</div>
-        )}
-      </Section>
+        </div>
+      </div>
     </main>
   );
 }

--- a/src/components/ui/LevelBanner.tsx
+++ b/src/components/ui/LevelBanner.tsx
@@ -1,11 +1,20 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 
 export function LevelBanner({
-  level = 80, current = 3200, total = 4000
-}:{level?:number; current?:number; total?:number;}){
-  const pct = Math.max(0, Math.min(100, Math.round((current/total)*100)));
+  level = 80,
+  current = 3200,
+  total = 4000,
+  className,
+}: {
+  level?: number;
+  current?: number;
+  total?: number;
+  className?: string;
+}) {
+  const pct = Math.max(0, Math.min(100, Math.round((current / total) * 100)));
   return (
-    <div className="card mx-4 mt-4 p-4">
+    <div className={cn("card p-4", className ?? "mx-4 mt-4")}>
       <div className="mb-3">
         <div className="font-extrabold text-[18px] tracking-wide">LEVEL {level}</div>
       </div>

--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -8,27 +8,39 @@ import { MonumentsList } from "@/components/monuments/MonumentsList";
 
 export function MonumentContainer() {
   return (
-    <section className="section mt-2">
-      <div className="mb-3">
-        <Link href="/monuments" className="h-label block">
+    <section className="card relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.02] px-6 py-6 shadow-[0_16px_40px_rgba(0,0,0,0.45)] backdrop-blur">
+      <div className="absolute inset-x-10 top-0 h-32 rounded-full bg-violet-500/10 blur-3xl" aria-hidden />
+      <div className="relative flex items-center justify-between gap-3">
+        <Link
+          href="/monuments"
+          className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60"
+        >
           Monuments
+        </Link>
+        <Link
+          href="/monuments/new"
+          className="text-xs font-semibold text-white/70 transition hover:text-white"
+        >
+          New monument
         </Link>
       </div>
 
-      <MonumentsList limit={8} createHref="/monuments/new">
-        {(monuments) => (
-          <div className="px-4">
-            <MonumentGridWithSharedTransition
-              monuments={monuments.map<MonumentCard>((m) => ({
-                id: m.id,
-                emoji: m.emoji || "\uD83C\uDFDB\uFE0F",
-                title: m.title,
-                stats: "0 Goals",
-              }))}
-            />
-          </div>
-        )}
-      </MonumentsList>
+      <div className="relative mt-6">
+        <MonumentsList limit={8} createHref="/monuments/new">
+          {(monuments) => (
+            <div className="-mx-1">
+              <MonumentGridWithSharedTransition
+                monuments={monuments.map<MonumentCard>((m) => ({
+                  id: m.id,
+                  emoji: m.emoji || "\uD83C\uDFDB\uFE0F",
+                  title: m.title,
+                  stats: "0 Goals",
+                }))}
+              />
+            </div>
+          )}
+        </MonumentsList>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the dashboard hub with a hero overview, quick stats, and refreshed goal/skill/monument sections while keeping existing interactions
- allow the LevelBanner component to accept custom class names so it can match varied layouts
- update the monuments container styling to match the new dashboard cards

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ccf6bfc7c4832c86c38c6c576e43ff