### PR TITLE
feat: add brand category palette and swatches

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 import { motion, Reorder } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import clsx from "clsx";
 import { updateCatColor, updateCatOrder } from "@/lib/data/cats";
+import { BRAND_CAT_COLORS } from "./brandColors";
 import DraggableSkill from "./DraggableSkill";
 import type { Category, Skill } from "./useSkillsData";
 
@@ -32,17 +34,19 @@ export default function CategoryCard({
   active,
   onSkillDrag,
 }: Props) {
-  const [color, setColor] = useState(category.color_hex || "#000000");
+  const defaultColor = category.color_hex || BRAND_CAT_COLORS[0];
+  const [color, setColor] = useState(defaultColor);
   const [menuOpen, setMenuOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [orderOpen, setOrderOpen] = useState(false);
   const [orderValue, setOrderValue] = useState<number>(category.order ?? 0);
   const [localSkills, setLocalSkills] = useState(() => [...skills]);
+  const [customColorOpen, setCustomColorOpen] = useState(false);
   const dragging = useRef(false);
   const router = useRouter();
 
   useEffect(() => {
-    setColor(category.color_hex || "#000000");
+    setColor(category.color_hex || BRAND_CAT_COLORS[0]);
   }, [category.color_hex]);
   useEffect(() => {
     setOrderValue(category.order ?? 0);
@@ -50,6 +54,13 @@ export default function CategoryCard({
   useEffect(() => {
     setLocalSkills([...skills]);
   }, [skills]);
+  useEffect(() => {
+    if (!menuOpen) {
+      setPickerOpen(false);
+      setOrderOpen(false);
+      setCustomColorOpen(false);
+    }
+  }, [menuOpen]);
 
   const bg = color;
   const on = getOnColor(bg);
@@ -116,41 +127,110 @@ export default function CategoryCard({
             {skills.length}
           </span>
           {menuOpen && (
-            <div className="absolute left-0 top-full mt-1 z-10 rounded-md bg-white/90 p-2 text-sm text-black shadow">
+            <div className="absolute left-0 top-full mt-1 z-10 w-56 rounded-xl border border-white/10 bg-[#10131c]/95 p-3 text-sm text-white shadow-lg backdrop-blur">
               {pickerOpen ? (
-                <input
-                  type="color"
-                  value={color}
-                  onChange={(e) => handleColorChange(e.target.value)}
-                  className="h-24 w-24 p-0 border-0 bg-transparent"
-                />
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center justify-between text-xs text-white/50">
+                    <span>Choose a color</span>
+                    <button
+                      type="button"
+                      className="rounded px-1 py-0.5 text-[11px] font-medium text-white/60 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                      onClick={() => {
+                        setPickerOpen(false);
+                        setCustomColorOpen(false);
+                      }}
+                    >
+                      Back
+                    </button>
+                  </div>
+                  <div className="grid grid-cols-4 gap-2">
+                    {BRAND_CAT_COLORS.map((swatch) => {
+                      const isActive = swatch.toLowerCase() === color.toLowerCase();
+                      return (
+                        <button
+                          key={swatch}
+                          type="button"
+                          onClick={() => handleColorChange(swatch)}
+                          style={{ backgroundColor: swatch }}
+                          className={clsx(
+                            "h-8 w-8 rounded-md border border-white/15 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80",
+                            isActive ? "ring-2 ring-offset-1 ring-white/90 ring-offset-[#10131c]" : ""
+                          )}
+                          aria-label={`Use ${swatch} color`}
+                          aria-pressed={isActive}
+                        />
+                      );
+                    })}
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setCustomColorOpen((o) => !o)}
+                      className="flex items-center justify-between rounded-md bg-white/5 px-2 py-1 text-left text-xs font-medium text-white/75 transition hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                    >
+                      <span>Custom color</span>
+                      <span className="text-[10px] uppercase tracking-wide">
+                        {customColorOpen ? "Hide" : "Show"}
+                      </span>
+                    </button>
+                    {customColorOpen && (
+                      <input
+                        type="color"
+                        value={color}
+                        onChange={(e) => handleColorChange(e.target.value)}
+                        className="h-10 w-full cursor-pointer rounded-md border border-white/10 bg-[#05070b] p-1"
+                      />
+                    )}
+                  </div>
+                </div>
               ) : orderOpen ? (
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-2 text-xs">
+                  <div className="flex items-center justify-between text-white/50">
+                    <span>Sort order</span>
+                    <button
+                      type="button"
+                      className="rounded px-1 py-0.5 text-[11px] font-medium text-white/60 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                      onClick={() => setOrderOpen(false)}
+                    >
+                      Back
+                    </button>
+                  </div>
                   <input
                     type="number"
                     value={orderValue}
                     onChange={(e) => setOrderValue(parseInt(e.target.value, 10))}
-                    className="w-20 p-1 border border-black/20 rounded"
+                    className="w-full rounded-md border border-white/15 bg-[#05070b] px-2 py-1 text-sm text-white focus:outline-none focus:ring-2 focus:ring-white/60"
                   />
-                  <button className="underline" onClick={handleOrderSave}>
+                  <button
+                    className="self-start rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                    onClick={handleOrderSave}
+                  >
                     Save order
                   </button>
                 </div>
               ) : (
-                <>
+                <div className="flex flex-col gap-2 text-xs">
                   <button
-                    className="underline block text-left"
-                    onClick={() => setPickerOpen(true)}
+                    className="block rounded-md px-2 py-1 text-left font-medium text-white/80 transition hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                    onClick={() => {
+                      setPickerOpen(true);
+                      setOrderOpen(false);
+                      setCustomColorOpen(false);
+                    }}
                   >
                     Change cat color
                   </button>
                   <button
-                    className="underline block text-left mt-1"
-                    onClick={() => setOrderOpen(true)}
+                    className="block rounded-md px-2 py-1 text-left font-medium text-white/80 transition hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+                    onClick={() => {
+                      setOrderOpen(true);
+                      setPickerOpen(false);
+                      setCustomColorOpen(false);
+                    }}
                   >
                     Change order
                   </button>
-                </>
+                </div>
               )}
             </div>
           )}

--- a/src/app/(app)/dashboard/_skills/brandColors.ts
+++ b/src/app/(app)/dashboard/_skills/brandColors.ts
@@ -1,0 +1,16 @@
+export const BRAND_CAT_COLORS = [
+  "#6366F1",
+  "#2563EB",
+  "#0EA5E9",
+  "#14B8A6",
+  "#22C55E",
+  "#84CC16",
+  "#FACC15",
+  "#F97316",
+  "#EF4444",
+  "#F43F5E",
+  "#EC4899",
+  "#A855F7",
+] as const;
+
+export type BrandCatColor = (typeof BRAND_CAT_COLORS)[number];

--- a/src/app/(app)/dashboard/_skills/useSkillsData.ts
+++ b/src/app/(app)/dashboard/_skills/useSkillsData.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
+import { BRAND_CAT_COLORS } from "./brandColors";
 
 export interface Category {
   id: string;
@@ -37,12 +38,17 @@ export async function fetchCategories(userId: string): Promise<Category[]> {
       .order("sort_order", { ascending: true, nullsFirst: false })
       .order("name", { ascending: true });
     if (fallback.error) return [];
-    return (fallback.data ?? []).map((c) => ({ id: c.id, name: c.name, order: c.sort_order }));
+    return (fallback.data ?? []).map((c) => ({
+      id: c.id,
+      name: c.name,
+      color_hex: BRAND_CAT_COLORS[0],
+      order: c.sort_order,
+    }));
   }
   return (data ?? []).map((c) => ({
     id: c.id,
     name: c.name,
-    color_hex: c.color_hex || "#000000",
+    color_hex: c.color_hex || BRAND_CAT_COLORS[0],
     order: c.sort_order,
   }));
 }
@@ -131,7 +137,9 @@ export function useSkillsData() {
           setCategories(cats);
         } else if (Object.keys(grouped).length > 0) {
           // derive a single fallback category so skills still render
-          setCategories([{ id: "uncategorized", name: "Skills" }]);
+          setCategories([
+            { id: "uncategorized", name: "Skills", color_hex: BRAND_CAT_COLORS[0] },
+          ]);
         } else {
           setCategories([]);
         }

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabase-server";
+import { BRAND_CAT_COLORS } from "@/app/(app)/dashboard/_skills/brandColors";
 import type {
   UserStats,
   MonumentCounts,
@@ -65,7 +66,7 @@ export async function GET() {
     return {
       ...skill,
       cat_name: category?.name || "Uncategorized",
-      cat_color_hex: category?.color_hex || "#000000",
+      cat_color_hex: category?.color_hex || BRAND_CAT_COLORS[0],
     };
   });
 
@@ -123,7 +124,9 @@ export async function GET() {
           cat_name: catName,
           user_id: skill.user_id,
           skill_count: 0,
-          color_hex: catId ? skill.cat_color_hex || "#000000" : "#000000",
+          color_hex: catId
+            ? skill.cat_color_hex || BRAND_CAT_COLORS[0]
+            : BRAND_CAT_COLORS[0],
           skills: [],
         };
       }
