### PR TITLE
Persist notes to Supabase

### DIFF
--- a/src/components/notes/NotesGrid.tsx
+++ b/src/components/notes/NotesGrid.tsx
@@ -6,7 +6,7 @@ import { Plus } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { NoteCard } from "./NoteCard";
 import type { Note } from "@/lib/types/note";
-import { getNotes, saveNotes } from "@/lib/notesStorage";
+import { fetchSkillNotes } from "@/lib/notesStorage";
 
 interface NotesGridProps {
   skillId: string;
@@ -16,12 +16,20 @@ export function NotesGrid({ skillId }: NotesGridProps) {
   const [notes, setNotes] = useState<Note[]>([]);
 
   useEffect(() => {
-    setNotes(getNotes(skillId));
-  }, [skillId]);
+    let active = true;
 
-  useEffect(() => {
-    saveNotes(skillId, notes);
-  }, [skillId, notes]);
+    const loadNotes = async () => {
+      const data = await fetchSkillNotes(skillId);
+      if (!active) return;
+      setNotes(data);
+    };
+
+    loadNotes();
+
+    return () => {
+      active = false;
+    };
+  }, [skillId]);
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/lib/monumentNotesStorage.ts
+++ b/src/lib/monumentNotesStorage.ts
@@ -1,25 +1,143 @@
+import { getSupabaseBrowser } from "@/lib/supabase";
 import type { MonumentNote } from "@/lib/types/monument-note";
 
-const KEY_PREFIX = "monument-notes-";
+type MonumentNoteRow = {
+  id: string;
+  monument_id: string;
+  title: string | null;
+  content: string | null;
+};
 
-export function getMonumentNotes(monumentId: string): MonumentNote[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const data = window.localStorage.getItem(`${KEY_PREFIX}${monumentId}`);
-    return data ? (JSON.parse(data) as MonumentNote[]) : [];
-  } catch {
-    return [];
-  }
+function mapMonumentNote(row: MonumentNoteRow): MonumentNote {
+  return {
+    id: row.id,
+    monumentId: row.monument_id,
+    title: row.title ?? "",
+    content: row.content ?? "",
+  };
 }
 
-export function saveMonumentNotes(monumentId: string, notes: MonumentNote[]) {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(
-      `${KEY_PREFIX}${monumentId}`,
-      JSON.stringify(notes)
-    );
-  } catch {
-    // ignore
+async function getUserId(
+  supabase: ReturnType<typeof getSupabaseBrowser>
+) {
+  if (!supabase) return null;
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    console.error("Failed to retrieve auth user for monument notes", error);
+    return null;
   }
+
+  return user?.id ?? null;
+}
+
+export async function fetchMonumentNotes(
+  monumentId: string
+): Promise<MonumentNote[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return [];
+
+  const userId = await getUserId(supabase);
+  if (!userId) return [];
+
+  const { data, error } = await supabase
+    .from("monument_notes")
+    .select("id, monument_id, title, content")
+    .eq("monument_id", monumentId)
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Failed to fetch monument notes", error);
+    return [];
+  }
+
+  return (data ?? []).map(mapMonumentNote);
+}
+
+export async function fetchMonumentNote(
+  monumentId: string,
+  noteId: string
+): Promise<MonumentNote | null> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return null;
+
+  const userId = await getUserId(supabase);
+  if (!userId) return null;
+
+  const { data, error } = await supabase
+    .from("monument_notes")
+    .select("id, monument_id, title, content")
+    .eq("id", noteId)
+    .eq("monument_id", monumentId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) {
+    if (error.code !== "PGRST116") {
+      console.error("Failed to fetch monument note", error);
+    }
+    return null;
+  }
+
+  return data ? mapMonumentNote(data) : null;
+}
+
+interface UpsertMonumentNoteInput {
+  id?: string;
+  monumentId: string;
+  title: string;
+  content: string;
+}
+
+export async function upsertMonumentNote(
+  input: UpsertMonumentNoteInput
+): Promise<MonumentNote | null> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return null;
+
+  const userId = await getUserId(supabase);
+  if (!userId) return null;
+
+  const payload = {
+    title: input.title,
+    content: input.content,
+    monument_id: input.monumentId,
+    user_id: userId,
+  };
+
+  if (input.id) {
+    const { data, error } = await supabase
+      .from("monument_notes")
+      .update({ title: input.title, content: input.content })
+      .eq("id", input.id)
+      .eq("monument_id", input.monumentId)
+      .eq("user_id", userId)
+      .select("id, monument_id, title, content")
+      .maybeSingle();
+
+    if (error) {
+      console.error("Failed to update monument note", error);
+      return null;
+    }
+
+    return data ? mapMonumentNote(data) : null;
+  }
+
+  const { data, error } = await supabase
+    .from("monument_notes")
+    .insert(payload)
+    .select("id, monument_id, title, content")
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to create monument note", error);
+    return null;
+  }
+
+  return data ? mapMonumentNote(data) : null;
 }

