### PR TITLE
Improve scheduler window prioritization

### DIFF
--- a/src/lib/scheduler/placement.ts
+++ b/src/lib/scheduler/placement.ts
@@ -24,7 +24,12 @@ type PlaceParams = {
     energy: string
     weight: number
   }
-  windows: Array<{ id: string; startLocal: Date; endLocal: Date }>
+  windows: Array<{
+    id: string
+    startLocal: Date
+    endLocal: Date
+    availableStartLocal?: Date
+  }>
   date: Date
   client?: Client
   reuseInstanceId?: string | null
@@ -33,7 +38,7 @@ type PlaceParams = {
 export async function placeItemInWindows(params: PlaceParams): Promise<PlacementResult> {
   const { userId, item, windows, client, reuseInstanceId } = params
   for (const w of windows) {
-    const start = new Date(w.startLocal)
+    const start = new Date(w.availableStartLocal ?? w.startLocal)
     const end = new Date(w.endLocal)
 
     const { data: taken, error } = await fetchInstancesForRange(

--- a/src/lib/scheduler/placement.ts
+++ b/src/lib/scheduler/placement.ts
@@ -29,6 +29,7 @@ type PlaceParams = {
     startLocal: Date
     endLocal: Date
     availableStartLocal?: Date
+    key?: string
   }>
   date: Date
   client?: Client

--- a/src/lib/scheduler/reschedule.ts
+++ b/src/lib/scheduler/reschedule.ts
@@ -262,6 +262,8 @@ export async function scheduleBacklog(
     return a.id.localeCompare(b.id)
   })
 
+  const windowAvailability = new Map<string, Date>()
+
   for (const item of queue) {
     let scheduled = false
     for (let offset = 0; offset < 28 && !scheduled; offset += 1) {
@@ -270,7 +272,10 @@ export async function scheduleBacklog(
         supabase,
         day,
         item,
-        offset === 0 ? { now: baseDate } : undefined
+        {
+          availability: windowAvailability,
+          now: offset === 0 ? baseDate : undefined,
+        }
       )
       if (windows.length === 0) continue
 
@@ -297,6 +302,16 @@ export async function scheduleBacklog(
 
       if (placed.data) {
         result.placed.push(placed.data)
+        const placementWindow = findPlacementWindow(
+          windows,
+          placed.data
+        )
+        if (placementWindow?.key) {
+          windowAvailability.set(
+            placementWindow.key,
+            new Date(placed.data.end_utc)
+          )
+        }
         scheduled = true
       }
     }
@@ -431,16 +446,18 @@ async function fetchCompatibleWindowsForItem(
   supabase: Client,
   date: Date,
   item: { energy: string; duration_min: number },
-  options?: { now?: Date }
+  options?: { now?: Date; availability?: Map<string, Date> }
 ) {
   const windows = await fetchWindowsForDate(date, supabase)
   const itemIdx = energyIndex(item.energy)
   const now = options?.now ? new Date(options.now) : null
   const nowMs = now?.getTime()
   const durationMs = Math.max(0, item.duration_min) * 60000
+  const availability = options?.availability
 
   const compatible = [] as Array<{
     id: string
+    key: string
     startLocal: Date
     endLocal: Date
     availableStartLocal: Date
@@ -453,20 +470,36 @@ async function fetchCompatibleWindowsForItem(
 
     const startLocal = resolveWindowStart(win, date)
     const endLocal = resolveWindowEnd(win, date)
+    const key = windowKey(win.id, startLocal)
     const startMs = startLocal.getTime()
     const endMs = endLocal.getTime()
 
     if (typeof nowMs === 'number' && endMs <= nowMs) continue
 
-    const availableStartMs = typeof nowMs === 'number' ? Math.max(startMs, nowMs) : startMs
+    const baseAvailableStartMs =
+      typeof nowMs === 'number' ? Math.max(startMs, nowMs) : startMs
+    const carriedStartMs = availability?.get(key)?.getTime()
+    const availableStartMs =
+      typeof carriedStartMs === 'number'
+        ? Math.max(baseAvailableStartMs, carriedStartMs)
+        : baseAvailableStartMs
     if (availableStartMs >= endMs) continue
     if (availableStartMs + durationMs > endMs) continue
 
+    const availableStartLocal = new Date(availableStartMs)
+    if (availability) {
+      const existing = availability.get(key)
+      if (!existing || existing.getTime() !== availableStartMs) {
+        availability.set(key, availableStartLocal)
+      }
+    }
+
     compatible.push({
       id: win.id,
+      key,
       startLocal,
       endLocal,
-      availableStartLocal: new Date(availableStartMs),
+      availableStartLocal,
       energyIdx,
     })
   }
@@ -483,10 +516,40 @@ async function fetchCompatibleWindowsForItem(
 
   return compatible.map(win => ({
     id: win.id,
+    key: win.key,
     startLocal: win.startLocal,
     endLocal: win.endLocal,
     availableStartLocal: win.availableStartLocal,
   }))
+}
+
+function findPlacementWindow(
+  windows: Array<{
+    id: string
+    startLocal: Date
+    endLocal: Date
+    key?: string
+  }>,
+  placement: ScheduleInstance
+) {
+  if (!placement.window_id) return null
+  const start = new Date(placement.start_utc)
+  const match = windows.find(win =>
+    win.id === placement.window_id && isWithinWindow(start, win)
+  )
+  if (match) return match
+  return windows.find(win => win.id === placement.window_id) ?? null
+}
+
+function isWithinWindow(
+  start: Date,
+  win: { startLocal: Date; endLocal: Date }
+) {
+  return start >= win.startLocal && start < win.endLocal
+}
+
+function windowKey(windowId: string, startLocal: Date) {
+  return `${windowId}:${startLocal.toISOString()}`
 }
 
 function energyIndex(level?: string | null) {

--- a/supabase/functions/scheduler_cron/index.ts
+++ b/supabase/functions/scheduler_cron/index.ts
@@ -189,6 +189,7 @@ async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
   })
 
   const placed: ScheduleInstance[] = []
+  const windowAvailability = new Map<string, Date>()
 
   for (const item of queue) {
     let scheduled = false
@@ -199,7 +200,10 @@ async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
         userId,
         day,
         item,
-        offset === 0 ? { now: baseDate } : undefined
+        {
+          availability: windowAvailability,
+          now: offset === 0 ? baseDate : undefined,
+        }
       )
       if (windows.length === 0) continue
 
@@ -212,6 +216,13 @@ async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
       )
       if (placedInstance) {
         placed.push(placedInstance)
+        const placementWindow = findPlacementWindow(windows, placedInstance)
+        if (placementWindow?.key) {
+          windowAvailability.set(
+            placementWindow.key,
+            new Date(placedInstance.end_utc)
+          )
+        }
         scheduled = true
       }
     }
@@ -457,16 +468,18 @@ async function fetchCompatibleWindowsForItem(
   userId: string,
   date: Date,
   item: { energy: string; duration_min: number },
-  options?: { now?: Date }
+  options?: { now?: Date; availability?: Map<string, Date> }
 ) {
   const windows = await fetchWindowsForDate(client, userId, date)
   const itemIdx = energyIndex(item.energy)
   const now = options?.now ? new Date(options.now) : null
   const nowMs = now?.getTime()
   const durationMs = Math.max(0, item.duration_min) * 60_000
+  const availability = options?.availability
 
   const compatible: Array<{
     id: string
+    key: string
     startLocal: Date
     endLocal: Date
     availableStartLocal: Date
@@ -479,20 +492,36 @@ async function fetchCompatibleWindowsForItem(
 
     const startLocal = resolveWindowStart(window, date)
     const endLocal = resolveWindowEnd(window, date)
+    const key = windowKey(window.id, startLocal)
     const startMs = startLocal.getTime()
     const endMs = endLocal.getTime()
 
     if (typeof nowMs === 'number' && endMs <= nowMs) continue
 
-    const availableStartMs = typeof nowMs === 'number' ? Math.max(startMs, nowMs) : startMs
+    const baseAvailableStartMs =
+      typeof nowMs === 'number' ? Math.max(startMs, nowMs) : startMs
+    const carriedStartMs = availability?.get(key)?.getTime()
+    const availableStartMs =
+      typeof carriedStartMs === 'number'
+        ? Math.max(baseAvailableStartMs, carriedStartMs)
+        : baseAvailableStartMs
     if (availableStartMs >= endMs) continue
     if (availableStartMs + durationMs > endMs) continue
 
+    const availableStartLocal = new Date(availableStartMs)
+    if (availability) {
+      const existing = availability.get(key)
+      if (!existing || existing.getTime() !== availableStartMs) {
+        availability.set(key, availableStartLocal)
+      }
+    }
+
     compatible.push({
       id: window.id,
+      key,
       startLocal,
       endLocal,
-      availableStartLocal: new Date(availableStartMs),
+      availableStartLocal,
       energyIdx,
     })
   }
@@ -509,6 +538,7 @@ async function fetchCompatibleWindowsForItem(
 
   return compatible.map(window => ({
     id: window.id,
+    key: window.key,
     startLocal: window.startLocal,
     endLocal: window.endLocal,
     availableStartLocal: window.availableStartLocal,
@@ -562,7 +592,13 @@ async function placeItemInWindows(
   client: Client,
   userId: string,
   item: { id: string; sourceType: 'PROJECT'; duration_min: number; energy: string; weight: number },
-  windows: Array<{ id: string; startLocal: Date; endLocal: Date; availableStartLocal?: Date }>,
+  windows: Array<{
+    id: string
+    startLocal: Date
+    endLocal: Date
+    availableStartLocal?: Date
+    key?: string
+  }>,
   reuseInstanceId?: string | null
 ): Promise<ScheduleInstance | null> {
   for (const window of windows) {
@@ -716,6 +752,35 @@ async function rescheduleInstance(
   }
 
   return data
+}
+
+function findPlacementWindow(
+  windows: Array<{
+    id: string
+    startLocal: Date
+    endLocal: Date
+    key?: string
+  }>,
+  placement: ScheduleInstance
+) {
+  if (!placement.window_id) return null
+  const start = new Date(placement.start_utc)
+  const match = windows.find(
+    window => window.id === placement.window_id && isWithinWindow(start, window)
+  )
+  if (match) return match
+  return windows.find(window => window.id === placement.window_id) ?? null
+}
+
+function isWithinWindow(
+  start: Date,
+  window: { startLocal: Date; endLocal: Date }
+) {
+  return start >= window.startLocal && start < window.endLocal
+}
+
+function windowKey(windowId: string, startLocal: Date) {
+  return `${windowId}:${startLocal.toISOString()}`
 }
 
 function resolveWindowStart(window: WindowRecord, date: Date) {

--- a/supabase/functions/scheduler_cron/index.ts
+++ b/supabase/functions/scheduler_cron/index.ts
@@ -194,7 +194,13 @@ async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
     let scheduled = false
     for (let offset = 0; offset < 28 && !scheduled; offset += 1) {
       const day = addDays(baseStart, offset)
-      const windows = await fetchCompatibleWindowsForItem(client, userId, day, item)
+      const windows = await fetchCompatibleWindowsForItem(
+        client,
+        userId,
+        day,
+        item,
+        offset === 0 ? { now: baseDate } : undefined
+      )
       if (windows.length === 0) continue
 
       const placedInstance = await placeItemInWindows(
@@ -450,28 +456,54 @@ async function fetchCompatibleWindowsForItem(
   client: Client,
   userId: string,
   date: Date,
-  item: { energy: string; duration_min: number }
+  item: { energy: string; duration_min: number },
+  options?: { now?: Date }
 ) {
   const windows = await fetchWindowsForDate(client, userId, date)
   const itemIdx = energyIndex(item.energy)
-  const compatible = windows
-    .map(window => {
-      const energyIdx = energyIndex(window.energy)
-      return {
-        id: window.id,
-        startLocal: resolveWindowStart(window, date),
-        endLocal: resolveWindowEnd(window, date),
-        energyIdx,
-      }
+  const now = options?.now ? new Date(options.now) : null
+  const nowMs = now?.getTime()
+  const durationMs = Math.max(0, item.duration_min) * 60_000
+
+  const compatible: Array<{
+    id: string
+    startLocal: Date
+    endLocal: Date
+    availableStartLocal: Date
+    energyIdx: number
+  }> = []
+
+  for (const window of windows) {
+    const energyIdx = energyIndex(window.energy)
+    if (energyIdx < itemIdx) continue
+
+    const startLocal = resolveWindowStart(window, date)
+    const endLocal = resolveWindowEnd(window, date)
+    const startMs = startLocal.getTime()
+    const endMs = endLocal.getTime()
+
+    if (typeof nowMs === 'number' && endMs <= nowMs) continue
+
+    const availableStartMs = typeof nowMs === 'number' ? Math.max(startMs, nowMs) : startMs
+    if (availableStartMs >= endMs) continue
+    if (availableStartMs + durationMs > endMs) continue
+
+    compatible.push({
+      id: window.id,
+      startLocal,
+      endLocal,
+      availableStartLocal: new Date(availableStartMs),
+      energyIdx,
     })
-    .filter(window => window.energyIdx >= itemIdx)
+  }
 
   compatible.sort((a, b) => {
-    const aDiff = a.energyIdx - itemIdx
-    const bDiff = b.energyIdx - itemIdx
-    if (aDiff !== bDiff) return aDiff - bDiff
-    const startDiff = a.startLocal.getTime() - b.startLocal.getTime()
+    const startDiff = a.availableStartLocal.getTime() - b.availableStartLocal.getTime()
     if (startDiff !== 0) return startDiff
+    const energyDiff = a.energyIdx - b.energyIdx
+    if (energyDiff !== 0) return energyDiff
+    const rawStartDiff = a.startLocal.getTime() - b.startLocal.getTime()
+    if (rawStartDiff !== 0) return rawStartDiff
     return a.id.localeCompare(b.id)
   })
 
@@ -479,6 +511,7 @@ async function fetchCompatibleWindowsForItem(
     id: window.id,
     startLocal: window.startLocal,
     endLocal: window.endLocal,
+    availableStartLocal: window.availableStartLocal,
   }))
 }
 
@@ -529,11 +562,11 @@ async function placeItemInWindows(
   client: Client,
   userId: string,
   item: { id: string; sourceType: 'PROJECT'; duration_min: number; energy: string; weight: number },
-  windows: Array<{ id: string; startLocal: Date; endLocal: Date }>,
+  windows: Array<{ id: string; startLocal: Date; endLocal: Date; availableStartLocal?: Date }>,
   reuseInstanceId?: string | null
 ): Promise<ScheduleInstance | null> {
   for (const window of windows) {
-    const start = new Date(window.startLocal)
+    const start = new Date(window.availableStartLocal ?? window.startLocal)
     const end = new Date(window.endLocal)
 
     const { data: taken, error } = await client

--- a/supabase/functions/scheduler_cron/index.ts
+++ b/supabase/functions/scheduler_cron/index.ts
@@ -618,7 +618,9 @@ async function placeItemInWindows(
       continue
     }
 
-    const sorted = (taken ?? []).sort(
+    const filtered = (taken ?? []).filter(instance => instance.id !== reuseInstanceId)
+
+    const sorted = filtered.sort(
       (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime()
     )
 

--- a/test/lib/scheduler/placement.spec.ts
+++ b/test/lib/scheduler/placement.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+vi.mock("../../../src/lib/scheduler/instanceRepo", () => ({
+  fetchInstancesForRange: vi.fn(async () => ({
+    data: [],
+    error: null,
+    count: null,
+    status: 200,
+    statusText: "OK",
+  })),
+  createInstance: vi.fn(async (input: unknown) => ({
+    data: input,
+    error: null,
+    count: null,
+    status: 201,
+    statusText: "Created",
+  })),
+  rescheduleInstance: vi.fn(),
+}));
+
+let placeItemInWindows: (typeof import("../../../src/lib/scheduler/placement"))[
+  "placeItemInWindows"
+];
+let instanceRepo: typeof import("../../../src/lib/scheduler/instanceRepo");
+
+beforeAll(async () => {
+  ({ placeItemInWindows } = await import("../../../src/lib/scheduler/placement"));
+  instanceRepo = await import("../../../src/lib/scheduler/instanceRepo");
+});
+
+describe("placeItemInWindows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts a placement at the provided available start time", async () => {
+    const createInstanceMock = instanceRepo.createInstance as unknown as vi.Mock;
+
+    let capturedStartUTC: string | null = null;
+    createInstanceMock.mockImplementation(async (input: { startUTC: string }) => {
+      capturedStartUTC = input.startUTC;
+      return {
+        data: { id: "inst-1" },
+        error: null,
+        count: null,
+        status: 201,
+        statusText: "Created",
+      };
+    });
+
+    const windowStart = new Date("2024-01-02T09:00:00Z");
+    const availableStart = new Date("2024-01-02T10:30:00Z");
+    const windowEnd = new Date("2024-01-02T13:00:00Z");
+
+    await placeItemInWindows({
+      userId: "user-1",
+      item: {
+        id: "proj-1",
+        sourceType: "PROJECT",
+        duration_min: 60,
+        energy: "MEDIUM",
+        weight: 1,
+      },
+      windows: [
+        {
+          id: "win-1",
+          startLocal: windowStart,
+          availableStartLocal: availableStart,
+          endLocal: windowEnd,
+        },
+      ],
+      date: windowStart,
+    });
+
+    expect(capturedStartUTC).toBe(availableStart.toISOString());
+  });
+});
+

--- a/test/lib/scheduler/reschedule.spec.ts
+++ b/test/lib/scheduler/reschedule.spec.ts
@@ -5,6 +5,8 @@ import * as repo from "../../../src/lib/scheduler/repo";
 import * as placement from "../../../src/lib/scheduler/placement";
 import type { ScheduleInstance } from "../../../src/lib/scheduler/instanceRepo";
 
+const realPlaceItemInWindows = placement.placeItemInWindows;
+
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => null),
 }));
@@ -393,6 +395,144 @@ describe("scheduleBacklog", () => {
 
     expect(observedStart).not.toBeNull();
     expect(observedStart?.toISOString()).toBe(anchorDate.toISOString());
+  });
+
+  it("fills the nearest window sequentially even when new placements are not yet visible", async () => {
+    instances = [];
+
+    const emptyBacklog: BacklogResponse = {
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: "OK",
+    };
+
+    (instanceRepo.fetchBacklogNeedingSchedule as unknown as vi.Mock).mockResolvedValue(
+      emptyBacklog,
+    );
+
+    (repo.fetchReadyTasks as unknown as vi.Mock).mockResolvedValue([]);
+
+    (repo.fetchProjectsMap as unknown as vi.Mock).mockResolvedValue({
+      "proj-1": {
+        id: "proj-1",
+        name: "One",
+        priority: "HIGH",
+        stage: "PLAN",
+        energy: "NO",
+        duration_min: 60,
+      },
+      "proj-2": {
+        id: "proj-2",
+        name: "Two",
+        priority: "HIGH",
+        stage: "PLAN",
+        energy: "NO",
+        duration_min: 60,
+      },
+      "proj-3": {
+        id: "proj-3",
+        name: "Three",
+        priority: "HIGH",
+        stage: "PLAN",
+        energy: "NO",
+        duration_min: 60,
+      },
+      "proj-4": {
+        id: "proj-4",
+        name: "Four",
+        priority: "HIGH",
+        stage: "PLAN",
+        energy: "NO",
+        duration_min: 60,
+      },
+    });
+
+    (repo.fetchWindowsForDate as unknown as vi.Mock).mockImplementation(
+      async (date: Date) => [
+        {
+          id: "win-primary",
+          label: "Primary",
+          energy: "NO",
+          start_local: "10:00",
+          end_local: "14:00",
+          days: [date.getDay()],
+        },
+      ],
+    );
+
+    fetchInstancesForRangeSpy.mockImplementation(async () => ({
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: "OK",
+    } satisfies InstancesResponse));
+
+    const createSpy = vi
+      .spyOn(instanceRepo, "createInstance")
+      .mockImplementation(async (input) => {
+        const data = createInstanceRecord({
+          id: `inst-${instances.length + 1}`,
+          source_id: input.sourceId,
+          start_utc: input.startUTC,
+          end_utc: input.endUTC,
+          duration_min: input.durationMin,
+          window_id: input.windowId ?? null,
+          weight_snapshot: input.weightSnapshot,
+          energy_resolved: input.energyResolved,
+          status: "scheduled",
+        });
+        instances.push(data);
+        return {
+          data,
+          error: null,
+          count: null,
+          status: 201,
+          statusText: "Created",
+        } as Awaited<ReturnType<typeof instanceRepo.createInstance>>;
+      });
+
+    vi.spyOn(instanceRepo, "rescheduleInstance").mockImplementation(
+      async () => {
+        throw new Error("rescheduleInstance should not be called");
+      },
+    );
+
+    (placement.placeItemInWindows as unknown as vi.Mock).mockImplementation(
+      async (params) => await realPlaceItemInWindows(params),
+    );
+
+    const anchor = new Date("2024-01-02T10:00:00Z");
+    const mockClient = {} as ScheduleBacklogClient;
+    const result = await scheduleBacklog(userId, anchor, mockClient);
+
+    expect(result.error).toBeUndefined();
+    expect(result.failures).toHaveLength(0);
+    expect(result.placed).toHaveLength(4);
+
+    const sorted = [...result.placed].sort(
+      (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime(),
+    );
+
+    const firstStart = new Date(sorted[0]!.start_utc).getTime();
+    const dayAhead = anchor.getTime() + 24 * 60 * 60 * 1000;
+
+    expect(firstStart).toBeGreaterThanOrEqual(anchor.getTime());
+
+    for (let i = 0; i < sorted.length; i += 1) {
+      const current = sorted[i]!;
+      const startMs = new Date(current.start_utc).getTime();
+      expect(startMs).toBeLessThan(dayAhead);
+      if (i > 0) {
+        const prevEnd = new Date(sorted[i - 1]!.end_utc).getTime();
+        expect(startMs).toBe(prevEnd);
+      }
+      expect(current.window_id).toBe("win-primary");
+    }
+
+    expect(createSpy).toHaveBeenCalledTimes(4);
   });
 
   it("skips already scheduled projects when falling back to enqueue all", async () => {


### PR DESCRIPTION
## Summary
- prioritize the earliest available windows after "now" when selecting placements and carry the minimum start time into placement
- ensure both the app and cron scheduler pass the adjusted window metadata so projects chain without gaps
- extend scheduler tests to cover the new ordering rules and verify placement starts from the provided anchor time

## Testing
- pnpm test:run

------
https://chatgpt.com/codex/tasks/task_e_68cde9e84240832cb1415b53b0fa217b