### PR TITLE
feat: surface scheduler draft preview

### DIFF
--- a/src/app/(app)/schedule/scheduler/page.tsx
+++ b/src/app/(app)/schedule/scheduler/page.tsx
@@ -1,14 +1,225 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { Button } from "@/components/ui/button";
+import { ENERGY } from "@/lib/scheduler/config";
+import { buildProjectItems, type ProjectItem } from "@/lib/scheduler/projects";
+import {
+  fetchAllWindows,
+  fetchProjectsMap,
+  fetchReadyTasks,
+  type WindowLite,
+} from "@/lib/scheduler/repo";
+import type { ScheduleInstance } from "@/lib/scheduler/instanceRepo";
+import type { ProjectLite, TaskLite } from "@/lib/scheduler/weight";
+import { toLocal } from "@/lib/time/tz";
+
+const GAP_THRESHOLD_MINUTES = 1;
+
+type SchedulerFailure = {
+  itemId: string;
+  reason: string;
+  detail?: unknown;
+};
+
+type ScheduleDraft = {
+  placed: ScheduleInstance[];
+  failures: SchedulerFailure[];
+  error?: unknown;
+};
+
+type LoadStatus = "idle" | "loading" | "loaded" | "error";
+
+type PlacementView = {
+  instance: ScheduleInstance;
+  project?: ProjectItem;
+  window?: WindowLite;
+  start: Date;
+  end: Date;
+  durationMin: number;
+};
+
+type GapEntry = {
+  type: "gap";
+  id: string;
+  start: Date;
+  end: Date;
+  durationMin: number;
+  message: string;
+};
+
+type TimelineEntry =
+  | { type: "placement"; placement: PlacementView }
+  | GapEntry;
 
 export default function SchedulerPage() {
   const [status, setStatus] = useState<"idle" | "pending" | "success" | "error">(
     "idle",
   );
   const [error, setError] = useState<string | null>(null);
+  const [scheduleDraft, setScheduleDraft] = useState<ScheduleDraft | null>(null);
+  const [lastRunAt, setLastRunAt] = useState<Date | null>(null);
+
+  const [metaStatus, setMetaStatus] = useState<LoadStatus>("idle");
+  const [metaError, setMetaError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<ProjectLite[]>([]);
+  const [tasks, setTasks] = useState<TaskLite[]>([]);
+  const [windows, setWindows] = useState<WindowLite[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    setMetaStatus("loading");
+    setMetaError(null);
+
+    async function loadMeta() {
+      try {
+        const [taskList, projectMap, windowList] = await Promise.all([
+          fetchReadyTasks(),
+          fetchProjectsMap(),
+          fetchAllWindows(),
+        ]);
+        if (!active) return;
+        setTasks(taskList);
+        setProjects(Object.values(projectMap));
+        setWindows(windowList);
+        setMetaStatus("loaded");
+      } catch (metaErr) {
+        if (!active) return;
+        console.error("Failed to load scheduler context", metaErr);
+        setMetaError(
+          metaErr instanceof Error
+            ? metaErr.message
+            : "Failed to load scheduler context",
+        );
+        setTasks([]);
+        setProjects([]);
+        setWindows([]);
+        setMetaStatus("error");
+      }
+    }
+
+    void loadMeta();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const projectItems = useMemo(
+    () => buildProjectItems(projects, tasks),
+    [projects, tasks],
+  );
+
+  const projectMap = useMemo(() => {
+    const map: Record<string, ProjectItem> = {};
+    for (const item of projectItems) {
+      map[item.id] = item;
+    }
+    return map;
+  }, [projectItems]);
+
+  const windowMap = useMemo(() => {
+    const map: Record<string, WindowLite> = {};
+    for (const window of windows) {
+      map[window.id] = window;
+    }
+    return map;
+  }, [windows]);
+
+  const placements = useMemo<PlacementView[]>(() => {
+    if (!scheduleDraft) return [];
+    return scheduleDraft.placed
+      .map(instance => {
+        if (!instance || typeof instance !== "object") return null;
+        if (typeof instance.start_utc !== "string") return null;
+        if (typeof instance.end_utc !== "string") return null;
+        const start = toLocal(instance.start_utc);
+        const end = toLocal(instance.end_utc);
+        const durationMin = Math.max(
+          0,
+          Math.round((end.getTime() - start.getTime()) / 60000),
+        );
+        const projectId = typeof instance.source_id === "string"
+          ? instance.source_id
+          : "";
+        return {
+          instance,
+          project: projectId ? projectMap[projectId] : undefined,
+          window:
+            typeof instance.window_id === "string"
+              ? windowMap[instance.window_id]
+              : undefined,
+          start,
+          end,
+          durationMin,
+        };
+      })
+      .filter((placement): placement is PlacementView => placement !== null)
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+  }, [scheduleDraft, projectMap, windowMap]);
+
+  const failureDetails = useMemo(() => {
+    if (!scheduleDraft) return [] as Array<{
+      failure: SchedulerFailure;
+      project?: ProjectItem;
+      message: string;
+      detail?: string | null;
+    }>;
+    return scheduleDraft.failures.map(failure => {
+      const project = projectMap[failure.itemId];
+      const description = describeFailure(failure, project);
+      return {
+        failure,
+        project,
+        message: description.message,
+        detail: description.detail,
+      };
+    });
+  }, [scheduleDraft, projectMap]);
+
+  const failureSummary = useMemo(() => {
+    if (failureDetails.length === 0) return null;
+    return failureDetails
+      .map(detail =>
+        detail.detail ? `${detail.message} ${detail.detail}` : detail.message,
+      )
+      .join(" ");
+  }, [failureDetails]);
+
+  const timelineEntries = useMemo<TimelineEntry[]>(() => {
+    if (placements.length === 0) return [];
+    const entries: TimelineEntry[] = [];
+    for (let index = 0; index < placements.length; index += 1) {
+      const placement = placements[index];
+      entries.push({ type: "placement", placement });
+      const next = placements[index + 1];
+      if (!next) continue;
+      const gapMs = next.start.getTime() - placement.end.getTime();
+      const gapMinutes = Math.round(gapMs / 60000);
+      if (gapMinutes <= GAP_THRESHOLD_MINUTES) continue;
+      entries.push({
+        type: "gap",
+        id: `${placement.instance.id}-gap-${next.instance.id}`,
+        start: placement.end,
+        end: next.start,
+        durationMin: gapMinutes,
+        message: buildGapMessage({ previous: placement, next, failureSummary }),
+      });
+    }
+    return entries;
+  }, [placements, failureSummary]);
+
+  const energyGroups = useMemo(
+    () =>
+      ENERGY.LIST.map(energy => {
+        const items = projectItems
+          .filter(project => project.energy === energy)
+          .sort((a, b) => b.weight - a.weight);
+        return { energy, items };
+      }).filter(group => group.items.length > 0),
+    [projectItems],
+  );
 
   async function handleReschedule() {
     setStatus("pending");
@@ -32,22 +243,37 @@ export default function SchedulerPage() {
       if (!response.ok) {
         const message =
           typeof payload === "object" && payload !== null && "error" in payload
-            ? String((payload as { error?: unknown }).error ?? "Failed to trigger reschedule")
+            ? String(
+                (payload as { error?: unknown }).error ??
+                  "Failed to trigger reschedule",
+              )
             : "Failed to trigger reschedule";
         throw new Error(message);
       }
 
+      if (payload && typeof payload === "object" && "schedule" in payload) {
+        const parsed = parseScheduleDraft(
+          (payload as { schedule?: unknown }).schedule,
+        );
+        setScheduleDraft(parsed ?? { placed: [], failures: [] });
+      } else {
+        setScheduleDraft(null);
+      }
+
+      setLastRunAt(new Date());
       setStatus("success");
     } catch (err) {
       console.error("Failed to trigger scheduler", err);
       setStatus("error");
-      setError(err instanceof Error ? err.message : "Failed to trigger reschedule");
+      setError(
+        err instanceof Error ? err.message : "Failed to trigger reschedule",
+      );
     }
   }
 
   return (
     <ProtectedRoute>
-      <div className="space-y-4 p-4 text-zinc-100">
+      <div className="space-y-6 p-4 text-zinc-100">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Scheduler</h1>
           <p className="text-sm text-zinc-400">
@@ -67,7 +293,375 @@ export default function SchedulerPage() {
         {status === "error" && error && (
           <p className="text-sm text-red-400">{error}</p>
         )}
+
+        <section className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <div>
+              <h2 className="text-xl font-semibold text-zinc-100">
+                Schedule draft
+              </h2>
+              <p className="text-xs text-zinc-400">
+                Preview the placements created during the latest scheduler run.
+              </p>
+            </div>
+            {lastRunAt && (
+              <p className="text-xs text-zinc-500">
+                Generated {lastRunAt.toLocaleString()}
+              </p>
+            )}
+          </div>
+
+          {metaStatus === "loading" && (
+            <p className="mt-3 text-sm text-zinc-400">
+              Loading projects and windows...
+            </p>
+          )}
+
+          {metaStatus === "error" && metaError && (
+            <p className="mt-3 text-sm text-red-400">
+              Failed to load scheduler context: {metaError}
+            </p>
+          )}
+
+          {scheduleDraft ? (
+            <div className="mt-4 space-y-3">
+              {scheduleDraft.error && (
+                <p className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+                  Scheduler reported an error while saving placements:{" "}
+                  {formatFailureDetail(scheduleDraft.error) ?? "Unknown error"}
+                </p>
+              )}
+
+              {timelineEntries.length > 0 ? (
+                timelineEntries.map(entry => {
+                  if (entry.type === "placement") {
+                    const { placement } = entry;
+                    const projectName = placement.project?.name?.trim()
+                      ? placement.project.name
+                      : placement.instance.source_id || "Untitled project";
+                    return (
+                      <div
+                        key={placement.instance.id}
+                        className="rounded-md border border-zinc-800 bg-zinc-900/60 p-3"
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <div className="text-sm font-medium text-zinc-100">
+                              {projectName}
+                            </div>
+                            <div className="text-xs text-zinc-400">
+                              {(placement.project?.stage || "") && (
+                                <span>{placement.project?.stage}</span>
+                              )}
+                              {placement.project?.priority && (
+                                <span>
+                                  {placement.project?.stage ? " · " : ""}
+                                  {placement.project.priority}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                          <div className="text-right text-xs text-zinc-400">
+                            <div>{formatDateTime(placement.start)}</div>
+                            <div className="text-zinc-500">
+                              → {formatDateTime(placement.end)}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-3 text-[11px] text-zinc-400">
+                          <span>
+                            Window:{" "}
+                            {placement.window?.label ||
+                              placement.instance.window_id ||
+                              "Unassigned"}
+                          </span>
+                          <span>
+                            Duration: {formatDurationMinutes(placement.durationMin)}
+                          </span>
+                          <span>
+                            Energy:{" "}
+                            {placement.project?.energy ||
+                              placement.instance.energy_resolved ||
+                              "NO"}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <div
+                      key={entry.id}
+                      className="rounded-md border border-dashed border-amber-500/40 bg-amber-500/10 p-3 text-amber-100"
+                    >
+                      <div className="text-sm font-semibold">
+                        Gap · {formatDurationMinutes(entry.durationMin)}
+                      </div>
+                      <p className="mt-1 text-xs text-amber-100/90">
+                        {entry.message}
+                      </p>
+                    </div>
+                  );
+                })
+              ) : (
+                <p className="text-sm text-zinc-400">
+                  The scheduler did not return any placements. Run the scheduler
+                  to generate a draft timeline.
+                </p>
+              )}
+
+              {failureDetails.length > 0 && (
+                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-amber-100">
+                  <div className="text-xs font-semibold uppercase tracking-wide text-amber-200">
+                    Unscheduled projects
+                  </div>
+                  <ul className="mt-2 space-y-2 text-xs text-amber-100/90">
+                    {failureDetails.map(({ failure, project, message, detail }) => (
+                      <li key={failure.itemId}>
+                        <div className="font-medium text-amber-50">
+                          {project?.name || failure.itemId}
+                        </div>
+                        <div>{message}</div>
+                        {detail && (
+                          <div className="text-amber-200/80">{detail}</div>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-zinc-400">
+              Run the scheduler to generate a draft preview of upcoming
+              placements.
+            </p>
+          )}
+        </section>
+
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-lg font-semibold text-zinc-100">
+              Projects by energy
+            </h2>
+            <p className="text-xs text-zinc-400">
+              Explore the backlog grouped by energy level. Each list is sorted by
+              scheduler weight (highest first).
+            </p>
+          </div>
+
+          {metaStatus === "loading" && (
+            <p className="text-sm text-zinc-400">Loading projects…</p>
+          )}
+
+          {metaStatus === "error" && metaError && (
+            <p className="text-sm text-red-400">
+              Failed to load projects: {metaError}
+            </p>
+          )}
+
+          {metaStatus === "loaded" && energyGroups.length === 0 && (
+            <p className="text-sm text-zinc-400">No projects available.</p>
+          )}
+
+          {metaStatus === "loaded" && energyGroups.length > 0 && (
+            <div className="space-y-2">
+              {energyGroups.map(group => (
+                <details
+                  key={group.energy}
+                  className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900/60"
+                >
+                  <summary className="flex cursor-pointer items-center justify-between gap-2 px-4 py-3 text-sm font-semibold text-zinc-100">
+                    <span>Energy: {group.energy}</span>
+                    <span className="text-xs text-zinc-400">
+                      {group.items.length} project
+                      {group.items.length === 1 ? "" : "s"}
+                    </span>
+                  </summary>
+                  <div className="border-t border-zinc-800 bg-zinc-900/70 px-4 py-3">
+                    <div className="overflow-x-auto">
+                      <table className="w-full min-w-[520px] text-left text-sm text-zinc-200">
+                        <thead className="text-xs uppercase text-zinc-400">
+                          <tr>
+                            <th className="py-2 pr-3 font-medium">Project</th>
+                            <th className="py-2 pr-3 font-medium">Stage</th>
+                            <th className="py-2 pr-3 font-medium">Priority</th>
+                            <th className="py-2 pr-3 text-right font-medium">Weight</th>
+                            <th className="py-2 pr-3 text-right font-medium">Duration</th>
+                            <th className="py-2 pl-3 text-right font-medium">Tasks</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-zinc-800">
+                          {group.items.map(project => (
+                            <tr key={project.id}>
+                              <td className="py-2 pr-3 align-top">
+                                <div className="font-medium text-zinc-100">
+                                  {project.name || "Untitled project"}
+                                </div>
+                                <div className="text-[11px] text-zinc-500">
+                                  {project.id}
+                                </div>
+                              </td>
+                              <td className="py-2 pr-3 text-xs uppercase tracking-wide text-zinc-400">
+                                {project.stage}
+                              </td>
+                              <td className="py-2 pr-3 text-xs uppercase tracking-wide text-zinc-400">
+                                {project.priority}
+                              </td>
+                              <td className="py-2 pr-3 text-right text-sm font-semibold text-zinc-100">
+                                {project.weight.toFixed(2)}
+                              </td>
+                              <td className="py-2 pr-3 text-right text-xs text-zinc-400">
+                                {formatDurationMinutes(
+                                  Math.round(project.duration_min),
+                                )}
+                              </td>
+                              <td className="py-2 pl-3 text-right text-xs text-zinc-400">
+                                {project.taskCount}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </details>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
     </ProtectedRoute>
   );
+}
+
+function parseScheduleDraft(input: unknown): ScheduleDraft | null {
+  if (!input || typeof input !== "object") return null;
+  const payload = input as {
+    placed?: unknown;
+    failures?: unknown;
+    error?: unknown;
+  };
+
+  const placed: ScheduleInstance[] = Array.isArray(payload.placed)
+    ? payload.placed
+        .map(toScheduleInstance)
+        .filter((item): item is ScheduleInstance => item !== null)
+    : [];
+
+  const failures: SchedulerFailure[] = Array.isArray(payload.failures)
+    ? payload.failures
+        .map(toSchedulerFailure)
+        .filter((item): item is SchedulerFailure => item !== null)
+    : [];
+
+  const error = payload.error;
+
+  if (placed.length === 0 && failures.length === 0 && !error) {
+    return { placed: [], failures: [] };
+  }
+
+  return { placed, failures, error };
+}
+
+function toScheduleInstance(input: unknown): ScheduleInstance | null {
+  if (!input || typeof input !== "object") return null;
+  const record = input as Partial<ScheduleInstance>;
+  if (typeof record.id !== "string") return null;
+  if (typeof record.start_utc !== "string") return null;
+  if (typeof record.end_utc !== "string") return null;
+  return record as ScheduleInstance;
+}
+
+function toSchedulerFailure(input: unknown): SchedulerFailure | null {
+  if (!input || typeof input !== "object") return null;
+  const record = input as Partial<SchedulerFailure>;
+  if (typeof record.itemId !== "string") return null;
+  if (typeof record.reason !== "string") return null;
+  return {
+    itemId: record.itemId,
+    reason: record.reason,
+    detail: record.detail,
+  };
+}
+
+function describeFailure(
+  failure: SchedulerFailure,
+  project?: ProjectItem,
+): { message: string; detail?: string | null } {
+  const projectName = project?.name?.trim()
+    ? project.name
+    : `Project ${failure.itemId}`;
+  const detail = formatFailureDetail(failure.detail);
+  switch (failure.reason) {
+    case "NO_WINDOW":
+      return {
+        message: `${projectName} could not be placed in an available window within the scheduling horizon.`,
+        detail,
+      };
+    case "error":
+      return {
+        message: `${projectName} encountered an error while scheduling.`,
+        detail,
+      };
+    default:
+      return {
+        message: `${projectName} was not scheduled (${failure.reason}).`,
+        detail,
+      };
+  }
+}
+
+function buildGapMessage({
+  previous,
+  next,
+  failureSummary,
+}: {
+  previous: PlacementView;
+  next: PlacementView;
+  failureSummary: string | null;
+}): string {
+  const base = `No project scheduled from ${formatDateTime(previous.end)} to ${formatDateTime(next.start)}.`;
+  const windowNote = next.window
+    ? ` Next available window "${next.window.label}" begins at ${formatDateTime(next.start)}.`
+    : ` Next scheduled project "${next.project?.name ?? next.instance.source_id ?? "project"}" begins at ${formatDateTime(next.start)}.`;
+  const failureNote = failureSummary
+    ? ` Scheduler also reported: ${failureSummary}`
+    : "";
+  return `${base}${windowNote}${failureNote}`;
+}
+
+function formatDurationMinutes(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes <= 0) return "0m";
+  const rounded = Math.max(0, Math.round(minutes));
+  const hours = Math.floor(rounded / 60);
+  const mins = rounded % 60;
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (mins > 0) parts.push(`${mins}m`);
+  if (parts.length === 0) return "0m";
+  return parts.join(" ");
+}
+
+function formatDateTime(date: Date): string {
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function formatFailureDetail(detail: unknown): string | null {
+  if (detail == null) return null;
+  if (typeof detail === "string") return detail;
+  if (detail instanceof Error) return detail.message;
+  if (typeof detail === "object") {
+    const maybeMessage = (detail as { message?: unknown }).message;
+    if (typeof maybeMessage === "string") return maybeMessage;
+    try {
+      return JSON.stringify(detail);
+    } catch {
+      return String(detail);
+    }
+  }
+  return String(detail);
 }

--- a/src/lib/scheduler/repo.ts
+++ b/src/lib/scheduler/repo.ts
@@ -79,6 +79,18 @@ export async function fetchWindowsForDate(
   return [...(today ?? []), ...prevCross] as WindowLite[];
 }
 
+export async function fetchAllWindows(client?: Client): Promise<WindowLite[]> {
+  const supabase = ensureClient(client);
+
+  const { data, error } = await supabase
+    .from('windows')
+    .select('id, label, energy, start_local, end_local, days');
+
+  if (error) throw error;
+
+  return (data ?? []) as WindowLite[];
+}
+
 export async function fetchProjectsMap(
   client?: Client
 ): Promise<Record<string, ProjectLite>> {

--- a/src/lib/scheduler/reschedule.ts
+++ b/src/lib/scheduler/reschedule.ts
@@ -19,6 +19,9 @@ import { ENERGY } from './config'
 type Client = SupabaseClient<Database>
 
 const GRACE_MIN = 60
+const BASE_LOOKAHEAD_DAYS = 28
+const LOOKAHEAD_PER_ITEM_DAYS = 7
+const MAX_LOOKAHEAD_DAYS = 365
 
 type ScheduleFailure = {
   itemId: string
@@ -261,10 +264,15 @@ export async function scheduleBacklog(
   })
 
   const windowAvailability = new Map<string, Date>()
+  const windowCache = new Map<string, WindowLite[]>()
+  const lookaheadDays = Math.min(
+    MAX_LOOKAHEAD_DAYS,
+    BASE_LOOKAHEAD_DAYS + queue.length * LOOKAHEAD_PER_ITEM_DAYS,
+  )
 
   for (const item of queue) {
     let scheduled = false
-    for (let offset = 0; offset < 28 && !scheduled; offset += 1) {
+    for (let offset = 0; offset < lookaheadDays && !scheduled; offset += 1) {
       const day = addDays(baseStart, offset)
       const windows = await fetchCompatibleWindowsForItem(
         supabase,
@@ -273,6 +281,7 @@ export async function scheduleBacklog(
         {
           availability: windowAvailability,
           now: offset === 0 ? baseDate : undefined,
+          cache: windowCache,
         }
       )
       if (windows.length === 0) continue
@@ -478,9 +487,21 @@ async function fetchCompatibleWindowsForItem(
   supabase: Client,
   date: Date,
   item: { energy: string; duration_min: number },
-  options?: { now?: Date; availability?: Map<string, Date> }
+  options?: {
+    now?: Date
+    availability?: Map<string, Date>
+    cache?: Map<string, WindowLite[]>
+  }
 ) {
-  const windows = await fetchWindowsForDate(date, supabase)
+  const cacheKey = dateCacheKey(date)
+  const cache = options?.cache
+  let windows: WindowLite[]
+  if (cache?.has(cacheKey)) {
+    windows = cache.get(cacheKey) ?? []
+  } else {
+    windows = await fetchWindowsForDate(date, supabase)
+    cache?.set(cacheKey, windows)
+  }
   const itemIdx = energyIndex(item.energy)
   const now = options?.now ? new Date(options.now) : null
   const nowMs = now?.getTime()
@@ -582,6 +603,10 @@ function isWithinWindow(
 
 function windowKey(windowId: string, startLocal: Date) {
   return `${windowId}:${startLocal.toISOString()}`
+}
+
+function dateCacheKey(date: Date) {
+  return startOfDay(date).toISOString()
 }
 
 function energyIndex(level?: string | null) {

--- a/supabase/functions/scheduler_cron/index.ts
+++ b/supabase/functions/scheduler_cron/index.ts
@@ -12,6 +12,9 @@ type ScheduleInstance = Database['public']['Tables']['schedule_instances']['Row'
 const GRACE_MIN = 60
 const DEFAULT_PROJECT_DURATION_MIN = 60
 const ENERGY_ORDER = ['NO', 'LOW', 'MEDIUM', 'HIGH', 'ULTRA', 'EXTREME'] as const
+const BASE_LOOKAHEAD_DAYS = 28
+const LOOKAHEAD_PER_ITEM_DAYS = 7
+const MAX_LOOKAHEAD_DAYS = 365
 
 serve(async req => {
   try {
@@ -190,10 +193,15 @@ async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
 
   const placed: ScheduleInstance[] = []
   const windowAvailability = new Map<string, Date>()
+  const windowCache = new Map<string, WindowRecord[]>()
+  const lookaheadDays = Math.min(
+    MAX_LOOKAHEAD_DAYS,
+    BASE_LOOKAHEAD_DAYS + queue.length * LOOKAHEAD_PER_ITEM_DAYS,
+  )
 
   for (const item of queue) {
     let scheduled = false
-    for (let offset = 0; offset < 28 && !scheduled; offset += 1) {
+    for (let offset = 0; offset < lookaheadDays && !scheduled; offset += 1) {
       const day = addDays(baseStart, offset)
       const windows = await fetchCompatibleWindowsForItem(
         client,
@@ -203,6 +211,7 @@ async function scheduleBacklog(client: Client, userId: string, baseDate: Date) {
         {
           availability: windowAvailability,
           now: offset === 0 ? baseDate : undefined,
+          cache: windowCache,
         }
       )
       if (windows.length === 0) continue
@@ -468,9 +477,21 @@ async function fetchCompatibleWindowsForItem(
   userId: string,
   date: Date,
   item: { energy: string; duration_min: number },
-  options?: { now?: Date; availability?: Map<string, Date> }
+  options?: {
+    now?: Date
+    availability?: Map<string, Date>
+    cache?: Map<string, WindowRecord[]>
+  }
 ) {
-  const windows = await fetchWindowsForDate(client, userId, date)
+  const cacheKey = dateCacheKey(date)
+  const cache = options?.cache
+  let windows: WindowRecord[]
+  if (cache?.has(cacheKey)) {
+    windows = cache.get(cacheKey) ?? []
+  } else {
+    windows = await fetchWindowsForDate(client, userId, date)
+    cache?.set(cacheKey, windows)
+  }
   const itemIdx = energyIndex(item.energy)
   const now = options?.now ? new Date(options.now) : null
   const nowMs = now?.getTime()
@@ -804,6 +825,10 @@ function isWithinWindow(
 
 function windowKey(windowId: string, startLocal: Date) {
   return `${windowId}:${startLocal.toISOString()}`
+}
+
+function dateCacheKey(date: Date) {
+  return startOfDay(date).toISOString()
 }
 
 function resolveWindowStart(window: WindowRecord, date: Date) {

--- a/test/lib/scheduler/repo.spec.ts
+++ b/test/lib/scheduler/repo.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { fetchWindowsForDate, type WindowLite } from "../../../src/lib/scheduler/repo";
+
+describe("fetchWindowsForDate", () => {
+  it("includes recurring windows without day restrictions and their prior-day carryover", async () => {
+    const date = new Date("2024-01-02T00:00:00Z");
+    const weekday = date.getDay();
+    const prevWeekday = (weekday + 6) % 7;
+
+    const todayWindows: WindowLite[] = [
+      {
+        id: "win-today",
+        label: "Today only",
+        energy: "NO",
+        start_local: "10:00",
+        end_local: "12:00",
+        days: [weekday],
+      },
+    ];
+
+    const prevWindows: WindowLite[] = [
+      {
+        id: "win-prev-cross",
+        label: "Yesterday overnight",
+        energy: "NO",
+        start_local: "23:00",
+        end_local: "01:00",
+        days: [prevWeekday],
+      },
+    ];
+
+    const recurringWindows: WindowLite[] = [
+      {
+        id: "win-recurring",
+        label: "Every day",
+        energy: "NO",
+        start_local: "08:00",
+        end_local: "09:00",
+        days: null,
+      },
+      {
+        id: "win-recurring-cross",
+        label: "Every night",
+        energy: "NO",
+        start_local: "22:00",
+        end_local: "02:00",
+        days: null,
+      },
+    ];
+
+    const containsResponses = new Map<string, WindowLite[]>([
+      [JSON.stringify([weekday]), todayWindows],
+      [JSON.stringify([prevWeekday]), prevWindows],
+    ]);
+
+    const select = vi.fn(() => ({
+      contains: vi.fn(async (_column: string, value: number[]) => {
+        const key = JSON.stringify(value);
+        const data = containsResponses.get(key) ?? [];
+        return { data, error: null } as const;
+      }),
+      is: vi.fn(async (_column: string, value: number[] | null) => {
+        if (value === null) {
+          return { data: recurringWindows, error: null } as const;
+        }
+        return { data: [], error: null } as const;
+      }),
+    }));
+
+    const client = {
+      from: vi.fn(() => ({ select })),
+    } as const;
+
+    const windows = await fetchWindowsForDate(date, client as never);
+
+    expect(windows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "win-today" }),
+        expect.objectContaining({ id: "win-recurring" }),
+        expect.objectContaining({ id: "win-recurring-cross" }),
+        expect.objectContaining({ id: "win-prev-cross", fromPrevDay: true }),
+      ]),
+    );
+
+    const carryover = windows.filter(win => win.fromPrevDay);
+    expect(carryover).toHaveLength(2);
+    expect(carryover.map(win => win.id)).toEqual(
+      expect.arrayContaining(["win-prev-cross", "win-recurring-cross"]),
+    );
+
+    const recurringAppearances = windows.filter(win => win.id === "win-recurring-cross");
+    expect(recurringAppearances.some(win => win.fromPrevDay === true)).toBe(true);
+    expect(recurringAppearances.some(win => !win.fromPrevDay)).toBe(true);
+  });
+});
+

--- a/test/lib/scheduler/reschedule.spec.ts
+++ b/test/lib/scheduler/reschedule.spec.ts
@@ -4,6 +4,7 @@ import * as instanceRepo from "../../../src/lib/scheduler/instanceRepo";
 import * as repo from "../../../src/lib/scheduler/repo";
 import * as placement from "../../../src/lib/scheduler/placement";
 import type { ScheduleInstance } from "../../../src/lib/scheduler/instanceRepo";
+import type { ProjectLite } from "../../../src/lib/scheduler/weight";
 
 const realPlaceItemInWindows = placement.placeItemInWindows;
 
@@ -537,6 +538,364 @@ describe("scheduleBacklog", () => {
     }
 
     expect(createSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it("rolls overflow into future days when a single window recurs daily", async () => {
+    instances = [];
+
+    const emptyBacklog: BacklogResponse = {
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: "OK",
+    };
+
+    (instanceRepo.fetchBacklogNeedingSchedule as unknown as vi.Mock).mockResolvedValue(
+      emptyBacklog,
+    );
+
+    (repo.fetchReadyTasks as unknown as vi.Mock).mockResolvedValue([]);
+
+    const projectDefs = Array.from({ length: 6 }).reduce<Record<string, ProjectLite>>(
+      (acc, _, index) => {
+        const id = `proj-${index + 1}`;
+        acc[id] = {
+          id,
+          name: `Project ${index + 1}`,
+          priority: "HIGH",
+          stage: "PLAN",
+          energy: "NO",
+          duration_min: 60,
+        } as ProjectLite;
+        return acc;
+      },
+      {},
+    );
+
+    (repo.fetchProjectsMap as unknown as vi.Mock).mockResolvedValue(projectDefs);
+
+    (repo.fetchWindowsForDate as unknown as vi.Mock).mockImplementation(
+      async (date: Date) => [
+        {
+          id: "win-daily",
+          label: "Daily focus",
+          energy: "NO",
+          start_local: "10:00",
+          end_local: "14:00",
+          days: [date.getDay()],
+        },
+      ],
+    );
+
+    fetchInstancesForRangeSpy.mockImplementation(async (_userId, startUTC, endUTC) => {
+      const startMs = new Date(startUTC).getTime();
+      const endMs = new Date(endUTC).getTime();
+      const data = instances.filter(inst => {
+        const instStart = new Date(inst.start_utc).getTime();
+        const instEnd = new Date(inst.end_utc).getTime();
+        return instStart < endMs && instEnd > startMs;
+      });
+      return {
+        data,
+        error: null,
+        count: null,
+        status: 200,
+        statusText: "OK",
+      } satisfies InstancesResponse;
+    });
+
+    vi.spyOn(instanceRepo, "rescheduleInstance").mockImplementation(async () => {
+      throw new Error("rescheduleInstance should not be called");
+    });
+
+    vi.spyOn(instanceRepo, "createInstance").mockImplementation(async input => {
+      const data = createInstanceRecord({
+        id: `inst-${instances.length + 1}`,
+        source_id: input.sourceId,
+        start_utc: input.startUTC,
+        end_utc: input.endUTC,
+        duration_min: input.durationMin,
+        window_id: input.windowId ?? null,
+        weight_snapshot: input.weightSnapshot,
+        energy_resolved: input.energyResolved,
+        status: "scheduled",
+      });
+      instances.push(data);
+      return {
+        data,
+        error: null,
+        count: null,
+        status: 201,
+        statusText: "Created",
+      } as Awaited<ReturnType<typeof instanceRepo.createInstance>>;
+    });
+
+    (placement.placeItemInWindows as unknown as vi.Mock).mockImplementation(
+      async params => await realPlaceItemInWindows(params),
+    );
+
+    const anchor = new Date("2024-01-02T10:00:00Z");
+    const mockClient = {} as ScheduleBacklogClient;
+    const result = await scheduleBacklog(userId, anchor, mockClient);
+
+    expect(result.error).toBeUndefined();
+    expect(result.failures).toHaveLength(0);
+    expect(result.placed).toHaveLength(6);
+    expect(result.timeline).toHaveLength(6);
+
+    const sorted = [...result.placed].sort(
+      (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime(),
+    );
+
+    const firstDay = sorted.slice(0, 4);
+    const secondDay = sorted.slice(4);
+
+    expect(firstDay.every(inst => inst.window_id === "win-daily")).toBe(true);
+    expect(secondDay.every(inst => inst.window_id === "win-daily")).toBe(true);
+
+    expect(
+      firstDay.every(inst =>
+        new Date(inst.start_utc).toISOString().startsWith("2024-01-02"),
+      ),
+    ).toBe(true);
+
+    expect(
+      secondDay.every(inst =>
+        new Date(inst.start_utc).toISOString().startsWith("2024-01-03"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reuses a recurring overnight window on consecutive days", async () => {
+    instances = [];
+
+    const emptyBacklog: BacklogResponse = {
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: "OK",
+    };
+
+    (instanceRepo.fetchBacklogNeedingSchedule as unknown as vi.Mock).mockResolvedValue(
+      emptyBacklog,
+    );
+
+    (repo.fetchReadyTasks as unknown as vi.Mock).mockResolvedValue([]);
+
+    const projectDefs = Array.from({ length: 4 }).reduce<Record<string, ProjectLite>>(
+      (acc, _, index) => {
+        const id = `proj-overnight-${index + 1}`;
+        acc[id] = {
+          id,
+          name: `Overnight ${index + 1}`,
+          priority: "HIGH",
+          stage: "PLAN",
+          energy: "NO",
+          duration_min: 120,
+        } as ProjectLite;
+        return acc;
+      },
+      {},
+    );
+
+    (repo.fetchProjectsMap as unknown as vi.Mock).mockResolvedValue(projectDefs);
+
+    (repo.fetchWindowsForDate as unknown as vi.Mock).mockImplementation(
+      async (date: Date) => [
+        {
+          id: "win-overnight",
+          label: "Overnight",
+          energy: "NO",
+          start_local: "22:00",
+          end_local: "02:00",
+          days: [date.getDay()],
+        },
+      ],
+    );
+
+    fetchInstancesForRangeSpy.mockImplementation(async (_userId, startUTC, endUTC) => {
+      const startMs = new Date(startUTC).getTime();
+      const endMs = new Date(endUTC).getTime();
+      const data = instances.filter(inst => {
+        const instStart = new Date(inst.start_utc).getTime();
+        const instEnd = new Date(inst.end_utc).getTime();
+        return instStart < endMs && instEnd > startMs;
+      });
+      return {
+        data,
+        error: null,
+        count: null,
+        status: 200,
+        statusText: "OK",
+      } satisfies InstancesResponse;
+    });
+
+    vi.spyOn(instanceRepo, "rescheduleInstance").mockImplementation(async () => {
+      throw new Error("rescheduleInstance should not be called");
+    });
+
+    vi.spyOn(instanceRepo, "createInstance").mockImplementation(async input => {
+      const data = createInstanceRecord({
+        id: `inst-overnight-${instances.length + 1}`,
+        source_id: input.sourceId,
+        start_utc: input.startUTC,
+        end_utc: input.endUTC,
+        duration_min: input.durationMin,
+        window_id: input.windowId ?? null,
+        weight_snapshot: input.weightSnapshot,
+        energy_resolved: input.energyResolved,
+        status: "scheduled",
+      });
+      instances.push(data);
+      return {
+        data,
+        error: null,
+        count: null,
+        status: 201,
+        statusText: "Created",
+      } as Awaited<ReturnType<typeof instanceRepo.createInstance>>;
+    });
+
+    (placement.placeItemInWindows as unknown as vi.Mock).mockImplementation(
+      async params => await realPlaceItemInWindows(params),
+    );
+
+    const anchor = new Date("2024-01-02T18:00:00Z");
+    const mockClient = {} as ScheduleBacklogClient;
+    const result = await scheduleBacklog(userId, anchor, mockClient);
+
+    expect(result.error).toBeUndefined();
+    expect(result.failures).toHaveLength(0);
+    expect(result.placed).toHaveLength(4);
+
+    const sorted = [...result.placed].sort(
+      (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime(),
+    );
+
+    expect(sorted.every(inst => inst.window_id === "win-overnight")).toBe(true);
+
+    const nightlyStarts = sorted
+      .filter(inst => inst.start_utc.endsWith("22:00:00.000Z"))
+      .map(inst => inst.start_utc);
+    expect(nightlyStarts).toHaveLength(2);
+    expect(nightlyStarts[0]?.startsWith("2024-01-02T22:00:00.000Z")).toBe(true);
+    expect(nightlyStarts[1]?.startsWith("2024-01-03T22:00:00.000Z")).toBe(true);
+
+    const finalStart = sorted.at(-1)?.start_utc ?? "";
+    expect(finalStart.startsWith("2024-01-04T00:00:00.000Z")).toBe(true);
+  });
+
+  it("extends the scheduling range when the backlog exceeds the default horizon", async () => {
+    instances = [];
+
+    const emptyBacklog: BacklogResponse = {
+      data: [],
+      error: null,
+      count: null,
+      status: 200,
+      statusText: "OK",
+    };
+
+    (instanceRepo.fetchBacklogNeedingSchedule as unknown as vi.Mock).mockResolvedValue(
+      emptyBacklog,
+    );
+
+    (repo.fetchReadyTasks as unknown as vi.Mock).mockResolvedValue([]);
+
+    const projectDefs = Array.from({ length: 30 }).reduce<Record<string, ProjectLite>>(
+      (acc, _, index) => {
+        const id = `proj-range-${index + 1}`;
+        acc[id] = {
+          id,
+          name: `Range ${index + 1}`,
+          priority: "HIGH",
+          stage: "PLAN",
+          energy: "NO",
+          duration_min: 60,
+        } as ProjectLite;
+        return acc;
+      },
+      {},
+    );
+
+    (repo.fetchProjectsMap as unknown as vi.Mock).mockResolvedValue(projectDefs);
+
+    (repo.fetchWindowsForDate as unknown as vi.Mock).mockImplementation(
+      async (date: Date) => [
+        {
+          id: "win-range",
+          label: "Daily slot",
+          energy: "NO",
+          start_local: "09:00",
+          end_local: "10:00",
+          days: [date.getDay()],
+        },
+      ],
+    );
+
+    fetchInstancesForRangeSpy.mockImplementation(async (_userId, startUTC, endUTC) => {
+      const startMs = new Date(startUTC).getTime();
+      const endMs = new Date(endUTC).getTime();
+      const data = instances.filter(inst => {
+        const instStart = new Date(inst.start_utc).getTime();
+        const instEnd = new Date(inst.end_utc).getTime();
+        return instStart < endMs && instEnd > startMs;
+      });
+      return {
+        data,
+        error: null,
+        count: null,
+        status: 200,
+        statusText: "OK",
+      } satisfies InstancesResponse;
+    });
+
+    vi.spyOn(instanceRepo, "rescheduleInstance").mockImplementation(async () => {
+      throw new Error("rescheduleInstance should not be called");
+    });
+
+    vi.spyOn(instanceRepo, "createInstance").mockImplementation(async input => {
+      const data = createInstanceRecord({
+        id: `inst-range-${instances.length + 1}`,
+        source_id: input.sourceId,
+        start_utc: input.startUTC,
+        end_utc: input.endUTC,
+        duration_min: input.durationMin,
+        window_id: input.windowId ?? null,
+        weight_snapshot: input.weightSnapshot,
+        energy_resolved: input.energyResolved,
+        status: "scheduled",
+      });
+      instances.push(data);
+      return {
+        data,
+        error: null,
+        count: null,
+        status: 201,
+        statusText: "Created",
+      } as Awaited<ReturnType<typeof instanceRepo.createInstance>>;
+    });
+
+    (placement.placeItemInWindows as unknown as vi.Mock).mockImplementation(
+      async params => await realPlaceItemInWindows(params),
+    );
+
+    const anchor = new Date("2024-01-02T09:00:00Z");
+    const mockClient = {} as ScheduleBacklogClient;
+    const result = await scheduleBacklog(userId, anchor, mockClient);
+
+    expect(result.error).toBeUndefined();
+    expect(result.failures).toHaveLength(0);
+    expect(result.placed).toHaveLength(30);
+
+    const sorted = [...result.placed].sort(
+      (a, b) => new Date(a.start_utc).getTime() - new Date(b.start_utc).getTime(),
+    );
+
+    expect(sorted[0]?.start_utc.startsWith("2024-01-02T09:00:00.000Z")).toBe(true);
+    expect(sorted.at(-1)?.start_utc.startsWith("2024-01-31T09:00:00.000Z")).toBe(true);
   });
 
   it(


### PR DESCRIPTION
## Summary
- add a schedule draft preview on the scheduler trigger page with window/time context, gap diagnostics, and unscheduled project messaging
- group all projects into energy-based toggle tables sorted by scheduler weight for quick backlog review
- expose a helper to fetch all scheduling windows for the draft view

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68ce1b3c8070832cb82f5ac88ffd6895