### PR TITLE
Revamp profile page layout and styling

### DIFF
--- a/src/app/(app)/friends/[username]/page.tsx
+++ b/src/app/(app)/friends/[username]/page.tsx
@@ -1,0 +1,183 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { MOCK_FRIENDS } from "@/lib/mock/friends";
+
+function getFriend(username: string) {
+  const normalized = decodeURIComponent(username).toLowerCase();
+  return MOCK_FRIENDS.find((friend) => friend.username.toLowerCase() === normalized);
+}
+
+export function generateMetadata({ params }: { params: { username: string } }): Metadata {
+  const friend = getFriend(params.username);
+
+  if (!friend) {
+    return {
+      title: "Friend profile",
+    };
+  }
+
+  return {
+    title: `${friend.displayName} (@${friend.username})`,
+    description: `Explore ${friend.displayName}'s profile highlights and connect without leaving Creator Studio.`,
+  };
+}
+
+export default function FriendProfilePage({ params }: { params: { username: string } }) {
+  const friend = getFriend(params.username);
+
+  if (!friend) {
+    notFound();
+  }
+
+  const isExternalProfile = /^https?:\/\//i.test(friend.profileUrl);
+  const firstName = friend.displayName.split(" ")[0] || friend.displayName;
+
+  let externalDomain: string | null = null;
+  if (isExternalProfile) {
+    try {
+      const url = new URL(friend.profileUrl);
+      externalDomain = url.hostname.replace(/^www\./, "");
+    } catch {
+      externalDomain = null;
+    }
+  }
+
+  return (
+    <main className="relative min-h-screen bg-slate-950 pb-[env(safe-area-inset-bottom)] text-white">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-blue-500/15 blur-[160px]" />
+        <div className="absolute bottom-[-25%] right-[-15%] h-[320px] w-[320px] rounded-full bg-purple-500/10 blur-[200px]" />
+      </div>
+
+      <div className="relative z-10 mx-auto w-full max-w-3xl px-4 py-12">
+        <Link
+          href="/friends"
+          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70 transition hover:border-white/20 hover:bg-white/10"
+        >
+          <span aria-hidden className="text-base">←</span>
+          Back to friends
+        </Link>
+
+        <section className="mt-8 rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-[0_25px_45px_rgba(15,23,42,0.45)] backdrop-blur">
+          <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
+            <div className="mx-auto flex shrink-0 items-center justify-center sm:mx-0">
+              <div
+                className={`rounded-full p-[3px] ${
+                  friend.hasRing
+                    ? "bg-gradient-to-tr from-pink-500 via-fuchsia-500 to-orange-400"
+                    : "bg-white/10"
+                }`}
+              >
+                <div className="rounded-full bg-slate-950 p-[3px]">
+                  <Image
+                    src={friend.avatarUrl}
+                    alt={`${friend.displayName} avatar`}
+                    width={132}
+                    height={132}
+                    className="h-32 w-32 rounded-full object-cover"
+                    priority
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex-1 text-center sm:text-left">
+              <h1 className="text-3xl font-semibold text-white">{friend.displayName}</h1>
+              <p className="mt-2 text-sm font-medium text-white/60">@{friend.username}</p>
+
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+                {friend.hasRing ? (
+                  <span className="rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-fuchsia-200">
+                    Fresh story
+                  </span>
+                ) : null}
+                <span
+                  className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide ${
+                    friend.isOnline
+                      ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-200"
+                      : "border-white/10 bg-white/5 text-white/60"
+                  }`}
+                >
+                  <span className={`h-2 w-2 rounded-full ${friend.isOnline ? "bg-emerald-400" : "bg-white/40"}`} />
+                  {friend.isOnline ? "Online now" : "Offline"}
+                </span>
+              </div>
+
+              <p className="mt-5 text-sm leading-relaxed text-white/70">
+                Get a closer look at {friend.displayName} and their creator presence before jumping out to their public profile.
+                Review their status, see what is new, and decide how you want to connect.
+              </p>
+
+              <div className="mt-6 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-start">
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-full bg-white px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                >
+                  Message {firstName}
+                </button>
+                {isExternalProfile ? (
+                  <a
+                    href={friend.profileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-6 py-2 text-sm font-semibold text-white/80 transition hover:border-white/25 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                  >
+                    View on {externalDomain ?? "profile"}
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-10 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/50">Status</h2>
+            <p className="mt-3 text-base font-medium text-white">
+              {friend.isOnline
+                ? `${firstName} is online right now.`
+                : `${firstName} is not online at the moment.`}
+            </p>
+            <p className="mt-2 text-sm text-white/60">
+              {friend.isOnline
+                ? "Send a message while they are active to stay at the top of their inbox."
+                : "Drop them a note—they will be notified the next time they log in."}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/50">Stories</h2>
+            <p className="mt-3 text-base font-medium text-white">
+              {friend.hasRing ? "New spotlight content available." : "No new spotlight content right now."}
+            </p>
+            <p className="mt-2 text-sm text-white/60">
+              {friend.hasRing
+                ? "They have posted recently—check out the latest highlight on their public profile."
+                : "Once they share something new, you will see the ring light up here first."}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-slate-900/60 p-5 sm:col-span-2">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/50">Connect</h2>
+            <p className="mt-3 text-base font-medium text-white">
+              Prefer to explore outside the app?
+            </p>
+            {isExternalProfile ? (
+              <p className="mt-2 text-sm text-white/60">
+                Head over to {externalDomain ?? friend.profileUrl} to see their latest public updates, or stay here to keep the
+                conversation going.
+              </p>
+            ) : (
+              <p className="mt-2 text-sm text-white/60">
+                This creator manages their profile entirely inside Creator Studio. Connect now to see more.
+              </p>
+            )}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(app)/profile/[handle]/page.tsx
+++ b/src/app/(app)/profile/[handle]/page.tsx
@@ -71,7 +71,7 @@ export default function ProfileByHandlePage() {
           url: window.location.href,
         });
       } catch (error) {
-        console.log("Share cancelled");
+        console.log("Share cancelled", error);
       }
     } else {
       // Fallback: copy to clipboard
@@ -80,7 +80,7 @@ export default function ProfileByHandlePage() {
         // You could add a toast notification here
         console.log("URL copied to clipboard");
       } catch (error) {
-        console.error("Failed to copy URL");
+        console.error("Failed to copy URL", error);
       }
     }
   };
@@ -102,14 +102,20 @@ export default function ProfileByHandlePage() {
 
   if (error || !profile) {
     return (
-      <div className="min-h-screen bg-slate-900 flex items-center justify-center px-4">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-white mb-4">
-            {error || "Profile not found"}
-          </h1>
+      <div className="relative flex min-h-screen items-center justify-center bg-slate-950 px-4 text-white">
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <div className="absolute left-1/2 top-[-20%] h-[320px] w-[320px] -translate-x-1/2 rounded-full bg-blue-500/10 blur-[160px]" />
+          <div className="absolute bottom-[-25%] right-[-15%] h-[260px] w-[260px] rounded-full bg-purple-500/10 blur-[200px]" />
+        </div>
+
+        <div className="relative z-10 w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/70 p-8 text-center shadow-[0_25px_45px_rgba(15,23,42,0.45)] backdrop-blur">
+          <h1 className="text-2xl font-semibold text-white">{error || "Profile not found"}</h1>
+          <p className="mt-3 text-sm text-white/60">
+            Something went wrong while loading this profile. Try again or head back to your dashboard.
+          </p>
           <button
             onClick={() => router.push("/dashboard")}
-            className="px-6 py-3 bg-slate-800 text-white rounded-2xl hover:bg-slate-700 transition-colors"
+            className="mt-6 inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/25 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
           >
             Back to Dashboard
           </button>
@@ -126,17 +132,63 @@ export default function ProfileByHandlePage() {
     }
   });
 
+  const activeSocialCount = socialLinks.filter(
+    (link) => link.is_active && !!link.url,
+  ).length;
+  const activeLinkCount = contentCards.filter((card) => card.is_active).length;
+
   return (
-    <div className="min-h-screen bg-slate-900 pb-[env(safe-area-inset-bottom)]">
-      <HeroHeader profile={profile} onShare={handleShare} onBack={handleBack} />
-
-      <div className="px-4 -mt-8">
-        <SocialPillsRow socials={socialsData} />
+    <div className="relative min-h-screen bg-slate-950 pb-[env(safe-area-inset-bottom)] text-white">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-blue-500/15 blur-[160px]" />
+        <div className="absolute bottom-[-25%] right-[-15%] h-[360px] w-[360px] rounded-full bg-purple-500/10 blur-[200px]" />
       </div>
 
-      <div className="mt-8">
-        <LinkGrid links={contentCards} />
-      </div>
+      <main className="relative z-10 py-12">
+        <HeroHeader profile={profile} onShare={handleShare} onBack={handleBack} />
+
+        <section className="mx-auto mt-10 w-full max-w-4xl px-4">
+          <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-[0_25px_45px_rgba(15,23,42,0.45)] backdrop-blur">
+            <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-white/60">
+              <div className="font-semibold uppercase tracking-[0.35em] text-white/50">
+                Connect
+              </div>
+              {activeSocialCount > 0 ? (
+                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/60">
+                  {activeSocialCount} {activeSocialCount === 1 ? "network" : "networks"}
+                </span>
+              ) : null}
+            </div>
+
+            <div className="mt-4">
+              <SocialPillsRow socials={socialsData} />
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-12 w-full max-w-5xl px-4 pb-16">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="text-2xl font-semibold text-white">Featured links</h2>
+              <p className="mt-1 text-sm text-white/50">
+                {activeLinkCount > 0
+                  ? "Curated highlights from across this creator's world."
+                  : "Links you add will appear here for your audience."}
+              </p>
+            </div>
+
+            {activeLinkCount > 0 ? (
+              <span className="rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm font-medium text-white/70">
+                {activeLinkCount} {activeLinkCount === 1 ? "link" : "links"}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="mt-6">
+            <LinkGrid links={contentCards} />
+          </div>
+        </section>
+      </main>
     </div>
   );
 }

--- a/src/components/friends/FriendRow.tsx
+++ b/src/components/friends/FriendRow.tsx
@@ -1,33 +1,75 @@
-'use client';
-import Image from 'next/image';
-import type { Friend } from '@/lib/mock/friends';
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import type { Friend } from "@/lib/mock/friends";
 
 export default function FriendRow({ f }: { f: Friend }) {
+  const isExternalProfile = /^https?:\/\//i.test(f.profileUrl);
+  const linkClassName =
+    "group flex flex-1 items-center gap-3 min-w-0 pr-2 transition";
+
+  const linkBody = (
+    <>
+      <div className="relative">
+        {/* gradient ring */}
+        <div
+          className={`rounded-full p-[2px] ${
+            f.hasRing
+              ? "bg-gradient-to-tr from-pink-500 via-fuchsia-500 to-orange-400"
+              : "bg-transparent"
+          }`}
+        >
+          <div className="rounded-full bg-black p-[2px]">
+            <Image
+              alt={`${f.displayName} avatar`}
+              src={f.avatarUrl}
+              width={44}
+              height={44}
+              className="rounded-full object-cover"
+            />
+          </div>
+        </div>
+        {f.isOnline && (
+          <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-emerald-500 ring-2 ring-black" />
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <div className="truncate text-[15px] font-semibold text-white transition-colors group-hover:text-white/90">
+          {f.username}
+        </div>
+        <div className="truncate text-xs text-white/60 transition-colors group-hover:text-white/70">
+          {f.displayName}
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <li className="flex items-center justify-between gap-3 px-2">
       {/* LEFT: avatar + names */}
-      <div className="flex items-center gap-3 min-w-0">
-        <div className="relative">
-          {/* gradient ring */}
-          <div className={`rounded-full p-[2px] ${f.hasRing ? 'bg-gradient-to-tr from-pink-500 via-fuchsia-500 to-orange-400' : 'bg-transparent'}`}>
-            <div className="rounded-full bg-black p-[2px]">
-              <Image
-                alt={`${f.displayName} avatar`}
-                src={f.avatarUrl}
-                width={44}
-                height={44}
-                className="rounded-full object-cover"
-              />
-            </div>
-          </div>
-          {f.isOnline && <span className="absolute bottom-0 right-0 h-3 w-3 rounded-full bg-emerald-500 ring-2 ring-black" />}
-        </div>
-
-        <div className="min-w-0">
-          <div className="truncate text-[15px] font-semibold text-white">{f.username}</div>
-          <div className="truncate text-xs text-white/60">{f.displayName}</div>
-        </div>
-      </div>
+      {isExternalProfile ? (
+        <a
+          href={f.profileUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClassName}
+          aria-label={`View ${f.displayName}'s profile`}
+          title={f.profileUrl}
+        >
+          {linkBody}
+        </a>
+      ) : (
+        <Link
+          href={f.profileUrl}
+          className={linkClassName}
+          prefetch={false}
+          aria-label={`View ${f.displayName}'s profile`}
+        >
+          {linkBody}
+        </Link>
+      )}
 
       {/* RIGHT: actions */}
       <div className="flex items-center gap-2 shrink-0">