--- a/src/lib/notesStorage.ts
+++ b/src/lib/notesStorage.ts
@@ -1,25 +1,141 @@
+import { getSupabaseBrowser } from "@/lib/supabase";
 import type { Note } from "@/lib/types/note";
 
-const KEY_PREFIX = "skill-notes-";
+type SkillNoteRow = {
+  id: string;
+  skill_id: string;
+  title: string | null;
+  content: string | null;
+};
 
-export function getNotes(skillId: string): Note[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const data = window.localStorage.getItem(`${KEY_PREFIX}${skillId}`);
-    return data ? (JSON.parse(data) as Note[]) : [];
-  } catch {
-    return [];
-  }
+function mapSkillNote(row: SkillNoteRow): Note {
+  return {
+    id: row.id,
+    skillId: row.skill_id,
+    title: row.title ?? "",
+    content: row.content ?? "",
+  };
 }
 
-export function saveNotes(skillId: string, notes: Note[]) {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(
-      `${KEY_PREFIX}${skillId}`,
-      JSON.stringify(notes)
-    );
-  } catch {
-    // ignore
+async function getUserId(
+  supabase: ReturnType<typeof getSupabaseBrowser>
+) {
+  if (!supabase) return null;
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    console.error("Failed to retrieve auth user for notes", error);
+    return null;
   }
+
+  return user?.id ?? null;
+}
+
+export async function fetchSkillNotes(skillId: string): Promise<Note[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return [];
+
+  const userId = await getUserId(supabase);
+  if (!userId) return [];
+
+  const { data, error } = await supabase
+    .from("skill_notes")
+    .select("id, skill_id, title, content")
+    .eq("skill_id", skillId)
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Failed to fetch skill notes", error);
+    return [];
+  }
+
+  return (data ?? []).map(mapSkillNote);
+}
+
+export async function fetchSkillNote(
+  skillId: string,
+  noteId: string
+): Promise<Note | null> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return null;
+
+  const userId = await getUserId(supabase);
+  if (!userId) return null;
+
+  const { data, error } = await supabase
+    .from("skill_notes")
+    .select("id, skill_id, title, content")
+    .eq("id", noteId)
+    .eq("skill_id", skillId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) {
+    if (error.code !== "PGRST116") {
+      console.error("Failed to fetch skill note", error);
+    }
+    return null;
+  }
+
+  return data ? mapSkillNote(data) : null;
+}
+
+interface UpsertSkillNoteInput {
+  id?: string;
+  skillId: string;
+  title: string;
+  content: string;
+}
+
+export async function upsertSkillNote(
+  input: UpsertSkillNoteInput
+): Promise<Note | null> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) return null;
+
+  const userId = await getUserId(supabase);
+  if (!userId) return null;
+
+  const payload = {
+    title: input.title,
+    content: input.content,
+    skill_id: input.skillId,
+    user_id: userId,
+  };
+
+  if (input.id) {
+    const { data, error } = await supabase
+      .from("skill_notes")
+      .update({ title: input.title, content: input.content })
+      .eq("id", input.id)
+      .eq("skill_id", input.skillId)
+      .eq("user_id", userId)
+      .select("id, skill_id, title, content")
+      .maybeSingle();
+
+    if (error) {
+      console.error("Failed to update skill note", error);
+      return null;
+    }
+
+    return data ? mapSkillNote(data) : null;
+  }
+
+  const { data, error } = await supabase
+    .from("skill_notes")
+    .insert(payload)
+    .select("id, skill_id, title, content")
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to create skill note", error);
+    return null;
+  }
+
+  return data ? mapSkillNote(data) : null;
 }


### PR DESCRIPTION
## Summary
- replace the localStorage-based skill note helpers with Supabase queries
- add Supabase-backed monument note helpers and wire them into the quick add grid and editor screens
- update the note modal and note editors to fetch and save asynchronously with loading states

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68d06229baa4832cb1a609133e8dca84