### PR TITLE
Restore project-to-task transition on schedule timeline

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -943,23 +943,33 @@ export default function SchedulePage() {
                       </div>
                     )
                   })}
-                  {projectInstances.map(({ instance, project, start, end, assignedWindow }, index) => {
-                    const projectId = project.id
-                    const startMin = start.getHours() * 60 + start.getMinutes()
-                    const top = (startMin - startHour * 60) * pxPerMin
-                    const height =
-                      ((end.getTime() - start.getTime()) / 60000) * pxPerMin
-                    const isExpanded = expandedProjects.has(projectId)
-                    const tasksForProject = taskInstancesByProject[projectId] || []
-                    const durationMinutes = Math.round(
-                      (end.getTime() - start.getTime()) / 60000
-                    )
-                    const timeRangeLabel = formatTimeRangeLabel(start, end)
-                    const trimmedWindowLabel =
-                      typeof assignedWindow?.label === 'string'
-                        ? assignedWindow.label.trim()
-                        : ''
-                    const hasWindow = Boolean(instance.window_id)
+                  {projectInstances.map(
+                    ({ instance, project, start: projectStart, end: projectEnd, assignedWindow }, index) => {
+                      const projectId = project.id
+                      const startMin =
+                        projectStart.getHours() * 60 + projectStart.getMinutes()
+                      const top = (startMin - startHour * 60) * pxPerMin
+                      const height =
+                        ((projectEnd.getTime() - projectStart.getTime()) / 60000) *
+                        pxPerMin
+                      const containerHeight =
+                        typeof height === 'number' ? Math.max(0, height) : 0
+                      const isExpanded = expandedProjects.has(projectId)
+                      const tasksForProject =
+                        taskInstancesByProject[projectId] || []
+                      const hasTasks = tasksForProject.length > 0
+                      const durationMinutes = Math.round(
+                        (projectEnd.getTime() - projectStart.getTime()) / 60000
+                      )
+                      const timeRangeLabel = formatTimeRangeLabel(
+                        projectStart,
+                        projectEnd
+                      )
+                      const trimmedWindowLabel =
+                        typeof assignedWindow?.label === 'string'
+                          ? assignedWindow.label.trim()
+                          : ''
+                      const hasWindow = Boolean(instance.window_id)
                     let windowDescriptor = `Window: ${
                       trimmedWindowLabel.length > 0
                         ? trimmedWindowLabel
@@ -985,130 +995,73 @@ export default function SchedulePage() {
                     ]
                     if (tasksLabel) detailParts.push(tasksLabel)
                     const detailText = detailParts.join(' · ')
-                    const style: CSSProperties = {
+                    const wrapperStyle: CSSProperties = {
                       top,
                       height,
+                    }
+                    const cardStyle: CSSProperties = {
                       boxShadow: 'var(--elev-card)',
                       outline: '1px solid var(--event-border)',
                       outlineOffset: '-1px',
+                      backgroundColor:
+                        hasTasks && isExpanded
+                          ? 'rgba(63, 63, 70, 0.35)'
+                          : 'var(--event-bg)',
                     }
+                    const cardClassName = `relative h-full rounded-[var(--radius-lg)] text-white transition-colors ${
+                      !isExpanded || !hasTasks
+                        ? 'flex items-center justify-between px-3 py-2'
+                        : ''
+                    }`
                     return (
                       <AnimatePresence
                         key={instance.id}
                         initial={false}
                         mode="wait"
                       >
-                        {!isExpanded || tasksForProject.length === 0 ? (
+                        <motion.div
+                          aria-label={`Project ${project.name}`}
+                          className="absolute left-16 right-2"
+                          style={wrapperStyle}
+                          initial={
+                            prefersReducedMotion ? false : { opacity: 0, y: 4 }
+                          }
+                          animate={
+                            prefersReducedMotion ? undefined : { opacity: 1, y: 0 }
+                          }
+                          exit={
+                            prefersReducedMotion
+                              ? undefined
+                              : { opacity: 0, y: 4 }
+                          }
+                          transition={
+                            prefersReducedMotion
+                              ? undefined
+                              : { delay: index * 0.02 }
+                          }
+                        >
                           <motion.div
-                            key="project"
-                            aria-label={`Project ${project.name}`}
-                            onClick={() => {
-                              if (tasksForProject.length === 0) return
-                              setExpandedProjects(prev => {
-                                const next = new Set(prev)
-                                if (next.has(projectId)) next.delete(projectId)
-                                else next.add(projectId)
-                                return next
-                              })
-                            }}
-                            className="absolute left-16 right-2 flex items-center justify-between rounded-[var(--radius-lg)] bg-[var(--event-bg)] px-3 py-2 text-white"
-                            style={style}
-                            initial={
-                              prefersReducedMotion ? false : { opacity: 0, y: 4 }
-                            }
-                            animate={
-                              prefersReducedMotion ? undefined : { opacity: 1, y: 0 }
-                            }
-                            exit={
-                              prefersReducedMotion
-                                ? undefined
-                                : { opacity: 0, y: 4 }
-                            }
-                            transition={
-                              prefersReducedMotion
-                                ? undefined
-                                : { delay: index * 0.02 }
-                            }
-                          >
-                            {renderInstanceActions(instance.id, { projectId })}
-                            <div className="flex flex-col">
-                              <span className="truncate text-sm font-medium">
-                                {project.name}
-                              </span>
-                              <div className="text-xs text-zinc-200/70">
-                                {detailText}
-                              </div>
-                            </div>
-                            {project.skill_icon && (
-                              <span
-                                className="ml-2 text-lg leading-none flex-shrink-0"
-                                aria-hidden
-                              >
-                                {project.skill_icon}
-                              </span>
-                            )}
-                            <FlameEmber
-                              level={
-                                (instance.energy_resolved?.toUpperCase() as FlameLevel) ||
-                                'NO'
-                              }
-                              size="sm"
-                              className="absolute -top-1 -right-1"
-                            />
-                          </motion.div>
-                        ) : (
-                          <motion.div
-                            key="tasks"
-                            initial={
-                              prefersReducedMotion
-                                ? false
-                                : { opacity: 0, y: 4 }
-                            }
-                            animate={
-                              prefersReducedMotion
-                                ? undefined
-                                : { opacity: 1, y: 0 }
-                            }
-                            exit={
-                              prefersReducedMotion
-                                ? undefined
-                                : { opacity: 0, y: 4 }
-                            }
-                            transition={
-                              prefersReducedMotion
-                                ? undefined
-                                : { delay: index * 0.02 }
-                            }
-                          >
-                            {tasksForProject.map(taskInfo => {
-                              const { instance: taskInstance, task, start, end } = taskInfo
-                              const tStartMin =
-                                start.getHours() * 60 + start.getMinutes()
-                              const tTop = (tStartMin - startHour * 60) * pxPerMin
-                              const tHeight =
-                                ((end.getTime() - start.getTime()) / 60000) * pxPerMin
-                              const tStyle: CSSProperties = {
-                                top: tTop,
-                                height: tHeight,
-                                boxShadow: 'var(--elev-card)',
-                                outline: '1px solid var(--event-border)',
-                                outlineOffset: '-1px',
-                              }
-                              const progress =
-                                (task as { progress?: number }).progress ?? 0
-                              return (
-                                <motion.div
-                                  key={taskInstance.id}
-                                  aria-label={`Task ${task.name}`}
-                                  className="absolute left-16 right-2 flex items-center justify-between rounded-[var(--radius-lg)] bg-stone-700 px-3 py-2 text-white"
-                                  style={tStyle}
-                                  onClick={() =>
+                            layout
+                            className={cardClassName}
+                            style={cardStyle}
+                            onClick={
+                              hasTasks
+                                ? () => {
                                     setExpandedProjects(prev => {
                                       const next = new Set(prev)
-                                      next.delete(projectId)
+                                      if (next.has(projectId)) next.delete(projectId)
+                                      else next.add(projectId)
                                       return next
                                     })
                                   }
+                                : undefined
+                            }
+                          >
+                            <AnimatePresence mode="wait">
+                              {!isExpanded || !hasTasks ? (
+                                <motion.div
+                                  key="project"
+                                  className="relative flex w-full items-center justify-between gap-3"
                                   initial={
                                     prefersReducedMotion
                                       ? false
@@ -1124,44 +1077,154 @@ export default function SchedulePage() {
                                       ? undefined
                                       : { opacity: 0, y: 4 }
                                   }
+                                  transition={{ duration: 0.2 }}
                                 >
-                                  {renderInstanceActions(taskInstance.id, { projectId })}
+                                  {renderInstanceActions(instance.id, { projectId })}
                                   <div className="flex flex-col">
                                     <span className="truncate text-sm font-medium">
-                                      {task.name}
+                                      {project.name}
                                     </span>
                                     <div className="text-xs text-zinc-200/70">
-                                      {Math.round(
-                                        (end.getTime() - start.getTime()) / 60000
-                                      )}
-                                      m
+                                      {detailText}
                                     </div>
                                   </div>
-                                  {task.skill_icon && (
+                                  {project.skill_icon && (
                                     <span
                                       className="ml-2 text-lg leading-none flex-shrink-0"
                                       aria-hidden
                                     >
-                                      {task.skill_icon}
+                                      {project.skill_icon}
                                     </span>
                                   )}
                                   <FlameEmber
-                                    level={(task.energy as FlameLevel) || 'NO'}
+                                    level={
+                                      (instance.energy_resolved?.toUpperCase() as FlameLevel) ||
+                                      'NO'
+                                    }
                                     size="sm"
                                     className="absolute -top-1 -right-1"
                                   />
-                                  <div
-                                    className="absolute left-0 bottom-0 h-[3px] bg-white/30"
-                                    style={{ width: `${progress}%` }}
-                                  />
                                 </motion.div>
-                              )
-                            })}
+                              ) : (
+                                <motion.div
+                                  key="tasks"
+                                  className="relative h-full"
+                                  initial={
+                                    prefersReducedMotion
+                                      ? false
+                                      : { opacity: 0, y: 4 }
+                                  }
+                                  animate={
+                                    prefersReducedMotion
+                                      ? undefined
+                                      : { opacity: 1, y: 0 }
+                                  }
+                                  exit={
+                                    prefersReducedMotion
+                                      ? undefined
+                                      : { opacity: 0, y: 4 }
+                                  }
+                                  transition={{ duration: 0.2 }}
+                                >
+                                  {tasksForProject.map(taskInfo => {
+                                    const {
+                                      instance: taskInstance,
+                                      task,
+                                      start: taskStart,
+                                      end: taskEnd,
+                                    } = taskInfo
+                                    const taskOffsetMinutes =
+                                      (taskStart.getTime() - projectStart.getTime()) / 60000
+                                    const taskDurationMinutes =
+                                      (taskEnd.getTime() - taskStart.getTime()) / 60000
+                                    const rawTop = taskOffsetMinutes * pxPerMin
+                                    const rawHeight = taskDurationMinutes * pxPerMin
+                                    const minHeight = Math.max(8, rawHeight)
+                                    const taskHeight =
+                                      containerHeight > 0
+                                        ? Math.min(minHeight, containerHeight)
+                                        : minHeight
+                                    const maxTop =
+                                      containerHeight > 0
+                                        ? Math.max(0, containerHeight - taskHeight)
+                                        : rawTop
+                                    const taskTop =
+                                      containerHeight > 0
+                                        ? Math.min(Math.max(0, rawTop), maxTop)
+                                        : rawTop
+                                    const progress =
+                                      (task as { progress?: number }).progress ?? 0
+                                    return (
+                                      <motion.div
+                                        key={taskInstance.id}
+                                        aria-label={`Task ${task.name}`}
+                                        className="absolute inset-x-0 flex items-center justify-between rounded-[var(--radius-lg)] bg-stone-700 px-3 py-2 text-white"
+                                        style={{ top: taskTop, height: taskHeight }}
+                                        onClick={event => {
+                                          event.stopPropagation()
+                                          setExpandedProjects(prev => {
+                                            const next = new Set(prev)
+                                            next.delete(projectId)
+                                            return next
+                                          })
+                                        }}
+                                        initial={
+                                          prefersReducedMotion
+                                            ? false
+                                            : { opacity: 0, y: 4 }
+                                        }
+                                        animate={
+                                          prefersReducedMotion
+                                            ? undefined
+                                            : { opacity: 1, y: 0 }
+                                        }
+                                        exit={
+                                          prefersReducedMotion
+                                            ? undefined
+                                            : { opacity: 0, y: 4 }
+                                        }
+                                      >
+                                        {renderInstanceActions(taskInstance.id, { projectId })}
+                                        <div className="flex flex-col">
+                                          <span className="truncate text-sm font-medium">
+                                            {task.name}
+                                          </span>
+                                          <div className="text-xs text-zinc-200/70">
+                                            {Math.round(
+                                              (taskEnd.getTime() - taskStart.getTime()) / 60000
+                                            )}
+                                            m
+                                          </div>
+                                        </div>
+                                        {task.skill_icon && (
+                                          <span
+                                            className="ml-2 text-lg leading-none flex-shrink-0"
+                                            aria-hidden
+                                          >
+                                            {task.skill_icon}
+                                          </span>
+                                        )}
+                                        <FlameEmber
+                                          level={(task.energy as FlameLevel) || 'NO'}
+                                          size="sm"
+                                          className="absolute -top-1 -right-1"
+                                        />
+                                        <div
+                                          className="absolute left-0 bottom-0 h-[3px] bg-white/30"
+                                          style={{ width: `${progress}%` }}
+                                        />
+                                      </motion.div>
+                                    )
+                                  })}
+                                </motion.div>
+                              )}
+                            </AnimatePresence>
                           </motion.div>
-                        )}
+                        </motion.div>
                       </AnimatePresence>
                     )
-                  })}
+                  }
+                  )}
                   {standaloneTaskInstances.map(({ instance, task, start, end }) => {
                     const startMin = start.getHours() * 60 + start.getMinutes()
                     const top = (startMin - startHour * 60) * pxPerMin


### PR DESCRIPTION
## Summary
- wrap each scheduled project card in a shared motion container so it animates between collapsed and expanded states
- render task cards within the expanded view using relative offsets to create the transforming gray task stack
- allow tapping anywhere on the project block to toggle expansion while preventing task clicks from bubbling

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68cf2246dae4832c9f9b7986dee34d27