@@ -163,7 +166,8 @@ export async function GET() {
     if (catSkills) {
       return {
         ...catSkills,
-        color_hex: cat.color_hex || catSkills.color_hex || "#000000",
+        color_hex:
+          cat.color_hex || catSkills.color_hex || BRAND_CAT_COLORS[0],
         order: cat.sort_order ?? null,
       }; // Return CAT with its skills
     } else {
@@ -173,7 +177,7 @@ export async function GET() {
         cat_name: cat.name,
         user_id: cat.user_id,
         skill_count: 0,
-        color_hex: cat.color_hex || "#000000",
+        color_hex: cat.color_hex || BRAND_CAT_COLORS[0],
         order: cat.sort_order ?? null,
         skills: [],
       };
@@ -185,7 +189,7 @@ export async function GET() {
   if (uncategorizedCat) {
     catsOut.push({
       ...uncategorizedCat,
-      color_hex: uncategorizedCat.color_hex || "#000000",
+      color_hex: uncategorizedCat.color_hex || BRAND_CAT_COLORS[0],
       order: null,
     });
   }

--- a/src/lib/data/cats.ts
+++ b/src/lib/data/cats.ts
@@ -1,4 +1,5 @@
 import { getSupabaseBrowser } from "../../../lib/supabase";
+import { BRAND_CAT_COLORS } from "@/app/(app)/dashboard/_skills/brandColors";
 import type { CatRow } from "../types/cat";
 
 export async function getCatsForUser(userId: string) {
@@ -15,7 +16,7 @@ export async function getCatsForUser(userId: string) {
   if (error) throw error;
   return (data ?? []).map((c) => ({
     ...c,
-    color_hex: c.color_hex || "#000000",
+    color_hex: c.color_hex || BRAND_CAT_COLORS[0],
   })) as CatRow[];
 }
 

--- a/src/lib/scheduler/timezone.ts
+++ b/src/lib/scheduler/timezone.ts
@@ -43,9 +43,9 @@ function getDateTimeParts(date: Date, timeZone: string): DateParts {
     else if (part.type === 'minute') result.minute = value
     else if (part.type === 'second') result.second = value
   }
-  let year = result.year ?? date.getUTCFullYear()
-  let month = result.month ?? date.getUTCMonth() + 1
-  let day = result.day ?? date.getUTCDate()
+  const year = result.year ?? date.getUTCFullYear()
+  const month = result.month ?? date.getUTCMonth() + 1
+  const day = result.day ?? date.getUTCDate()
   let hour = result.hour ?? date.getUTCHours()
   const minute = result.minute ?? date.getUTCMinutes()
   const second = result.second ?? date.getUTCSeconds()


### PR DESCRIPTION
## Summary
- add a shared BRAND_CAT_COLORS palette for skill categories and reuse it in the dashboard carousel
- refresh the category menu with accessible preset swatches and a gated custom color picker, updating fallbacks to the shared default
- align server responses with the new default color and fix a lint warning in the timezone helper

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68cf9c8caa74832c8399bf193ae80f03