### PR TITLE
Add frosted tone styling for dashboard sections

### DIFF
--- a/src/app/(app)/dashboard/DashboardClient.tsx
+++ b/src/app/(app)/dashboard/DashboardClient.tsx
@@ -204,13 +204,18 @@ export default function DashboardClient() {
     <main className="pb-20">
       <LevelBanner level={80} current={3200} total={4000} />
 
-      <MonumentContainer />
+      <MonumentContainer tone="frosted" />
 
-      <Section title={<Link href="/skills">Skills</Link>} className="mt-1 px-4">
+      <Section
+        tone="frosted"
+        title={<Link href="/skills">Skills</Link>}
+        className="mt-1 px-4"
+      >
         <SkillsCarousel />
       </Section>
 
       <Section
+        tone="frosted"
         title={<Link href="/goals">Current Goals</Link>}
         className="safe-bottom mt-2 px-4"
       >

--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -5,16 +5,23 @@ import MonumentGridWithSharedTransition, {
   type Monument as MonumentCard,
 } from "@/components/MonumentGridWithSharedTransition";
 import { MonumentsList } from "@/components/monuments/MonumentsList";
+import { Section } from "@/components/ui/Section";
 
-export function MonumentContainer() {
+interface MonumentContainerProps {
+  tone?: "plain" | "frosted";
+}
+
+export function MonumentContainer({ tone = "plain" }: MonumentContainerProps) {
   return (
-    <section className="section mt-2">
-      <div className="mb-3">
-        <Link href="/monuments" className="h-label block">
+    <Section
+      tone={tone}
+      title={
+        <Link href="/monuments" className="block">
           Monuments
         </Link>
-      </div>
-
+      }
+      className="mt-2"
+    >
       <MonumentsList limit={8} createHref="/monuments/new">
         {(monuments) => (
           <div className="px-4">
@@ -29,7 +36,7 @@ export function MonumentContainer() {
           </div>
         )}
       </MonumentsList>
-    </section>
+    </Section>
   );
 }
 

--- a/src/components/ui/Section.tsx
+++ b/src/components/ui/Section.tsx
@@ -1,8 +1,33 @@
 import React from "react";
 
-export function Section({title,children,className=""}:{title?:React.ReactNode;children?:React.ReactNode;className?:string;}){
-  return (<section className={`section ${className}`}>
-    {title ? <div className="h-label mb-3">{title}</div> : null}
-    {children}
-  </section>);
+import { cn } from "@/lib/utils";
+
+type SectionTone = "plain" | "frosted";
+
+interface SectionProps {
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+  tone?: SectionTone;
+}
+
+export function Section({
+  title,
+  children,
+  className,
+  tone = "plain",
+}: SectionProps) {
+  return (
+    <section
+      className={cn(
+        "section",
+        tone === "frosted" &&
+          "frosted-surface border border-white/10 bg-white/5 backdrop-blur",
+        className,
+      )}
+    >
+      {title ? <div className="h-label mb-3">{title}</div> : null}
+      {children}
+    </section>
+  );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,6 +44,9 @@ html,body{
   overflow-x:hidden;
 }
 .section{ padding:20px 16px 8px; }
+.frosted-surface{
+  background-image:radial-gradient(120% 120% at 50% 0%, rgba(255,255,255,0.18) 0%, rgba(255,255,255,0.05) 100%);
+}
 .h-label{ letter-spacing:.12em; text-transform:uppercase; font-weight:700; color:var(--muted); font-size:12px; }
 .card{ background:linear-gradient(180deg,var(--surface),var(--surface-2));
        border-radius:var(--radius);


### PR DESCRIPTION
## Summary
- add a `tone` prop to the shared `Section` component with optional frosted styling
- update the dashboard sections and monument container to opt into the frosted tone
- introduce a reusable frosted-surface gradient utility in the global styles

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf9403c298832c99028e932d4ae140