### PR TITLE
Enhance dashboard skill carousel presentation

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -1,23 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { motion, Reorder } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import { motion, Reorder, useReducedMotion } from "framer-motion";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { updateCatColor, updateCatOrder } from "@/lib/data/cats";
 import DraggableSkill from "./DraggableSkill";
 import type { Category, Skill } from "./useSkillsData";
-
-function getOnColor(hex: string) {
-  if (!hex) return "#fff";
-  const c = hex.replace("#", "");
-  const r = parseInt(c.substring(0, 2), 16);
-  const g = parseInt(c.substring(2, 4), 16);
-  const b = parseInt(c.substring(4, 6), 16);
-  // luminance
-  const l = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return l > 0.6 ? "#000" : "#fff";
-}
+import { FALLBACK_ACCENT, getReadableColor, rgba, tintColor } from "./carouselUtils";
 
 interface Props {
   category: Category;
@@ -32,7 +22,7 @@ export default function CategoryCard({
   active,
   onSkillDrag,
 }: Props) {
-  const [color, setColor] = useState(category.color_hex || "#000000");
+  const [color, setColor] = useState(category.color_hex || FALLBACK_ACCENT);
   const [menuOpen, setMenuOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [orderOpen, setOrderOpen] = useState(false);
@@ -40,9 +30,10 @@ export default function CategoryCard({
   const [localSkills, setLocalSkills] = useState(() => [...skills]);
   const dragging = useRef(false);
   const router = useRouter();
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
-    setColor(category.color_hex || "#000000");
+    setColor(category.color_hex || FALLBACK_ACCENT);
   }, [category.color_hex]);
   useEffect(() => {
     setOrderValue(category.order ?? 0);
@@ -51,10 +42,25 @@ export default function CategoryCard({
     setLocalSkills([...skills]);
   }, [skills]);
 
-  const bg = color;
-  const on = getOnColor(bg);
-  const track = on === "#fff" ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)";
-  const fill = on === "#fff" ? "rgba(255,255,255,0.7)" : "rgba(0,0,0,0.7)";
+  const accent = color || FALLBACK_ACCENT;
+  const on = useMemo(() => getReadableColor(accent), [accent]);
+  const palette = useMemo(
+    () => ({
+      surface: tintColor(accent, active ? 0.92 : 0.85, active ? 0.22 : 0.16),
+      glow: rgba(accent, active ? 0.45 : 0.26),
+      halo: tintColor(accent, 0.96, active ? 0.45 : 0.32),
+      border: rgba(accent, active ? 0.45 : 0.28),
+      chip: tintColor(accent, 0.78, 0.22),
+      track: rgba(accent, 0.22),
+      fill: tintColor(accent, 0.35, 0.9),
+      shadow: rgba(accent, active ? 0.42 : 0.24),
+      highlight: tintColor(accent, 0.62, 0.5),
+    }),
+    [accent, active]
+  );
+  const sweepTransition = active
+    ? { duration: 6, repeat: Infinity as const, repeatType: "loop" as const, ease: "easeInOut" }
+    : { duration: 0.5, ease: "easeOut" };
 
   const handleColorChange = async (newColor: string) => {
     setColor(newColor);
@@ -81,76 +87,132 @@ export default function CategoryCard({
   };
 
   return (
-    <motion.div
+    <motion.article
       layout
-      className="h-full rounded-3xl border border-black/10 p-3 sm:p-4 flex flex-col shadow-md"
-      style={{ backgroundColor: bg, color: on }}
+      className="group/card relative h-full overflow-hidden rounded-[32px] border"
+      style={{
+        color: on,
+        borderColor: palette.border,
+        background: `linear-gradient(140deg, ${palette.surface}, rgba(12, 10, 32, ${active ? 0.32 : 0.22}))`,
+        transformStyle: "preserve-3d",
+        transformOrigin: "center",
+      }}
       animate={{
-        scale: active ? 1.02 : 1,
+        scale: active ? 1.04 : 0.97,
+        opacity: active ? 1 : 0.78,
+        y: active ? 0 : 12,
+        rotateX: active ? 0 : 3,
         boxShadow: active
-          ? "0 12px 24px rgba(0,0,0,0.25)"
-          : "0 4px 12px rgba(0,0,0,0.15)",
+          ? `0 48px 120px -60px ${palette.shadow}`
+          : "0 24px 80px -60px rgba(15,23,42,0.55)",
       }}
       transition={{ type: "spring", stiffness: 260, damping: 30 }}
     >
       <motion.div
-        key={category.id}
-        initial={{ opacity: 0, y: 4 }}
-        animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0, y: -4 }}
-        transition={{ duration: 0.16 }}
-        className="flex-1 flex flex-col overflow-hidden"
-      >
-        <header className="flex items-center justify-between mb-2 relative">
-          <button
-            className="font-semibold"
-            style={{ color: on }}
-            onClick={() => setMenuOpen((o) => !o)}
-          >
-            {category.name}
-          </button>
+        aria-hidden
+        className="pointer-events-none absolute -inset-12 opacity-80 blur-3xl"
+        animate={{
+          opacity: active ? 0.88 : 0.45,
+          scale: active ? 1.08 : 0.94,
+        }}
+        transition={{ duration: 0.8, ease: "easeOut" }}
+        style={{ background: `radial-gradient(circle at 20% 20%, ${palette.glow}, transparent 65%)` }}
+      />
+      <motion.div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        animate={{ opacity: active ? 0.6 : 0.35 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+        style={{ background: `linear-gradient(160deg, ${palette.halo} 0%, transparent 60%)` }}
+      />
+      {!prefersReducedMotion && (
+        <motion.div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-[-20%] left-[-45%] z-10 w-[135%] rotate-[18deg] blur-3xl"
+          style={{ background: `linear-gradient(90deg, transparent, ${palette.highlight}, transparent)` }}
+          animate={
+            active
+              ? { opacity: 0.7, x: ["-35%", "118%"] }
+              : { opacity: 0, x: "-45%" }
+          }
+          transition={sweepTransition}
+        />
+      )}
+      <div className="relative z-20 flex h-full flex-col px-5 py-6 sm:px-7 sm:py-8">
+        <header className="relative mb-4 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <button
+              className="text-left text-lg font-semibold tracking-tight transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+              style={{ color: on }}
+              onClick={() => setMenuOpen((o) => !o)}
+            >
+              <span
+                className="block leading-snug"
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                {category.name}
+              </span>
+            </button>
+          </div>
           <span
-            className="text-xs rounded-xl px-2 py-0.5"
-            style={{ backgroundColor: track, color: on }}
+            className="inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.28em]"
+            style={{
+              background: palette.chip,
+              color: on,
+              borderColor: rgba(accent, 0.35),
+              boxShadow: `0 18px 42px -28px ${palette.shadow}`,
+            }}
           >
             {skills.length}
+            <span className="hidden sm:inline">skills</span>
           </span>
           {menuOpen && (
-            <div className="absolute left-0 top-full mt-1 z-10 rounded-md bg-white/90 p-2 text-sm text-black shadow">
+            <div className="absolute left-0 top-full z-40 mt-2 min-w-[11rem] rounded-2xl border border-white/10 bg-black/70 p-3 text-sm text-white shadow-xl backdrop-blur-xl">
               {pickerOpen ? (
                 <input
                   type="color"
                   value={color}
                   onChange={(e) => handleColorChange(e.target.value)}
-                  className="h-24 w-24 p-0 border-0 bg-transparent"
+                  className="h-24 w-full cursor-pointer rounded-xl border border-white/20 bg-white/5 p-1"
                 />
               ) : orderOpen ? (
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-3">
                   <input
                     type="number"
                     value={orderValue}
-                    onChange={(e) => setOrderValue(parseInt(e.target.value, 10))}
-                    className="w-20 p-1 border border-black/20 rounded"
+                    onChange={(e) => {
+                      const next = Number.parseInt(e.target.value, 10);
+                      setOrderValue(Number.isNaN(next) ? 0 : next);
+                    }}
+                    className="w-full rounded-lg border border-white/20 bg-white/5 px-2 py-1 text-base text-white"
                   />
-                  <button className="underline" onClick={handleOrderSave}>
+                  <button
+                    className="rounded-lg border border-white/20 px-3 py-1 font-medium tracking-wide text-white transition hover:bg-white/10"
+                    onClick={handleOrderSave}
+                  >
                     Save order
                   </button>
                 </div>
               ) : (
-                <>
+                <div className="flex flex-col gap-2">
                   <button
-                    className="underline block text-left"
+                    className="rounded-lg px-3 py-2 text-left font-medium transition hover:bg-white/10"
                     onClick={() => setPickerOpen(true)}
                   >
-                    Change cat color
+                    Change color palette
                   </button>
                   <button
-                    className="underline block text-left mt-1"
+                    className="rounded-lg px-3 py-2 text-left font-medium transition hover:bg-white/10"
                     onClick={() => setOrderOpen(true)}
                   >
-                    Change order
+                    Reorder category
                   </button>
-                </>
+                </div>
               )}
             </div>
           )}
@@ -160,14 +222,14 @@ export default function CategoryCard({
           values={localSkills}
           onReorder={setLocalSkills}
           as="div"
-          className="flex-1 overflow-y-auto overscroll-contain flex flex-col gap-2 pt-3 pb-4"
+          className="flex-1 space-y-2 overflow-y-auto overscroll-contain pr-1 sm:pr-2"
         >
           {localSkills.length === 0 ? (
-            <div className="text-sm" style={{ color: on }}>
+            <div className="rounded-2xl border border-white/20 bg-white/5 p-4 text-sm text-white/80">
               No skills yet
               <div className="mt-2">
-                <Link href="/skills" className="underline">
-                  Add Skill
+                <Link href="/skills" className="font-medium underline">
+                  Add your first skill
                 </Link>
               </div>
             </div>
@@ -178,15 +240,15 @@ export default function CategoryCard({
                 skill={s}
                 dragging={dragging}
                 onColor={on}
-                trackColor={track}
-                fillColor={fill}
+                trackColor={palette.track}
+                fillColor={palette.fill}
                 onDragStateChange={onSkillDrag}
               />
             ))
           )}
         </Reorder.Group>
-      </motion.div>
-    </motion.div>
+      </div>
+    </motion.article>
   );
 }
 

--- a/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import {
+  type FocusEvent,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { motion, useReducedMotion } from "framer-motion";
 import CategoryCard from "./CategoryCard";
 import useSkillsData from "./useSkillsData";
-import { deriveInitialIndex } from "./carouselUtils";
+import { deriveInitialIndex, FALLBACK_ACCENT, getReadableColor, rgba, tintColor } from "./carouselUtils";
 
 export default function SkillsCarousel() {
   const { categories, skillsByCategory, isLoading } = useSkillsData();
@@ -14,6 +23,8 @@ export default function SkillsCarousel() {
   const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [activeIndex, setActiveIndex] = useState(0);
   const [skillDragging, setSkillDragging] = useState(false);
+  const [isInteracting, setIsInteracting] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     if (categories.length === 0) return;
@@ -21,17 +32,29 @@ export default function SkillsCarousel() {
     const idx = deriveInitialIndex(categories, initialId);
     setActiveIndex(idx);
     const el = cardRefs.current[idx];
-    el?.scrollIntoView({ behavior: "instant", inline: "center" });
-  }, [categories, search]);
+    el?.scrollIntoView({
+      behavior: prefersReducedMotion ? "auto" : "instant",
+      inline: "center",
+    });
+  }, [categories, search, prefersReducedMotion]);
 
-  const changeIndex = (idx: number) => {
-    if (idx < 0 || idx >= categories.length) return;
-    cardRefs.current[idx]?.scrollIntoView({ behavior: "smooth", inline: "center", block: "nearest" });
-    setActiveIndex(idx);
-    const params = new URLSearchParams(search);
-    params.set("cat", categories[idx].id);
-    router.replace(`?${params.toString()}`, { scroll: false });
-  };
+  const changeIndex = useCallback(
+    (idx: number, options?: { fromAutoplay?: boolean }) => {
+      if (idx < 0 || idx >= categories.length) return;
+      cardRefs.current[idx]?.scrollIntoView({
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+        inline: "center",
+        block: "nearest",
+      });
+      setActiveIndex(idx);
+      if (!options?.fromAutoplay) {
+        const params = new URLSearchParams(search);
+        params.set("cat", categories[idx].id);
+        router.replace(`?${params.toString()}`, { scroll: false });
+      }
+    },
+    [categories, prefersReducedMotion, router, search]
+  );
 
   useEffect(() => {
     const el = trackRef.current;
@@ -57,6 +80,51 @@ export default function SkillsCarousel() {
     return () => el.removeEventListener("scroll", onScroll);
   }, [categories]);
 
+  const activeCategory = categories[activeIndex];
+  const accentColor = activeCategory?.color_hex || FALLBACK_ACCENT;
+  const stagePalette = useMemo(
+    () => ({
+      glow: rgba(accentColor, 0.34),
+      halo: tintColor(accentColor, 0.9, 0.18),
+      frame: rgba(accentColor, 0.28),
+      surface: tintColor(accentColor, 0.86, 0.14),
+      sheen: tintColor(accentColor, 0.7, 0.38),
+      shadow: rgba(accentColor, 0.22),
+    }),
+    [accentColor]
+  );
+
+  const autoplayEnabled = !prefersReducedMotion && categories.length > 1;
+
+  useEffect(() => {
+    if (!autoplayEnabled || skillDragging || isInteracting) return;
+    const id = window.setInterval(() => {
+      const nextIndex = (activeIndex + 1) % categories.length;
+      changeIndex(nextIndex, { fromAutoplay: true });
+    }, 6500);
+    return () => window.clearInterval(id);
+  }, [
+    autoplayEnabled,
+    skillDragging,
+    isInteracting,
+    activeIndex,
+    categories.length,
+    changeIndex,
+  ]);
+
+  const handleBlurCapture = (event: FocusEvent<HTMLDivElement>) => {
+    const nextTarget = event.relatedTarget as Node | null;
+    if (!event.currentTarget.contains(nextTarget)) {
+      setIsInteracting(false);
+    }
+  };
+
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "touch") {
+      setIsInteracting(false);
+    }
+  };
+
   if (isLoading) {
     return <div className="py-8 text-center text-zinc-400">Loading...</div>;
   }
@@ -64,6 +132,9 @@ export default function SkillsCarousel() {
   if (categories.length === 0) {
     return <div className="text-center py-8 text-zinc-400">No skills yet</div>;
   }
+
+  const maskGradient =
+    "linear-gradient(to right, transparent, black 48px, black calc(100% - 48px), transparent)";
 
   return (
     <div
@@ -79,55 +150,142 @@ export default function SkillsCarousel() {
           cardRefs.current[activeIndex]?.querySelector("button")?.click();
         }
       }}
+      onMouseEnter={() => setIsInteracting(true)}
+      onMouseLeave={() => setIsInteracting(false)}
+      onPointerEnter={() => setIsInteracting(true)}
+      onPointerLeave={() => setIsInteracting(false)}
+      onPointerDown={() => setIsInteracting(true)}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={() => setIsInteracting(false)}
+      onFocusCapture={() => setIsInteracting(true)}
+      onBlurCapture={handleBlurCapture}
     >
-      <div
-        ref={trackRef}
-        className={`flex gap-4 overflow-x-auto overflow-y-hidden scroll-smooth snap-x px-4 ${
-          skillDragging ? "snap-none touch-none" : "snap-mandatory touch-pan-x"
-        }`}
-        style={{
-          maskImage:
-            "linear-gradient(to right, transparent, black 16px, black calc(100% - 16px), transparent)",
-        }}
-      >
-        {categories.map((cat, idx) => {
-          if (categories.length > 20 && Math.abs(idx - activeIndex) > 5) {
-            return <div key={cat.id} className="snap-center shrink-0 w-[86vw] sm:w-[74vw] lg:w-[56vw]" />;
-          }
-          const isActive = idx === activeIndex;
-          return (
-            <div
-              key={cat.id}
-              ref={(el) => {
-                cardRefs.current[idx] = el;
-              }}
-              role="group"
-              aria-label={`Category ${idx + 1} of ${categories.length}`}
-              className="snap-center shrink-0 w-[86vw] sm:w-[74vw] lg:w-[56vw]"
-            >
-              <CategoryCard
-                category={cat}
-                skills={skillsByCategory[cat.id] || []}
-                active={isActive}
-                onSkillDrag={setSkillDragging}
-              />
-            </div>
-          );
-        })}
-      </div>
-      <div className="flex justify-center gap-2 mt-4" role="tablist">
-        {categories.map((cat, idx) => (
-          <button
-            key={cat.id}
-            role="tab"
-            aria-selected={idx === activeIndex}
-            aria-label={`Go to ${cat.name}`}
-            className={`h-2 w-2 rounded-full ${
-              idx === activeIndex ? "scale-110 bg-white" : "bg-white/40"
-            }`}
-            onClick={() => changeIndex(idx)}
+      <motion.div className="relative mx-auto w-full px-2 sm:px-4 lg:px-6">
+        <motion.div
+          className="relative overflow-hidden rounded-[40px] border backdrop-blur-2xl"
+          style={{
+            borderColor: stagePalette.frame,
+            background: `linear-gradient(140deg, ${stagePalette.surface}, rgba(10, 12, 28, 0.35))`,
+          }}
+          animate={{ boxShadow: `0 42px 120px -60px ${stagePalette.shadow}` }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+        >
+          <motion.div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            animate={{ opacity: skillDragging ? 0.5 : 0.85 }}
+            transition={{ duration: 0.5, ease: "easeOut" }}
+            style={{ background: `radial-gradient(circle at 18% 18%, ${stagePalette.glow}, transparent 65%)` }}
           />
-        ))}
+          <motion.div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            animate={{ opacity: isInteracting ? 0.4 : 0.6 }}
+            transition={{ duration: 0.4, ease: "easeOut" }}
+            style={{ background: `radial-gradient(90% 140% at 82% 0%, ${stagePalette.halo}, transparent 70%)` }}
+          />
+          <motion.div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-10 top-0 h-px"
+            animate={{ opacity: isInteracting ? 0.25 : 0.45 }}
+            transition={{ duration: 0.3, ease: "easeOut" }}
+            style={{ background: `linear-gradient(90deg, transparent, ${stagePalette.sheen}, transparent)` }}
+          />
+          <div className="relative">
+            <div
+              ref={trackRef}
+              className={`relative flex gap-6 overflow-x-auto overflow-y-hidden overscroll-x-contain scroll-smooth px-6 py-10 sm:px-10 ${
+                skillDragging ? "snap-none touch-none" : "snap-mandatory touch-pan-x"
+              } snap-x`}
+              style={{ maskImage: maskGradient, WebkitMaskImage: maskGradient }}
+            >
+              {categories.map((cat, idx) => {
+                if (categories.length > 20 && Math.abs(idx - activeIndex) > 5) {
+                  return (
+                    <div
+                      key={cat.id}
+                      className="snap-center shrink-0 w-[86vw] sm:w-[70vw] lg:w-[54vw] xl:w-[46vw]"
+                    />
+                  );
+                }
+                const isActive = idx === activeIndex;
+                return (
+                  <div
+                    key={cat.id}
+                    ref={(el) => {
+                      cardRefs.current[idx] = el;
+                    }}
+                    role="group"
+                    aria-label={`Category ${idx + 1} of ${categories.length}`}
+                    className={`snap-center shrink-0 transition-all duration-500 ease-out w-[86vw] sm:w-[70vw] lg:w-[54vw] xl:w-[46vw] 2xl:w-[42vw] ${
+                      isActive ? "opacity-100" : "opacity-80"
+                    }`}
+                  >
+                    <CategoryCard
+                      category={cat}
+                      skills={skillsByCategory[cat.id] || []}
+                      active={isActive}
+                      onSkillDrag={setSkillDragging}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </motion.div>
+      </motion.div>
+      <div className="mt-8 px-2 sm:px-4 lg:px-6">
+        <div
+          className="mx-auto flex max-w-3xl items-center gap-2 overflow-x-auto rounded-full border border-white/10 bg-white/5 px-2 py-2 backdrop-blur-xl"
+          role="tablist"
+        >
+          {categories.map((cat, idx) => {
+            const isActive = idx === activeIndex;
+            const accent = cat.color_hex || FALLBACK_ACCENT;
+            const previewSkill = (skillsByCategory[cat.id] || [])[0];
+            const preview =
+              previewSkill?.emoji || (cat.name?.charAt(0) || "?").toUpperCase();
+            const textColor = isActive
+              ? getReadableColor(accent)
+              : tintColor(accent, 0.8, 0.9);
+            return (
+              <motion.button
+                key={cat.id}
+                role="tab"
+                tabIndex={isActive ? 0 : -1}
+                aria-selected={isActive}
+                aria-label={`Go to ${cat.name}`}
+                onClick={() => changeIndex(idx)}
+                className="relative inline-flex min-w-[3.25rem] items-center gap-2 overflow-hidden rounded-full px-3 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.28em] text-white/70 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+                style={{ color: textColor }}
+              >
+                {isActive && (
+                  <motion.span
+                    layoutId="carousel-nav-pill"
+                    className="absolute inset-0 rounded-full"
+                    style={{
+                      background: `linear-gradient(135deg, ${rgba(accent, 0.7)}, ${tintColor(accent, 0.75, 0.6)})`,
+                      boxShadow: `0 18px 42px -26px ${rgba(accent, 0.55)}`,
+                    }}
+                    transition={{ type: "spring", stiffness: 320, damping: 32 }}
+                  />
+                )}
+                <span
+                  className="relative z-10 flex size-6 items-center justify-center rounded-full text-base"
+                  style={{
+                    background: tintColor(accent, 0.85, isActive ? 0.32 : 0.22),
+                    color: getReadableColor(accent),
+                  }}
+                >
+                  {preview}
+                </span>
+                <span className="relative z-10 hidden max-w-[12ch] truncate tracking-[0.22em] sm:inline">
+                  {cat.name}
+                </span>
+              </motion.button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/app/(app)/dashboard/_skills/carouselUtils.ts
+++ b/src/app/(app)/dashboard/_skills/carouselUtils.ts
@@ -2,9 +2,61 @@ export interface SimpleCategory {
   id: string;
 }
 
+export const FALLBACK_ACCENT = "#6366f1";
+
+const FALLBACK_RGB = hexToRgb(FALLBACK_ACCENT) ?? { r: 99, g: 102, b: 241 };
+
 export function deriveInitialIndex(categories: SimpleCategory[], id?: string) {
   const idx = categories.findIndex((c) => c.id === id);
   return idx >= 0 ? idx : 0;
+}
+
+export function hexToRgb(hex?: string | null) {
+  if (!hex) return null;
+  let normalized = hex.trim();
+  if (!normalized) return null;
+  if (!normalized.startsWith("#")) {
+    normalized = `#${normalized}`;
+  }
+  if (normalized.length === 4) {
+    const [, r, g, b] = normalized;
+    normalized = `#${r}${r}${g}${g}${b}${b}`;
+  }
+  if (normalized.length !== 7) return null;
+  const parsed = Number.parseInt(normalized.slice(1), 16);
+  if (Number.isNaN(parsed)) return null;
+  return {
+    r: (parsed >> 16) & 255,
+    g: (parsed >> 8) & 255,
+    b: parsed & 255,
+  };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function rgba(hex?: string | null, alpha = 1) {
+  const rgb = hexToRgb(hex) ?? FALLBACK_RGB;
+  const safeAlpha = clamp(alpha, 0, 1);
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${safeAlpha})`;
+}
+
+export function tintColor(hex?: string | null, amount = 0.5, alpha = 1) {
+  const rgb = hexToRgb(hex) ?? FALLBACK_RGB;
+  const ratio = clamp(amount, 0, 1);
+  const safeAlpha = clamp(alpha, 0, 1);
+  const r = Math.round(rgb.r + (255 - rgb.r) * ratio);
+  const g = Math.round(rgb.g + (255 - rgb.g) * ratio);
+  const b = Math.round(rgb.b + (255 - rgb.b) * ratio);
+  return `rgba(${r}, ${g}, ${b}, ${safeAlpha})`;
+}
+
+export function getReadableColor(hex?: string | null, light = "#ffffff", dark = "#000000") {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return light;
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255;
+  return luminance > 0.6 ? dark : light;
 }
 
 export function computeNextIndex(

--- a/src/lib/scheduler/timezone.ts
+++ b/src/lib/scheduler/timezone.ts
@@ -43,9 +43,9 @@ function getDateTimeParts(date: Date, timeZone: string): DateParts {
     else if (part.type === 'minute') result.minute = value
     else if (part.type === 'second') result.second = value
   }
-  let year = result.year ?? date.getUTCFullYear()
-  let month = result.month ?? date.getUTCMonth() + 1
-  let day = result.day ?? date.getUTCDate()
+  const year = result.year ?? date.getUTCFullYear()
+  const month = result.month ?? date.getUTCMonth() + 1
+  const day = result.day ?? date.getUTCDate()
   let hour = result.hour ?? date.getUTCHours()
   const minute = result.minute ?? date.getUTCMinutes()
   const second = result.second ?? date.getUTCSeconds()


### PR DESCRIPTION
## Summary
- refresh the dashboard skill carousel with an ambient stage, autoplay cadence, and pill navigation that respond to category accents
- restyle category cards with glassy gradients, animated highlights, and richer empty states using shared color utilities
- add reusable color helpers and clean up a scheduler lint warning to keep the build healthy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cf9eee9984832c91166bd9ebac6e47