### PR TITLE
Fix project schedule timezone handling

### DIFF
--- a/components/ui/CreateSheet.tsx
+++ b/components/ui/CreateSheet.tsx
@@ -2,6 +2,7 @@
 
 import { Target, FolderOpen, CheckSquare, Repeat, X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { toLocal } from '@/lib/time/tz'
 
 interface CreateSheetProps {
   isOpen: boolean
@@ -64,14 +65,14 @@ export function CreateSheet({ isOpen, onClose, selectedTime }: CreateSheetProps)
                 <div className="text-zinc-200 font-medium">{action.name}</div>
                 {selectedTime && (
                   <div className="text-sm text-zinc-400">
-                    {new Date(selectedTime.start).toLocaleTimeString('en-US', { 
-                      hour: 'numeric', 
+                    {toLocal(selectedTime.start).toLocaleTimeString('en-US', {
+                      hour: 'numeric',
                       minute: '2-digit',
-                      hour12: true 
-                    })} - {new Date(selectedTime.end).toLocaleTimeString('en-US', { 
-                      hour: 'numeric', 
+                      hour12: true
+                    })} - {toLocal(selectedTime.end).toLocaleTimeString('en-US', {
+                      hour: 'numeric',
                       minute: '2-digit',
-                      hour12: true 
+                      hour12: true
                     })}
                   </div>
                 )}

--- a/components/ui/EventCard.tsx
+++ b/components/ui/EventCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { scheduleIcons, ScheduleIconName } from '@/lib/icons'
+import { toLocal } from '@/lib/time/tz'
 
 interface EventCardProps {
   title: string
@@ -16,9 +17,9 @@ export function EventCard({ title, start, end, icon, muted = false, onClick, sty
   const Icon = scheduleIcons[icon]
   
   const formatTime = (isoString: string) => {
-    const date = new Date(isoString)
-    return date.toLocaleTimeString('en-US', { 
-      hour: 'numeric', 
+    const date = toLocal(isoString)
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
       minute: '2-digit',
       hour12: true 
     })

--- a/components/ui/QuickPeek.tsx
+++ b/components/ui/QuickPeek.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { CheckCircle, Edit, Trash2, X } from 'lucide-react'
-import { ScheduleItem } from '@/lib/mock/schedule'
 import { scheduleIcons } from '@/lib/icons'
+import { ScheduleItem } from '@/lib/mock/schedule'
+import { toLocal } from '@/lib/time/tz'
 
 interface QuickPeekProps {
   event: ScheduleItem | null
@@ -19,9 +20,9 @@ export function QuickPeek({ event, isOpen, onClose, onEdit, onDelete, onMarkDone
   const Icon = scheduleIcons[event.icon]
   
   const formatTime = (isoString: string) => {
-    const date = new Date(isoString)
-    return date.toLocaleTimeString('en-US', { 
-      hour: 'numeric', 
+    const date = toLocal(isoString)
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
       minute: '2-digit',
       hour12: true 
     })

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -43,7 +43,7 @@ import { TaskLite, ProjectLite } from '@/lib/scheduler/weight'
 import { buildProjectItems } from '@/lib/scheduler/projects'
 import { windowRect } from '@/lib/scheduler/windowRect'
 import { ENERGY } from '@/lib/scheduler/config'
-import { toLocal } from '@/lib/time/tz'
+import { formatLocalDateKey, toLocal } from '@/lib/time/tz'
 
 function ScheduleViewShell({ children }: { children: ReactNode }) {
   const prefersReducedMotion = useReducedMotion()
@@ -302,7 +302,7 @@ export default function SchedulePage() {
   useEffect(() => {
     const params = new URLSearchParams()
     params.set('view', view)
-    params.set('date', currentDate.toISOString().slice(0, 10))
+    params.set('date', formatLocalDateKey(currentDate))
     router.replace(`${pathname}?${params.toString()}`, { scroll: false })
   }, [view, currentDate, router, pathname])
 
@@ -392,7 +392,7 @@ export default function SchedulePage() {
     const map: Record<string, FlameLevel> = {}
     for (const inst of instances) {
       const start = toLocal(inst.start_utc)
-      const key = start.toISOString().slice(0, 10)
+      const key = formatLocalDateKey(start)
       const level = (inst.energy_resolved?.toUpperCase() as FlameLevel) || 'NO'
       const current = map[key]
       if (!current || ENERGY.LIST.indexOf(level) > ENERGY.LIST.indexOf(current)) {

--- a/src/components/schedule/MonthView.tsx
+++ b/src/components/schedule/MonthView.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { FlameLevel } from "@/components/FlameEmber";
 import FlameEmber from "@/components/FlameEmber";
+import { formatLocalDateKey } from "@/lib/time/tz";
 import { cn } from "@/lib/utils";
 
 const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -248,7 +249,7 @@ const DayCell = React.memo(function DayCell({
     () => (cell ? new Date(year, month + cell.offset, cell.day) : null),
     [year, month, cell]
   );
-  const key = dayDate ? dayDate.toISOString().slice(0, 10) : "";
+  const key = dayDate ? formatLocalDateKey(dayDate) : "";
   const count = key && events ? events[key] ?? 0 : 0;
   const energy = key && energies ? energies[key] : undefined;
   const isToday = dayDate ? isSameDay(dayDate, today) : false;

--- a/src/lib/time/tz.ts
+++ b/src/lib/time/tz.ts
@@ -9,6 +9,47 @@ export function localWindowToUTC(dateLocalISO: string): string {
   return localDate.toISOString()
 }
 
+const parseIntegerOrZero = (value: string | undefined): number => {
+  const parsed = Number.parseInt(value ?? '', 10)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
 export function toLocal(isoUTC: string): Date {
-  return new Date(isoUTC)
+  if (typeof isoUTC !== 'string' || isoUTC.length === 0) {
+    return new Date(isoUTC)
+  }
+
+  const [datePart, timeAndOffset = ''] = isoUTC.split('T')
+  if (!datePart) return new Date(isoUTC)
+
+  const dateSegments = datePart.split('-')
+  if (dateSegments.length < 3) return new Date(isoUTC)
+
+  const [yearRaw, monthRaw, dayRaw] = dateSegments
+  const year = Number.parseInt(yearRaw, 10)
+  const month = Number.parseInt(monthRaw, 10)
+  const day = Number.parseInt(dayRaw, 10)
+
+  if ([year, month, day].some(Number.isNaN)) {
+    return new Date(isoUTC)
+  }
+
+  const [timePartRaw = ''] = timeAndOffset.split(/Z|[+-]/)
+  const [hourPart, minutePart, secondAndFractionPart] = timePartRaw.split(':')
+  const secondPart = secondAndFractionPart
+    ? secondAndFractionPart.split('.')[0]
+    : secondAndFractionPart
+
+  const hour = parseIntegerOrZero(hourPart)
+  const minute = parseIntegerOrZero(minutePart)
+  const second = parseIntegerOrZero(secondPart)
+
+  return new Date(year, month - 1, day, hour, minute, second)
+}
+
+export function formatLocalDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }


### PR DESCRIPTION
## Summary
- ignore timezone offsets when converting ISO timestamps so scheduled projects render at the stored start and end times
- normalize date key generation for the schedule view and month grid to avoid day shifts when formatting
- update project-related UI elements to format times via the new helper for consistent display

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68cdd5aa187c832cbff027a762daa9dd