### PR TITLE
Prevent dashboard auto-scroll on load

### DIFF
--- a/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
@@ -21,7 +21,11 @@ export default function SkillsCarousel() {
     const idx = deriveInitialIndex(categories, initialId);
     setActiveIndex(idx);
     const el = cardRefs.current[idx];
-    el?.scrollIntoView({ behavior: "instant", inline: "center" });
+    el?.scrollIntoView({
+      behavior: "instant",
+      inline: "center",
+      block: "nearest",
+    });
   }, [categories, search]);
 
   const changeIndex = (idx: number) => {


### PR DESCRIPTION
## Summary
- avoid the skills carousel from forcing the dashboard view to jump down by constraining its initial `scrollIntoView`

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68cf06dc8584832c8a3d988363a5dcad