--- a/src/components/friends/FriendRow.tsx
+++ b/src/components/friends/FriendRow.tsx
@@ -5,9 +5,15 @@ import Link from "next/link";
 import type { Friend } from "@/lib/mock/friends";
 
 export default function FriendRow({ f }: { f: Friend }) {
-  const isExternalProfile = /^https?:\/\//i.test(f.profileUrl);
   const linkClassName =
     "group flex flex-1 items-center gap-3 min-w-0 pr-2 transition";
+  const isInternalProfile = f.profileUrl.startsWith("/");
+  const href = isInternalProfile
+    ? f.profileUrl
+    : `/friends/${encodeURIComponent(f.username)}`;
+  const title = !isInternalProfile && /^https?:\/\//i.test(f.profileUrl)
+    ? f.profileUrl
+    : undefined;
 
   const linkBody = (
     <>
@@ -49,27 +55,15 @@ export default function FriendRow({ f }: { f: Friend }) {
   return (
     <li className="flex items-center justify-between gap-3 px-2">
       {/* LEFT: avatar + names */}
-      {isExternalProfile ? (
-        <a
-          href={f.profileUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={linkClassName}
-          aria-label={`View ${f.displayName}'s profile`}
-          title={f.profileUrl}
-        >
-          {linkBody}
-        </a>
-      ) : (
-        <Link
-          href={f.profileUrl}
-          className={linkClassName}
-          prefetch={false}
-          aria-label={`View ${f.displayName}'s profile`}
-        >
-          {linkBody}
-        </Link>
-      )}
+      <Link
+        href={href}
+        className={linkClassName}
+        prefetch={false}
+        aria-label={`View ${f.displayName}'s profile`}
+        title={title}
+      >
+        {linkBody}
+      </Link>
 
       {/* RIGHT: actions */}
       <div className="flex items-center gap-2 shrink-0">

--- a/src/components/friends/SearchFriends.tsx
+++ b/src/components/friends/SearchFriends.tsx
@@ -12,19 +12,25 @@ export default function SearchFriends({ data }: { data: Friend[] }) {
     const supabase = getSupabaseBrowser();
     supabase?.auth.getUser().then(({ data: { user } }) => {
       if (user) {
+        const rawUsername =
+          (user.user_metadata?.username as string | undefined) ||
+          user.email?.split('@')[0] ||
+          'me';
+        const username = rawUsername.toLowerCase();
+        const displayName =
+          (user.user_metadata?.full_name as string | undefined) ||
+          user.email ||
+          'Me';
+        const avatarUrl =
+          (user.user_metadata?.avatar_url as string | undefined) ||
+          'https://i.pravatar.cc/96?img=67';
+
         setMe({
           id: user.id,
-          username:
-            user.user_metadata?.username ||
-            user.email?.split('@')[0] ||
-            'me',
-          displayName:
-            user.user_metadata?.full_name ||
-            user.email ||
-            'Me',
-          avatarUrl:
-            user.user_metadata?.avatar_url ||
-            'https://i.pravatar.cc/96?img=67',
+          username,
+          displayName,
+          avatarUrl,
+          profileUrl: username ? `/profile/${username}` : '#',
         });
       }
     });

--- a/src/components/profile/HeroHeader.tsx
+++ b/src/components/profile/HeroHeader.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChevronLeft, ExternalLink, Share2 } from "lucide-react";
+import {
+  Calendar,
+  ChevronLeft,
+  ExternalLink,
+  MapPin,
+  Share2,
+} from "lucide-react";
+import Image from "next/image";
 import { Profile } from "@/lib/types";
 
 interface HeroHeaderProps {
@@ -26,114 +33,168 @@ export default function HeroHeader({
     return username.slice(0, 2).toUpperCase();
   };
 
-  const initials = getInitials(profile.name || null, profile.username);
+  const formatBioSegments = (bio: string | null | undefined) => {
+    if (!bio) return [] as string[];
 
-  // Format tagline with bullet separators
-  const formatTagline = (bio: string | null | undefined) => {
-    if (!bio) return "Creator • Entrepreneur • Innovator";
-
-    // Split by common separators and join with bullets
-    const parts = bio
-      .split(/[•,|]/)
-      .map((part) => part.trim())
-      .filter(Boolean);
-    return parts.join(" • ");
+    return bio
+      .split(/[\n•|]+/)
+      .flatMap((segment) =>
+        segment
+          .split(",")
+          .map((part) => part.trim())
+          .filter(Boolean),
+      );
   };
 
-  const tagline = formatTagline(profile.bio);
+  const initials = getInitials(profile.name || null, profile.username);
+  const displayName = profile.name?.trim() || profile.username;
+  const bioSegments = formatBioSegments(profile.bio);
+  const tagline = bioSegments.length
+    ? bioSegments.join(" • ")
+    : "Share a short introduction so people know what to expect from your world.";
+
+  const joinedDate = profile.created_at
+    ? new Intl.DateTimeFormat(undefined, {
+        month: "long",
+        year: "numeric",
+      }).format(new Date(profile.created_at))
+    : null;
 
   return (
-    <div className="relative">
-      {/* Cover Block */}
-      <div className="relative h-[200px] overflow-hidden rounded-2xl mx-4 mt-4">
-        {profile.banner_url ? (
-          <div
-            className="w-full h-full bg-cover bg-center"
-            style={{ backgroundImage: `url(${profile.banner_url})` }}
-          />
-        ) : (
-          <div className="w-full h-full bg-gradient-to-br from-[#1E293B] via-[#111827] to-[#0B1220]" />
-        )}
-
-        {/* Overlay gradient for better text readability */}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
+    <section className="relative mx-auto w-full max-w-4xl px-4">
+      <div className="absolute inset-0 -z-10 flex justify-center">
+        <div className="h-48 w-48 rounded-full bg-blue-500/20 blur-[120px]" />
       </div>
 
-      {/* Top Row - Back, Title, Share */}
-      <div className="absolute top-6 left-6 right-6 flex items-center justify-between">
-        <button
-          onClick={onBack}
-          className="w-10 h-10 rounded-full bg-black/20 backdrop-blur-sm flex items-center justify-center text-white hover:bg-black/30 transition-colors"
-        >
-          <ChevronLeft className="w-5 h-5" />
-        </button>
+      <article className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 shadow-[0_25px_50px_-12px_rgba(15,23,42,0.65)] backdrop-blur-xl">
+        <div className="relative h-44 sm:h-52">
+          {profile.banner_url ? (
+            <Image
+              src={profile.banner_url}
+              alt="Profile banner"
+              fill
+              priority
+              unoptimized
+              sizes="(min-width: 640px) 1024px, 100vw"
+              className="object-cover"
+            />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
+          )}
 
-        <div className="flex items-center space-x-2 text-white/80">
-          <span className="text-sm font-medium">Bio Link</span>
-          <ExternalLink className="w-4 h-4" />
+          <div className="absolute inset-0 bg-gradient-to-t from-slate-950 via-slate-950/20 to-transparent" />
+
+          <div className="absolute inset-x-6 top-6 flex items-center gap-3 text-white">
+            {onBack ? (
+              <button
+                type="button"
+                onClick={onBack}
+                className="inline-flex items-center gap-2 rounded-full bg-black/40 px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                <span className="hidden sm:inline">Back</span>
+              </button>
+            ) : null}
+
+            <div className="flex flex-1 justify-center">
+              <div className="flex flex-col items-center text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-white/60">
+                <span>Profile</span>
+                <div className="mt-2 h-px w-12 bg-white/30" />
+              </div>
+            </div>
+
+            {onShare ? (
+              <button
+                type="button"
+                onClick={onShare}
+                className="inline-flex items-center gap-2 rounded-full bg-black/40 px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              >
+                <span className="hidden sm:inline">Share</span>
+                <Share2 className="h-4 w-4" aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
         </div>
 
-        <button
-          onClick={onShare}
-          className="w-10 h-10 rounded-full bg-black/20 backdrop-blur-sm flex items-center justify-center text-white hover:bg-black/30 transition-colors"
-        >
-          <Share2 className="w-5 h-5" />
-        </button>
-      </div>
+        <div className="-mt-12 px-6 pb-8 sm:-mt-16">
+          <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
+            <div className="relative mx-auto sm:mx-0">
+              <div className="relative h-24 w-24 overflow-hidden rounded-2xl border border-white/20 bg-slate-800 shadow-[0_10px_40px_rgba(15,23,42,0.6)] sm:h-28 sm:w-28">
+                {profile.avatar_url ? (
+                  <Image
+                    src={profile.avatar_url}
+                    alt={`${displayName}'s avatar`}
+                    fill
+                    sizes="(min-width: 640px) 112px, 96px"
+                    unoptimized
+                    className="object-cover"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center bg-slate-700 text-3xl font-bold text-white">
+                    {initials}
+                  </div>
+                )}
+              </div>
+            </div>
 
-      {/* Profile Info Container */}
-      <div className="px-4 -mt-14 relative z-10">
-        {/* Avatar */}
-        <div className="flex justify-center mb-4">
-          <div className="relative">
-            <div className="w-[84px] h-[84px] rounded-full overflow-hidden ring-4 ring-slate-900 bg-slate-800">
-              {profile.avatar_url ? (
-                <img
-                  src={profile.avatar_url}
-                  alt={`${profile.name || profile.username}'s avatar`}
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                <div className="w-full h-full bg-slate-700 flex items-center justify-center text-white text-2xl font-bold">
-                  {initials}
+            <div className="flex-1 text-center sm:text-left">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="mx-auto flex flex-col gap-3 sm:mx-0">
+                  <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+                    <h1 className="text-3xl font-semibold text-white sm:text-4xl">
+                      {displayName}
+                    </h1>
+                    {profile.verified && (
+                      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-500">
+                        <svg
+                          className="h-3 w-3 text-white"
+                          fill="currentColor"
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="flex justify-center sm:justify-start">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-sm font-medium text-white/70">
+                      <ExternalLink className="h-4 w-4 text-white/40" aria-hidden="true" />
+                      @{profile.username}
+                    </span>
+                  </div>
                 </div>
-              )}
+              </div>
+
+              <div className="mt-6 space-y-4">
+                <p className="mx-auto max-w-2xl text-base leading-relaxed text-white/70 sm:mx-0">
+                  {tagline}
+                </p>
+
+                <div className="flex flex-wrap justify-center gap-3 text-sm text-white/60 sm:justify-start">
+                  {profile.city ? (
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                      <MapPin className="h-4 w-4 text-blue-200" aria-hidden="true" />
+                      <span>{profile.city}</span>
+                    </span>
+                  ) : null}
+
+                  {joinedDate ? (
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                      <Calendar className="h-4 w-4 text-blue-200" aria-hidden="true" />
+                      <span>Joined {joinedDate}</span>
+                    </span>
+                  ) : null}
+                </div>
+              </div>
             </div>
           </div>
         </div>
-
-        {/* Name and Handle */}
-        <div className="text-center mb-3">
-          <div className="flex items-center justify-center space-x-2 mb-1">
-            <h1 className="text-2xl font-bold text-white">
-              {profile.name || profile.username}
-            </h1>
-            {profile.verified && (
-              <div className="w-5 h-5 bg-blue-500 rounded-full flex items-center justify-center">
-                <svg
-                  className="w-3 h-3 text-white"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              </div>
-            )}
-          </div>
-          <p className="text-white/70 text-lg">@{profile.username}</p>
-        </div>
-
-        {/* Tagline */}
-        <div className="text-center mb-6">
-          <p className="text-white/70 text-base leading-relaxed max-w-md mx-auto line-clamp-2">
-            {tagline}
-          </p>
-        </div>
-      </div>
-    </div>
+      </article>
+    </section>
   );
 }

--- a/src/components/profile/LinkGrid.tsx
+++ b/src/components/profile/LinkGrid.tsx
@@ -2,7 +2,6 @@
 
 import { ContentCard } from "@/lib/types";
 import LinkTile from "./LinkTile";
-import { ProfileSkeleton } from "./ProfileSkeleton";
 
 interface LinkGridProps {
   links: ContentCard[];
@@ -10,14 +9,18 @@ interface LinkGridProps {
 }
 
 export default function LinkGrid({ links, loading = false }: LinkGridProps) {
+  const activeLinks = (links || [])
+    .filter((link) => link.is_active)
+    .sort((a, b) => a.position - b.position);
+
   if (loading) {
     return (
       <div className="px-4">
-        <div className="grid grid-cols-2 gap-3">
-          {Array.from({ length: 6 }).map((_, index) => (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
             <div
-              key={index}
-              className="aspect-square rounded-2xl bg-white/5 animate-pulse"
+              key={`link-skeleton-${index}`}
+              className="h-44 rounded-3xl bg-white/5 animate-pulse"
             />
           ))}
         </div>
@@ -25,20 +28,13 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
     );
   }
 
-  if (!links || links.length === 0) {
+  if (activeLinks.length === 0) {
     return (
       <div className="px-4">
-        <div
-          className="
-          rounded-2xl bg-slate-900/60 
-          ring-1 ring-white/10 
-          p-8 text-center
-          shadow-[inset_0_1px_rgba(255,255,255,0.06),0_10px_30px_rgba(0,0,0,0.45)]
-        "
-        >
-          <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-slate-800 flex items-center justify-center">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/70 p-10 text-center shadow-[0_25px_45px_rgba(15,23,42,0.45)]">
+          <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-white/5 text-white/50">
             <svg
-              className="w-8 h-8 text-white/50"
+              className="h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -47,29 +43,22 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
                 strokeLinecap="round"
                 strokeLinejoin="round"
                 strokeWidth={2}
-                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-.758l1.102-1.101a4 4 0 105.656-5.656l4-4a4 4 0 00-5.656 0l-1.102 1.101"
+                d="M12 4v16m8-8H4"
               />
             </svg>
           </div>
-          <h3 className="text-white font-semibold text-lg mb-2">
-            No links yet
-          </h3>
-          <p className="text-white/50 text-sm">
-            Add your first link to get started
+          <h3 className="text-lg font-semibold text-white">No links yet</h3>
+          <p className="mt-2 text-sm text-white/50">
+            Publish your first link to showcase what you are working on.
           </p>
         </div>
       </div>
     );
   }
 
-  // Filter active links and sort by position
-  const activeLinks = links
-    .filter((link) => link.is_active)
-    .sort((a, b) => a.position - b.position);
-
   return (
     <div className="px-4">
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {activeLinks.map((link) => (
           <LinkTile
             key={link.id}

--- a/src/components/profile/LinkTile.tsx
+++ b/src/components/profile/LinkTile.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ExternalLink } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 
 interface LinkTileProps {
@@ -21,81 +22,51 @@ export default function LinkTile({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block group"
+      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
     >
-      <div
-        className="
-        aspect-square rounded-2xl overflow-hidden relative
-        bg-slate-900/60 ring-1 ring-white/10 
-        shadow-[inset_0_1px_rgba(255,255,255,0.06),0_10px_30px_rgba(0,0,0,0.45)]
-        hover:ring-white/20 hover:shadow-[inset_0_1px_rgba(255,255,255,0.08),0_15px_40px_rgba(0,0,0,0.6)]
-        transition-all duration-200
-        active:scale-95
-      "
-      >
-        {/* Background Image or Fallback Gradient */}
-        {thumbUrl ? (
-          <div
-            className="w-full h-full bg-cover bg-center"
-            style={{ backgroundImage: `url(${thumbUrl})` }}
-          />
-        ) : (
-          <div className="w-full h-full bg-gradient-to-br from-slate-800 to-slate-900" />
-        )}
+      <article className="flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 shadow-[0_20px_45px_rgba(15,23,42,0.45)] transition-all duration-200 hover:border-white/25 hover:shadow-[0_28px_60px_rgba(15,23,42,0.55)]">
+        <div className="relative h-32 w-full overflow-hidden">
+          {thumbUrl ? (
+            <Image
+              src={thumbUrl}
+              alt={`${title} preview`}
+              fill
+              sizes="(min-width: 640px) 50vw, 100vw"
+              unoptimized
+              className="object-cover"
+            />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
+          )}
 
-        {/* Overlay Gradient */}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-black/10" />
+          <div className="absolute inset-0 bg-gradient-to-t from-slate-950/60 via-slate-950/10 to-transparent" />
 
-        {/* External Link Badge - Top Right */}
-        <div className="absolute top-3 right-3">
-          <div
-            className="
-            w-8 h-8 rounded-full 
-            bg-black/40 backdrop-blur-sm
-            ring-1 ring-white/20
-            flex items-center justify-center
-            group-hover:bg-black/60 transition-colors
-          "
-          >
-            <ExternalLink className="w-4 h-4 text-white" />
+          <div className="absolute right-4 top-4">
+            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-black/30 text-white transition-colors group-hover:border-white/30 group-hover:bg-black/50">
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </span>
           </div>
         </div>
 
-        {/* Content - Bottom Left */}
-        <div className="absolute bottom-0 left-0 right-0 p-4">
-          <h3
-            className="
-            text-white font-semibold text-lg leading-tight
-            line-clamp-2 mb-1
-            group-hover:text-white/90 transition-colors
-          "
-          >
+        <div className="flex flex-1 flex-col gap-3 p-5">
+          <h3 className="text-lg font-semibold text-white transition-colors group-hover:text-white/90">
             {title}
           </h3>
 
-          {description && (
-            <p
-              className="
-              text-white/70 text-sm leading-relaxed
-              line-clamp-2
-              group-hover:text-white/80 transition-colors
-            "
-            >
+          {description ? (
+            <p className="text-sm leading-relaxed text-white/70 line-clamp-3">
               {description}
             </p>
+          ) : (
+            <p className="text-sm text-white/40">Tap to open this link in a new tab.</p>
           )}
-        </div>
 
-        {/* Hover Effect Overlay */}
-        <div
-          className="
-          absolute inset-0 
-          bg-gradient-to-t from-blue-500/10 to-transparent
-          opacity-0 group-hover:opacity-100
-          transition-opacity duration-200
-        "
-        />
-      </div>
+          <div className="mt-auto flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/40">
+            <span className="h-px w-6 bg-white/20" />
+            <span>Open link</span>
+          </div>
+        </div>
+      </article>
     </Link>
   );
 }

--- a/src/components/profile/ProfileSkeleton.tsx
+++ b/src/components/profile/ProfileSkeleton.tsx
@@ -2,66 +2,47 @@
 
 export function ProfileSkeleton() {
   return (
-    <div className="min-h-screen bg-slate-900 pb-[env(safe-area-inset-bottom)]">
-      {/* Hero Header Skeleton */}
-      <div className="relative">
-        {/* Cover Block Skeleton */}
-        <div className="relative h-[200px] overflow-hidden rounded-2xl mx-4 mt-4">
-          <div className="w-full h-full bg-slate-800 animate-pulse" />
-        </div>
+    <div className="relative min-h-screen bg-slate-950 pb-[env(safe-area-inset-bottom)]">
+      <div className="absolute inset-0 overflow-hidden">
+        <div className="absolute left-1/2 top-[-20%] h-96 w-96 -translate-x-1/2 rounded-full bg-blue-500/15 blur-[160px]" />
+        <div className="absolute bottom-[-25%] right-[-15%] h-80 w-80 rounded-full bg-purple-500/10 blur-[180px]" />
+      </div>
 
-        {/* Top Row Skeleton */}
-        <div className="absolute top-6 left-6 right-6 flex items-center justify-between">
-          <div className="w-10 h-10 rounded-full bg-black/20 animate-pulse" />
-          <div className="flex items-center space-x-2">
-            <div className="w-20 h-4 bg-white/20 rounded animate-pulse" />
-            <div className="w-4 h-4 bg-white/20 rounded animate-pulse" />
-          </div>
-          <div className="w-10 h-10 rounded-full bg-black/20 animate-pulse" />
-        </div>
+      <div className="relative mx-auto w-full max-w-4xl px-4 pt-12">
+        <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 backdrop-blur-xl shadow-[0_25px_50px_-12px_rgba(15,23,42,0.65)]">
+          <div className="h-44 w-full bg-slate-800/70 animate-pulse sm:h-52" />
 
-        {/* Profile Info Container Skeleton */}
-        <div className="px-4 -mt-14 relative z-10">
-          {/* Avatar Skeleton */}
-          <div className="flex justify-center mb-4">
-            <div className="w-[84px] h-[84px] rounded-full bg-slate-800 animate-pulse" />
-          </div>
+          <div className="-mt-12 px-6 pb-8 sm:-mt-16">
+            <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
+              <div className="mx-auto h-24 w-24 rounded-2xl bg-slate-800 animate-pulse sm:mx-0 sm:h-28 sm:w-28" />
 
-          {/* Name and Handle Skeleton */}
-          <div className="text-center mb-3">
-            <div className="flex items-center justify-center space-x-2 mb-1">
-              <div className="w-32 h-8 bg-white/20 rounded animate-pulse" />
-              <div className="w-5 h-5 rounded-full bg-blue-500 animate-pulse" />
+              <div className="flex-1 space-y-4 text-center sm:text-left">
+                <div className="mx-auto h-8 w-48 rounded-full bg-white/10 animate-pulse sm:mx-0" />
+                <div className="mx-auto h-3 w-40 rounded-full bg-white/10 animate-pulse sm:mx-0" />
+                <div className="mx-auto h-20 w-full max-w-md rounded-2xl bg-white/5 animate-pulse sm:mx-0" />
+              </div>
             </div>
-            <div className="w-24 h-6 bg-white/20 rounded animate-pulse mx-auto" />
-          </div>
-
-          {/* Tagline Skeleton */}
-          <div className="text-center mb-6">
-            <div className="w-48 h-4 bg-white/20 rounded animate-pulse mx-auto" />
           </div>
         </div>
       </div>
 
-      {/* Social Pills Row Skeleton */}
-      <div className="px-4 -mt-8">
-        <div className="flex justify-center space-x-3">
-          {Array.from({ length: 5 }).map((_, index) => (
+      <div className="relative mx-auto mt-10 w-full max-w-4xl px-4">
+        <div className="flex flex-wrap justify-center gap-3">
+          {Array.from({ length: 4 }).map((_, index) => (
             <div
-              key={index}
-              className="w-11 h-11 rounded-full bg-white/10 animate-pulse"
+              key={`social-skeleton-${index}`}
+              className="h-10 w-32 rounded-full bg-white/5 animate-pulse"
             />
           ))}
         </div>
       </div>
 
-      {/* Link Grid Skeleton */}
-      <div className="mt-8 px-4">
-        <div className="grid grid-cols-2 gap-3">
-          {Array.from({ length: 6 }).map((_, index) => (
+      <div className="relative mx-auto mt-12 w-full max-w-5xl px-4 pb-16">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, index) => (
             <div
-              key={index}
-              className="aspect-square rounded-2xl bg-white/5 animate-pulse"
+              key={`link-card-skeleton-${index}`}
+              className="h-44 rounded-3xl bg-white/5 animate-pulse"
             />
           ))}
         </div>

--- a/src/components/profile/SocialPillsRow.tsx
+++ b/src/components/profile/SocialPillsRow.tsx
@@ -2,15 +2,15 @@
 
 import Link from "next/link";
 import {
+  Github,
+  Globe,
   Instagram,
-  Twitter,
-  Youtube,
-  Music,
   Linkedin,
   Mail,
-  Globe,
-  Github,
   MessageCircle,
+  Music,
+  Twitter,
+  Youtube,
 } from "lucide-react";
 
 interface SocialPillsRowProps {
@@ -74,7 +74,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
 
   // Filter out undefined URLs and sort by platform priority
   const availableSocials = Object.entries(socials)
-    .filter(([_, url]) => url && url !== "#")
+    .filter(([, url]) => url && url !== "#")
     .sort(([a], [b]) => {
       const priority = [
         "instagram",
@@ -100,7 +100,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   }
 
   return (
-    <div className="flex justify-center space-x-3">
+    <div className="flex flex-wrap justify-center gap-3">
       {availableSocials.map(([platform, url]) => {
         const config = platformConfig[platform as keyof typeof platformConfig];
         if (!config || !url) return null;
@@ -113,24 +113,14 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group"
+            className="group inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 transition-all hover:border-white/30 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
           >
-            <div
-              className={`
-              w-11 h-11 rounded-full 
-              ${config.color} 
-              ring-1 ring-white/10 
-              hover:bg-white/8 
-              hover:ring-white/20
-              transition-all duration-200 
-              flex items-center justify-center
-              shadow-lg hover:shadow-xl
-              transform hover:scale-105
-            `}
+            <span
+              className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-white shadow-lg ${config.color}`}
             >
-              <IconComponent className="w-5 h-5 text-white" />
-            </div>
-            <span className="sr-only">{config.label}</span>
+              <IconComponent className="h-4 w-4" aria-hidden="true" />
+            </span>
+            <span>{config.label}</span>
           </Link>
         );
       })}

--- a/src/lib/mock/friends.ts
+++ b/src/lib/mock/friends.ts
@@ -3,6 +3,7 @@ export type Friend = {
   username: string;
   displayName: string;
   avatarUrl: string;
+  profileUrl: string;
   hasRing?: boolean;   // show gradient ring like IG story
   isOnline?: boolean;
 };
@@ -10,41 +11,46 @@ export type Friend = {
 export const MOCK_FRIENDS: Friend[] = [
   {
     id: 'u1',
-    username: 'drake',
+    username: 'champagnepapi',
     displayName: 'Drake',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/9/90/Drake_at_Sound_Academy_Toronto_Canada_2016-03-14.jpg/160px-Drake_at_Sound_Academy_Toronto_Canada_2016-03-14.jpg',
+    profileUrl: 'https://www.instagram.com/champagnepapi/',
     hasRing: true,
   },
   {
     id: 'u2',
-    username: 'kendrick_lamar',
+    username: 'kendricklamar',
     displayName: 'Kendrick Lamar',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Kendrick_Lamar_Lollapalooza_2016-2.jpg/160px-Kendrick_Lamar_Lollapalooza_2016-2.jpg',
+    profileUrl: 'https://www.instagram.com/kendricklamar/',
   },
   {
     id: 'u3',
-    username: 'nicki_minaj',
+    username: 'nickiminaj',
     displayName: 'Nicki Minaj',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/Nicki_Minaj_NBC_2022.jpg/160px-Nicki_Minaj_NBC_2022.jpg',
+    profileUrl: 'https://www.instagram.com/nickiminaj/',
     hasRing: true,
   },
   {
     id: 'u4',
-    username: 'jayz',
+    username: 'officialjayz',
     displayName: 'Jay-Z',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f7/Jay-Z_2011.jpg/160px-Jay-Z_2011.jpg',
+    profileUrl: 'https://www.instagram.com/officialjayz/',
     hasRing: true,
   },
   {
     id: 'u5',
-    username: 'jcole',
+    username: 'realcoleworld',
     displayName: 'J. Cole',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/J._Cole_2018.jpg/160px-J._Cole_2018.jpg',
+    profileUrl: 'https://www.instagram.com/realcoleworld/',
   },
   {
     id: 'u6',
@@ -52,6 +58,7 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: 'Snoop Dogg',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Snoop_Dogg_2019_by_Glenn_Francis.jpg/160px-Snoop_Dogg_2019_by_Glenn_Francis.jpg',
+    profileUrl: 'https://www.instagram.com/snoopdogg/',
   },
   {
     id: 'u7',
@@ -59,6 +66,7 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: 'Kanye West',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Kanye_West_at_the_2009_Tribeca_Film_Festival.jpg/160px-Kanye_West_at_the_2009_Tribeca_Film_Festival.jpg',
+    profileUrl: 'https://www.instagram.com/kanyewest/',
   },
   {
     id: 'u8',
@@ -66,13 +74,15 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: 'Eminem',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Eminem@Dublin.jpg/160px-Eminem@Dublin.jpg',
+    profileUrl: 'https://www.instagram.com/eminem/',
   },
   {
     id: 'u9',
-    username: 'cardib',
+    username: 'iamcardib',
     displayName: 'Cardi B',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Cardi_B_2018.jpg/160px-Cardi_B_2018.jpg',
+    profileUrl: 'https://www.instagram.com/iamcardib/',
   },
   {
     id: 'u10',
@@ -80,13 +90,15 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: 'Travis Scott',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6d/Travis_Scott_August_2019.jpg/160px-Travis_Scott_August_2019.jpg',
+    profileUrl: 'https://www.instagram.com/travisscott/',
   },
   {
     id: 'u11',
-    username: 'lilwayne',
+    username: 'liltunechi',
     displayName: 'Lil Wayne',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/6/62/Lil_Wayne_2011.jpg/160px-Lil_Wayne_2011.jpg',
+    profileUrl: 'https://www.instagram.com/liltunechi/',
     hasRing: true,
   },
   {
@@ -95,6 +107,7 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: 'A$AP Rocky',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/ASAP_Rocky_2013.jpg/160px-ASAP_Rocky_2013.jpg',
+    profileUrl: 'https://www.instagram.com/asaprocky/',
   },
   {
     id: 'u13',
@@ -102,6 +115,7 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: '50 Cent',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/50_Cent_2018.jpg/160px-50_Cent_2018.jpg',
+    profileUrl: 'https://www.instagram.com/50cent/',
   },
   {
     id: 'u14',
@@ -109,5 +123,6 @@ export const MOCK_FRIENDS: Friend[] = [
     displayName: 'Ice Cube',
     avatarUrl:
       'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Ice_Cube_2014.jpg/160px-Ice_Cube_2014.jpg',
+    profileUrl: 'https://www.instagram.com/icecube/',
   },
 ];


### PR DESCRIPTION
## Summary
- redesign the profile hero with modern typography, background treatments, and responsive metadata chips
- refresh the social + link sections with accessible pills, counters, and richer empty states
- update link tiles and skeleton loaders to match the new layout and improve readability

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68cf0397bd34832cb3fb742ab0c1d4cc