### PR TITLE
Reset window availability per day in backlog scheduler

### DIFF
--- a/src/lib/scheduler/reschedule.ts
+++ b/src/lib/scheduler/reschedule.ts
@@ -263,6 +263,7 @@ export async function scheduleBacklog(
     return a.id.localeCompare(b.id)
   })
 
+  const windowAvailabilityByDay = new Map<number, Map<string, Date>>()
   const windowCache = new Map<string, WindowLite[]>()
   const lookaheadDays = Math.min(
     MAX_LOOKAHEAD_DAYS,
@@ -272,8 +273,12 @@ export async function scheduleBacklog(
   for (const item of queue) {
     let scheduled = false
     for (let offset = 0; offset < lookaheadDays && !scheduled; offset += 1) {
+      let windowAvailability = windowAvailabilityByDay.get(offset)
+      if (!windowAvailability) {
+        windowAvailability = new Map<string, Date>()
+        windowAvailabilityByDay.set(offset, windowAvailability)
+      }
       const day = addDays(baseStart, offset)
-      const windowAvailability = new Map<string, Date>()
       const windows = await fetchCompatibleWindowsForItem(
         supabase,
         day,

--- a/src/lib/scheduler/reschedule.ts
+++ b/src/lib/scheduler/reschedule.ts
@@ -263,7 +263,6 @@ export async function scheduleBacklog(
     return a.id.localeCompare(b.id)
   })
 
-  const windowAvailability = new Map<string, Date>()
   const windowCache = new Map<string, WindowLite[]>()
   const lookaheadDays = Math.min(
     MAX_LOOKAHEAD_DAYS,
@@ -274,6 +273,7 @@ export async function scheduleBacklog(
     let scheduled = false
     for (let offset = 0; offset < lookaheadDays && !scheduled; offset += 1) {
       const day = addDays(baseStart, offset)
+      const windowAvailability = new Map<string, Date>()
       const windows = await fetchCompatibleWindowsForItem(
         supabase,
         day,


### PR DESCRIPTION
## Summary
- reinitialize the window availability map inside the daily lookahead loop so each day starts with clean availability
- ensure compatible window selection uses the per-day map to avoid blocking reuse of windows on later dates

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68ce575b34bc832ca883047641d80f82