### PR TITLE
Remove Lovable watermarks automatically

### DIFF
--- a/components/ClientProviders.tsx
+++ b/components/ClientProviders.tsx
@@ -27,6 +27,90 @@ export default function ClientProviders({
     return () => document.removeEventListener("touchmove", handler);
   }, []);
 
+  useEffect(() => {
+    const phrases = [
+      "made with lovable",
+      "made with ai",
+      "generated with ai",
+      "lovable",
+      "lovable ai",
+      "powered by ai",
+    ];
+    const normalized = phrases.map((phrase) => phrase.toLowerCase());
+    const markerAttribute = "data-watermark-filtered";
+
+    const shouldHide = (value: string | null | undefined) => {
+      if (!value) return false;
+      const text = value.toLowerCase();
+      return normalized.some((phrase) => text.includes(phrase));
+    };
+
+    const hideElement = (element: HTMLElement) => {
+      if (element.hasAttribute(markerAttribute)) {
+        return;
+      }
+      element.setAttribute(markerAttribute, "true");
+      element.style.setProperty("display", "none", "important");
+      element.style.setProperty("visibility", "hidden", "important");
+    };
+
+    const inspectNode = (node: Node | null) => {
+      if (!node) return;
+
+      if (node.nodeType === Node.TEXT_NODE) {
+        const parent = node.parentElement;
+        if (parent && shouldHide(node.textContent)) {
+          hideElement(parent);
+        }
+        return;
+      }
+
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as HTMLElement;
+        if (element.hasAttribute(markerAttribute)) {
+          return;
+        }
+
+        if (shouldHide(element.textContent)) {
+          hideElement(element);
+          return;
+        }
+
+        for (const attributeName of element.getAttributeNames()) {
+          if (shouldHide(element.getAttribute(attributeName))) {
+            hideElement(element);
+            return;
+          }
+        }
+
+        element.childNodes.forEach((child) => inspectNode(child));
+      }
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "characterData") {
+          inspectNode(mutation.target.parentNode);
+        }
+
+        mutation.addedNodes.forEach((node) => {
+          inspectNode(node);
+        });
+      }
+    });
+
+    if (document?.body) {
+      inspectNode(document.body);
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );


### PR DESCRIPTION
## Summary
- add a client-side observer that hides any elements containing phrases like "made with lovable" or other AI watermarks so they never appear in the UI

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d19703bfe8832cbe3029c4d3474dbf