### PR TITLE
Simplify dashboard skills carousel

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { motion, Reorder } from "framer-motion";
+import { Reorder } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { updateCatColor, updateCatOrder } from "@/lib/data/cats";
@@ -158,39 +158,36 @@ export default function CategoryCard({
   };
 
   return (
-    <motion.div layout className="relative h-full">
-      <motion.article
-        className="relative flex h-full flex-col rounded-[26px] border px-3 pb-4 pt-5 shadow-lg sm:px-4"
+    <div className="relative h-full">
+      <article
+        className="relative flex h-full flex-col rounded-[26px] border px-3 pb-4 pt-5 shadow-lg transition-all duration-200 sm:px-4"
         style={{
           color: palette.on,
           background: palette.surface,
           borderColor: palette.frame,
           boxShadow: palette.dropShadow,
+          transform: active ? "translateY(-6px) scale(1.02)" : undefined,
+          opacity: active ? 1 : 0.92,
         }}
-        animate={{ scale: active ? 1.02 : 1, y: active ? -6 : 0, opacity: active ? 1 : 0.92 }}
-        transition={{ type: "spring", stiffness: 230, damping: 28, mass: 0.9 }}
       >
-        <motion.span
+        <span
           aria-hidden
-          className="pointer-events-none absolute -inset-12 rounded-[34px] blur-3xl"
-          style={{ background: palette.halo }}
-          animate={{ opacity: active ? 0.3 : 0.16 }}
-          transition={{ duration: 0.6 }}
+          className="pointer-events-none absolute -inset-12 rounded-[34px] blur-3xl transition-opacity duration-300"
+          style={{ background: palette.halo, opacity: active ? 0.3 : 0.16 }}
         />
         <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-[26px]">
-          <motion.span
+          <span
             aria-hidden
-            className="absolute inset-[1px] rounded-[24px]"
-            style={{ border: `1px solid ${withAlpha(palette.on === "#fff" ? "#ffffff" : "#0f172a", active ? 0.24 : 0.14)}` }}
-            animate={{ opacity: active ? 0.75 : 0.5 }}
-            transition={{ duration: 0.4 }}
+            className="absolute inset-[1px] rounded-[24px] transition-opacity duration-300"
+            style={{
+              border: `1px solid ${withAlpha(palette.on === "#fff" ? "#ffffff" : "#0f172a", active ? 0.24 : 0.14)}`,
+              opacity: active ? 0.75 : 0.5,
+            }}
           />
-          <motion.span
+          <span
             aria-hidden
-            className="absolute inset-0"
-            style={{ background: palette.sheen, mixBlendMode: "screen" }}
-            animate={{ opacity: active ? 0.6 : 0.35 }}
-            transition={{ duration: 0.5 }}
+            className="absolute inset-0 transition-opacity duration-300"
+            style={{ background: palette.sheen, mixBlendMode: "screen", opacity: active ? 0.6 : 0.35 }}
           />
         </div>
         <div className="relative z-10 flex h-full flex-col">
@@ -206,12 +203,10 @@ export default function CategoryCard({
               onClick={() => setMenuOpen((o) => !o)}
             >
               <span className="pr-3">{category.name}</span>
-              <motion.span
+              <span
                 aria-hidden
-                className="pointer-events-none absolute inset-0 rounded-full"
-                style={{ background: palette.sheen, mixBlendMode: "screen" }}
-                animate={{ opacity: active ? 0.55 : 0.4 }}
-                transition={{ duration: 0.45 }}
+                className="pointer-events-none absolute inset-0 rounded-full transition-opacity duration-300"
+                style={{ background: palette.sheen, mixBlendMode: "screen", opacity: active ? 0.55 : 0.4 }}
               />
             </button>
             <span
@@ -294,8 +289,8 @@ export default function CategoryCard({
             )}
           </Reorder.Group>
         </div>
-      </motion.article>
-    </motion.div>
+      </article>
+    </div>
   );
 }
 

--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -166,7 +166,6 @@ export default function CategoryCard({
           background: palette.surface,
           borderColor: palette.frame,
           boxShadow: palette.dropShadow,
-          transform: active ? "translateY(-6px) scale(1.02)" : undefined,
           opacity: active ? 1 : 0.92,
         }}
       >

--- a/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
@@ -1,379 +1,209 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { motion, useMotionValue, useSpring, useTransform } from "framer-motion";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
 import CategoryCard from "./CategoryCard";
 import useSkillsData from "./useSkillsData";
 import { deriveInitialIndex } from "./carouselUtils";
 
 const FALLBACK_COLOR = "#6366f1";
 
-function clamp(value: number, min: number, max: number) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function channelToHex(channel: number) {
-  return Math.round(clamp(channel, 0, 255)).toString(16).padStart(2, "0");
-}
-
-function hexToRgb(hex?: string | null) {
-  if (!hex) return { r: 99, g: 102, b: 241 };
-  const normalized = hex.replace("#", "");
-  const r = parseInt(normalized.substring(0, 2), 16);
-  const g = parseInt(normalized.substring(2, 4), 16);
-  const b = parseInt(normalized.substring(4, 6), 16);
-  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+function parseHex(hex?: string | null) {
+  if (!hex) {
     return { r: 99, g: 102, b: 241 };
   }
+
+  const normalized = hex.replace("#", "");
+  if (normalized.length !== 6) {
+    return { r: 99, g: 102, b: 241 };
+  }
+
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+
+  if ([r, g, b].some((channel) => Number.isNaN(channel))) {
+    return { r: 99, g: 102, b: 241 };
+  }
+
   return { r, g, b };
 }
 
-function mixChannel(channel: number, mix: number, amount: number) {
-  return Math.round(channel + (mix - channel) * amount);
-}
-
-function adjustColor(hex: string | null | undefined, amount: number) {
-  const { r, g, b } = hexToRgb(hex || FALLBACK_COLOR);
-  const mixTarget = amount >= 0 ? 255 : 0;
-  const ratio = Math.abs(amount);
-  const nr = mixChannel(r, mixTarget, ratio);
-  const ng = mixChannel(g, mixTarget, ratio);
-  const nb = mixChannel(b, mixTarget, ratio);
-  return `rgb(${nr}, ${ng}, ${nb})`;
-}
-
-function mixHexColors(a?: string | null, b?: string | null, amount = 0) {
-  const start = hexToRgb(a);
-  const end = hexToRgb(b);
-  const ratio = clamp(amount, 0, 1);
-  const r = start.r + (end.r - start.r) * ratio;
-  const g = start.g + (end.g - start.g) * ratio;
-  const blue = start.b + (end.b - start.b) * ratio;
-  return `#${channelToHex(r)}${channelToHex(g)}${channelToHex(blue)}`;
-}
-
 function withAlpha(hex: string | null | undefined, alpha: number) {
-  const { r, g, b } = hexToRgb(hex || FALLBACK_COLOR);
+  const { r, g, b } = parseHex(hex);
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function rgbToRgba(rgb: string, alpha: number) {
-  return rgb.replace("rgb", "rgba").replace(")", `, ${alpha})`);
 }
 
 export default function SkillsCarousel() {
   const { categories, skillsByCategory, isLoading } = useSkillsData();
   const router = useRouter();
   const search = useSearchParams();
+
   const trackRef = useRef<HTMLDivElement>(null);
   const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const autoplayRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const manualPauseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeIndexRef = useRef(0);
-  const cardCentersRef = useRef<number[]>([]);
-  const scrollFrameRef = useRef<number | null>(null);
+  const scrollFrame = useRef<number | null>(null);
 
   const [activeIndex, setActiveIndex] = useState(0);
   const [skillDragging, setSkillDragging] = useState(false);
-  const [hovering, setHovering] = useState(false);
-  const [manualPause, setManualPause] = useState(false);
-  const [stageColor, setStageColor] = useState(FALLBACK_COLOR);
 
-  const glowMotion = useMotionValue(0.5);
-  const glowSpring = useSpring(glowMotion, { stiffness: 90, damping: 24, mass: 0.6 });
-  const glowX = useTransform(glowSpring, (value) => `${value * 100}%`);
+  const scrollToIndex = useCallback(
+    (index: number, options: { instant?: boolean; skipUrl?: boolean } = {}) => {
+      if (categories.length === 0) return;
 
-  const measureCards = useCallback(() => {
-    cardCentersRef.current = cardRefs.current.map((card) =>
-      card ? card.offsetLeft + card.offsetWidth / 2 : Number.NaN
-    );
-  }, []);
+      const bounded = Math.max(0, Math.min(index, categories.length - 1));
+      const track = trackRef.current;
+      const card = cardRefs.current[bounded];
 
-  const computeStageColor = useCallback(
-    (center: number) => {
-      if (categories.length === 0) return FALLBACK_COLOR;
-      const centers = cardCentersRef.current;
-      if (centers.length === 0) return categories[activeIndexRef.current]?.color_hex || FALLBACK_COLOR;
+      if (track && card) {
+        const trackRect = track.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+        const offset = cardRect.left - trackRect.left;
+        const target =
+          track.scrollLeft + offset - (trackRect.width - cardRect.width) / 2;
+        const maxScroll = Math.max(0, track.scrollWidth - track.clientWidth);
+        const nextScroll = Math.max(0, Math.min(target, maxScroll));
 
-      let leftIdx = -1;
-      let rightIdx = -1;
-      let leftCenter = -Infinity;
-      let rightCenter = Infinity;
-
-      centers.forEach((middle, idx) => {
-        if (!Number.isFinite(middle)) return;
-        if (middle <= center && middle > leftCenter) {
-          leftIdx = idx;
-          leftCenter = middle;
+        if (options.instant) {
+          track.scrollLeft = nextScroll;
+        } else if (typeof track.scrollTo === "function") {
+          track.scrollTo({ left: nextScroll, behavior: "smooth" });
+        } else {
+          track.scrollLeft = nextScroll;
         }
-        if (middle >= center && middle < rightCenter) {
-          rightIdx = idx;
-          rightCenter = middle;
-        }
-      });
+      }
 
-      if (leftIdx === -1 && rightIdx === -1) {
-        return FALLBACK_COLOR;
+      activeIndexRef.current = bounded;
+      setActiveIndex((prev) => (prev === bounded ? prev : bounded));
+
+      if (!options.skipUrl && categories[bounded]) {
+        const nextId = categories[bounded].id;
+        if (search.get("cat") !== nextId) {
+          const params = new URLSearchParams(search);
+          params.set("cat", nextId);
+          router.replace(`?${params.toString()}`, { scroll: false });
+        }
       }
-      if (leftIdx === -1) {
-        return categories[rightIdx]?.color_hex || FALLBACK_COLOR;
-      }
-      if (rightIdx === -1) {
-        return categories[leftIdx]?.color_hex || FALLBACK_COLOR;
-      }
-      if (leftIdx === rightIdx) {
-        return categories[leftIdx]?.color_hex || FALLBACK_COLOR;
-      }
-      const span = rightCenter - leftCenter;
-      if (!Number.isFinite(span) || span <= 0) {
-        return categories[rightIdx]?.color_hex || FALLBACK_COLOR;
-      }
-      const ratio = clamp((center - leftCenter) / span, 0, 1);
-      return mixHexColors(categories[leftIdx]?.color_hex, categories[rightIdx]?.color_hex, ratio);
     },
-    [categories]
+    [categories, router, search]
   );
 
-  const updateStageColor = useCallback(
-    (centerOverride?: number) => {
-      if (categories.length === 0) {
-        setStageColor((prev) => (prev === FALLBACK_COLOR ? prev : FALLBACK_COLOR));
-        return;
+  const syncToNearestCard = useCallback(() => {
+    const track = trackRef.current;
+    if (!track || categories.length === 0) return;
+
+    const trackRect = track.getBoundingClientRect();
+    const center = trackRect.left + trackRect.width / 2;
+
+    let nearest = activeIndexRef.current;
+    let minDistance = Number.POSITIVE_INFINITY;
+
+    cardRefs.current.forEach((card, idx) => {
+      if (!card) return;
+
+      const rect = card.getBoundingClientRect();
+      const cardCenter = rect.left + rect.width / 2;
+      const distance = Math.abs(cardCenter - center);
+
+      if (distance < minDistance) {
+        nearest = idx;
+        minDistance = distance;
       }
+    });
 
-      const track = trackRef.current;
-      if (!track) {
-        const fallbackColor =
-          categories[activeIndexRef.current]?.color_hex || categories[0]?.color_hex || FALLBACK_COLOR;
-        setStageColor((prev) => (prev === fallbackColor ? prev : fallbackColor));
-        return;
+    if (nearest !== activeIndexRef.current) {
+      activeIndexRef.current = nearest;
+      setActiveIndex((prev) => (prev === nearest ? prev : nearest));
+
+      const nextId = categories[nearest]?.id;
+      if (nextId && search.get("cat") !== nextId) {
+        const params = new URLSearchParams(search);
+        params.set("cat", nextId);
+        router.replace(`?${params.toString()}`, { scroll: false });
       }
-
-      if (!cardCentersRef.current.some((middle) => Number.isFinite(middle))) {
-        measureCards();
-      }
-
-      const center =
-        typeof centerOverride === "number" ? centerOverride : track.scrollLeft + track.clientWidth / 2;
-      const color = computeStageColor(center);
-      setStageColor((prev) => (prev === color ? prev : color));
-    },
-    [categories, computeStageColor, measureCards]
-  );
-
-  const galleryGradient = useMemo(() => {
-    const soft = withAlpha(stageColor, 0.22);
-    const bright = rgbToRgba(adjustColor(stageColor, 0.45), 0.3);
-    const deep = rgbToRgba(adjustColor(stageColor, -0.3), 0.28);
-    return `radial-gradient(120% 160% at 48% 20%, ${soft} 0%, ${bright} 45%, transparent 75%), radial-gradient(140% 200% at 20% 120%, ${deep} 0%, transparent 70%)`;
-  }, [stageColor]);
-
-  const railTint = useMemo(() => withAlpha(stageColor, 0.12), [stageColor]);
-
-  const animateToIndex = useCallback(
-    (idx: number, options: { instant?: boolean } = {}) => {
-      const track = trackRef.current;
-      const card = cardRefs.current[idx];
-      if (!track || !card) return;
-
-      measureCards();
-
-      const rawTarget = card.offsetLeft - track.clientWidth / 2 + card.clientWidth / 2;
-      const maxScroll = Math.max(0, track.scrollWidth - track.clientWidth);
-      const target = clamp(rawTarget, 0, maxScroll);
-
-    if (options.instant) {
-      track.scrollLeft = target;
-      updateStageColor(target + track.clientWidth / 2);
-      return;
     }
-
-      if (typeof track.scrollTo === "function") {
-        track.scrollTo({ left: target, behavior: "smooth" });
-      } else {
-        track.scrollLeft = target;
-        updateStageColor(target + track.clientWidth / 2);
-      }
-    },
-    [measureCards, updateStageColor]
-  );
-
-  useEffect(() => {
-    if (categories.length === 0) return;
-    const initialId = search.get("cat") || undefined;
-    const idx = deriveInitialIndex(categories, initialId);
-    setActiveIndex(idx);
-    activeIndexRef.current = idx;
-    animateToIndex(idx, { instant: true });
-  }, [categories, search, animateToIndex]);
+  }, [categories, router, search]);
 
   useEffect(() => {
     cardRefs.current = cardRefs.current.slice(0, categories.length);
-  }, [categories.length]);
-
-  useEffect(() => {
-    activeIndexRef.current = activeIndex;
-  }, [activeIndex]);
-
-  useEffect(() => {
     if (categories.length === 0) {
-      setStageColor(FALLBACK_COLOR);
       return;
     }
-    updateStageColor();
-  }, [categories, updateStageColor]);
+
+    if (activeIndexRef.current >= categories.length) {
+      const fallback = Math.max(0, categories.length - 1);
+      scrollToIndex(fallback, { instant: true });
+    } else {
+      scrollToIndex(activeIndexRef.current, { instant: true, skipUrl: true });
+    }
+  }, [categories.length, scrollToIndex]);
 
   useEffect(() => {
-    const el = trackRef.current;
-    if (!el || categories.length === 0) return;
+    if (categories.length === 0) return;
+
+    const initialId = search.get("cat") || undefined;
+    const initialIndex = deriveInitialIndex(categories, initialId);
+
+    activeIndexRef.current = initialIndex;
+    setActiveIndex(initialIndex);
+
+    const frame = requestAnimationFrame(() => {
+      scrollToIndex(initialIndex, { instant: true, skipUrl: true });
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [categories, scrollToIndex, search]);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track || categories.length === 0) return;
 
     const handleScroll = () => {
-      if (scrollFrameRef.current != null) {
-        cancelAnimationFrame(scrollFrameRef.current);
+      if (scrollFrame.current != null) {
+        cancelAnimationFrame(scrollFrame.current);
       }
-      scrollFrameRef.current = requestAnimationFrame(() => {
-        scrollFrameRef.current = null;
-        const { scrollLeft, clientWidth, scrollWidth } = el;
-        const center = scrollLeft + clientWidth / 2;
-        updateStageColor(center);
 
-        let centers = cardCentersRef.current;
-        if (!centers.some((middle) => Number.isFinite(middle))) {
-          measureCards();
-          centers = cardCentersRef.current;
-        }
-        let closest = activeIndexRef.current;
-        let min = Number.POSITIVE_INFINITY;
-        centers.forEach((middle, idx) => {
-          if (!Number.isFinite(middle)) return;
-          const dist = Math.abs(center - middle);
-          if (dist < min) {
-            min = dist;
-            closest = idx;
-          }
-        });
-
-        if (closest !== activeIndexRef.current) {
-          activeIndexRef.current = closest;
-          setActiveIndex(closest);
-          const params = new URLSearchParams(search);
-          if (categories[closest]) {
-            params.set("cat", categories[closest].id);
-            router.replace(`?${params.toString()}`, { scroll: false });
-          }
-        }
-
-        const progress =
-          scrollWidth <= clientWidth ? 0.5 : scrollLeft / Math.max(1, scrollWidth - clientWidth);
-        glowMotion.set(clamp(progress, 0, 1));
+      scrollFrame.current = requestAnimationFrame(() => {
+        scrollFrame.current = null;
+        syncToNearestCard();
       });
     };
 
     handleScroll();
-    el.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      if (scrollFrameRef.current != null) {
-        cancelAnimationFrame(scrollFrameRef.current);
-        scrollFrameRef.current = null;
-      }
-      el.removeEventListener("scroll", handleScroll);
-    };
-  }, [categories, glowMotion, measureCards, router, search, updateStageColor]);
+    track.addEventListener("scroll", handleScroll, { passive: true });
 
-  useLayoutEffect(() => {
-    if (categories.length === 0) return;
-    measureCards();
-    const track = trackRef.current;
-    if (track) {
-      updateStageColor(track.scrollLeft + track.clientWidth / 2);
-    }
-  }, [activeIndex, categories.length, measureCards, updateStageColor]);
+    return () => {
+      if (scrollFrame.current != null) {
+        cancelAnimationFrame(scrollFrame.current);
+        scrollFrame.current = null;
+      }
+      track.removeEventListener("scroll", handleScroll);
+    };
+  }, [categories.length, syncToNearestCard]);
 
   useEffect(() => {
     const handleResize = () => {
-      measureCards();
-      updateStageColor();
+      scrollToIndex(activeIndexRef.current, { instant: true, skipUrl: true });
+      requestAnimationFrame(syncToNearestCard);
     };
+
     window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [measureCards, updateStageColor]);
-
-  const goToIndex = useCallback(
-    (idx: number, options: { instant?: boolean; fromAutoplay?: boolean } = {}) => {
-      if (categories.length === 0) return;
-      const bounded = ((idx % categories.length) + categories.length) % categories.length;
-      animateToIndex(bounded, { instant: options.instant });
-      setActiveIndex(bounded);
-      activeIndexRef.current = bounded;
-      const params = new URLSearchParams(search);
-      params.set("cat", categories[bounded].id);
-      router.replace(`?${params.toString()}`, { scroll: false });
-      if (!options.fromAutoplay) {
-        // ensure scroll listener updates immediately
-        glowMotion.set(bounded / Math.max(1, categories.length - 1));
-      }
-    },
-    [animateToIndex, categories, glowMotion, router, search]
-  );
-
-  const stopAutoplay = useCallback(() => {
-    if (autoplayRef.current) {
-      clearInterval(autoplayRef.current);
-      autoplayRef.current = null;
-    }
-  }, []);
-
-  const startAutoplay = useCallback(() => {
-    if (autoplayRef.current || categories.length <= 1 || manualPause || skillDragging || hovering) {
-      return;
-    }
-    autoplayRef.current = setInterval(() => {
-      const next = (activeIndexRef.current + 1) % categories.length;
-      goToIndex(next, { fromAutoplay: true });
-    }, 6500);
-  }, [categories.length, goToIndex, hovering, manualPause, skillDragging]);
-
-  const triggerAutoplayDelay = useCallback(() => {
-    stopAutoplay();
-    if (manualPauseTimeoutRef.current) {
-      clearTimeout(manualPauseTimeoutRef.current);
-    }
-    setManualPause(true);
-    manualPauseTimeoutRef.current = setTimeout(() => {
-      setManualPause(false);
-    }, 4500);
-  }, [stopAutoplay]);
-
-  useEffect(() => {
-    if (skillDragging || hovering || manualPause) {
-      stopAutoplay();
-      return;
-    }
-    startAutoplay();
-    return () => {
-      stopAutoplay();
-    };
-  }, [hovering, manualPause, skillDragging, startAutoplay, stopAutoplay]);
-
-  useEffect(() => {
-    return () => {
-      stopAutoplay();
-      if (manualPauseTimeoutRef.current) {
-        clearTimeout(manualPauseTimeoutRef.current);
-      }
-    };
-  }, [stopAutoplay]);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [scrollToIndex, syncToNearestCard]);
 
   if (isLoading) {
     return <div className="py-8 text-center text-zinc-400">Loading...</div>;
   }
 
   if (categories.length === 0) {
-    return <div className="text-center py-8 text-zinc-400">No skills yet</div>;
+    return <div className="py-8 text-center text-zinc-400">No skills yet</div>;
   }
+
+  const activeColor = categories[activeIndex]?.color_hex || FALLBACK_COLOR;
+  const canGoPrev = activeIndex > 0;
+  const canGoNext = activeIndex < categories.length - 1;
 
   return (
     <div
@@ -382,81 +212,77 @@ export default function SkillsCarousel() {
       aria-roledescription="carousel"
       aria-label="Skill categories"
       tabIndex={0}
-      onMouseEnter={() => setHovering(true)}
-      onMouseLeave={() => setHovering(false)}
-      onFocus={() => setHovering(true)}
-      onBlur={() => setHovering(false)}
-      onKeyDown={(e) => {
-        if (e.key === "ArrowLeft") {
-          e.preventDefault();
-          triggerAutoplayDelay();
-          goToIndex(activeIndex - 1);
-        }
-        if (e.key === "ArrowRight") {
-          e.preventDefault();
-          triggerAutoplayDelay();
-          goToIndex(activeIndex + 1);
-        }
-        if (e.key === "Enter") {
-          e.preventDefault();
-          cardRefs.current[activeIndex]?.querySelector("button")?.click();
+      onKeyDown={(event) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          scrollToIndex(activeIndexRef.current - 1);
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          scrollToIndex(activeIndexRef.current + 1);
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          cardRefs.current[activeIndexRef.current]
+            ?.querySelector<HTMLButtonElement>("button")
+            ?.click();
         }
       }}
     >
-      <div className="relative overflow-hidden rounded-[30px] border border-white/10 bg-slate-950/40 px-2 py-5 sm:px-4">
-        <motion.div
-          className="pointer-events-none absolute inset-0 transition-opacity duration-700"
-          style={{ background: galleryGradient }}
-          animate={{ opacity: 1 }}
-        />
-        <motion.div
-          className="pointer-events-none absolute -inset-24 blur-3xl"
-          style={{ background: railTint }}
-          animate={{ opacity: 0.5 }}
-          transition={{ duration: 0.6 }}
-        />
-        <motion.div
-          className="pointer-events-none absolute top-1/2 h-[120%] w-[115%] -translate-y-1/2 -translate-x-1/2"
-          style={{
-            left: glowX,
-            background: `radial-gradient(60% 120% at 50% 50%, ${withAlpha(stageColor, 0.52)} 0%, transparent 70%)`,
-          }}
-          animate={{ opacity: 0.55 }}
-          transition={{ duration: 0.6 }}
-        />
+      <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-slate-950/70 px-2 py-6 shadow-lg sm:px-4">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-slate-900/60 via-slate-950/70 to-slate-950" aria-hidden />
+        {categories.length > 1 && (
+          <>
+            <button
+              type="button"
+              aria-label="Previous category"
+              onClick={() => scrollToIndex(activeIndexRef.current - 1)}
+              disabled={!canGoPrev}
+              className="absolute left-3 top-1/2 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border text-slate-100 shadow-lg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:cursor-not-allowed disabled:opacity-35 sm:flex"
+              style={{
+                backgroundColor: withAlpha(activeColor, 0.18),
+                borderColor: withAlpha(activeColor, 0.35),
+                boxShadow: `0 16px 40px ${withAlpha(activeColor, 0.22)}`,
+              }}
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              aria-label="Next category"
+              onClick={() => scrollToIndex(activeIndexRef.current + 1)}
+              disabled={!canGoNext}
+              className="absolute right-3 top-1/2 hidden h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border text-slate-100 shadow-lg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:cursor-not-allowed disabled:opacity-35 sm:flex"
+              style={{
+                backgroundColor: withAlpha(activeColor, 0.18),
+                borderColor: withAlpha(activeColor, 0.35),
+                boxShadow: `0 16px 40px ${withAlpha(activeColor, 0.22)}`,
+              }}
+            >
+              <ChevronRight className="h-5 w-5" />
+            </button>
+          </>
+        )}
         <div
           ref={trackRef}
           className={`relative flex snap-x gap-5 overflow-x-auto overflow-y-hidden px-2 sm:px-3 ${
             skillDragging ? "snap-none touch-none" : "snap-mandatory touch-pan-x"
           }`}
-          onPointerDown={triggerAutoplayDelay}
-          onTouchStart={triggerAutoplayDelay}
         >
-          {categories.map((cat, idx) => {
-            if (categories.length > 20 && Math.abs(idx - activeIndex) > 6) {
-              return (
-                <div
-                  key={cat.id}
-                  className="snap-center shrink-0 w-[85vw] sm:w-[70vw] lg:w-[52vw] xl:w-[44vw]"
-                  aria-hidden
-                />
-              );
-            }
+          {categories.map((category, idx) => {
             const isActive = idx === activeIndex;
             return (
               <div
-                key={cat.id}
-                ref={(el) => {
-                  cardRefs.current[idx] = el;
+                key={category.id}
+                ref={(element) => {
+                  cardRefs.current[idx] = element;
                 }}
                 role="group"
                 aria-label={`Category ${idx + 1} of ${categories.length}`}
-                className="snap-center shrink-0 w-[85vw] sm:w-[70vw] lg:w-[52vw] xl:w-[44vw]"
+                className="w-[85vw] shrink-0 snap-center sm:w-[70vw] lg:w-[52vw] xl:w-[44vw]"
                 style={{ scrollMarginInline: "12px" }}
               >
                 <CategoryCard
-                  category={cat}
-                  skills={skillsByCategory[cat.id] || []}
+                  category={category}
+                  skills={skillsByCategory[category.id] || []}
                   active={isActive}
                   onSkillDrag={setSkillDragging}
                 />
@@ -466,52 +292,44 @@ export default function SkillsCarousel() {
         </div>
       </div>
       <div className="mt-6 flex flex-wrap justify-center gap-2.5" role="tablist">
-        {categories.map((cat, idx) => {
+        {categories.map((category, idx) => {
           const isActive = idx === activeIndex;
-          const previewSkill = (skillsByCategory[cat.id] || []).find((s) => s.emoji)?.emoji;
-          const preview = previewSkill || cat.name.charAt(0).toUpperCase();
-          const chipColor = cat.color_hex || FALLBACK_COLOR;
+          const previewSkill = (skillsByCategory[category.id] || []).find((skill) => skill.emoji)?.emoji;
+          const preview = previewSkill || category.name.charAt(0).toUpperCase();
+          const chipColor = category.color_hex || FALLBACK_COLOR;
+
           return (
-            <motion.button
-              key={cat.id}
+            <button
+              key={category.id}
               role="tab"
               aria-selected={isActive}
-              aria-label={`Go to ${cat.name}`}
-              onClick={() => {
-                triggerAutoplayDelay();
-                goToIndex(idx);
-              }}
-              className="group inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium backdrop-blur focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+              aria-label={`Go to ${category.name}`}
+              onClick={() => scrollToIndex(idx)}
+              className={`inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 ${
+                isActive ? "text-slate-100" : "text-slate-300/85 hover:text-slate-100"
+              }`}
               style={{
-                background: isActive ? withAlpha(chipColor, 0.28) : "rgba(15,23,42,0.55)",
-                border: `1px solid ${isActive ? withAlpha(chipColor, 0.55) : "rgba(148,163,184,0.25)"}`,
+                backgroundColor: isActive ? withAlpha(chipColor, 0.24) : "rgba(15, 23, 42, 0.65)",
+                borderColor: isActive ? withAlpha(chipColor, 0.45) : "rgba(148, 163, 184, 0.25)",
                 boxShadow: isActive
-                  ? `0 16px 34px ${withAlpha(chipColor, 0.28)}`
-                  : "0 6px 18px rgba(15, 23, 42, 0.35)",
-                color: isActive ? "rgba(248,250,252,0.97)" : "rgba(226,232,240,0.82)",
+                  ? `0 16px 32px ${withAlpha(chipColor, 0.28)}`
+                  : "0 6px 18px rgba(15, 23, 42, 0.3)",
               }}
-              whileHover={isActive ? undefined : { scale: 1.045 }}
-              whileFocus={isActive ? undefined : { scale: 1.035 }}
-              animate={{
-                scale: isActive ? 1.055 : 1,
-                opacity: isActive ? 1 : 0.8,
-              }}
-              transition={{ type: "spring", stiffness: 260, damping: 26 }}
             >
               <span
                 className="flex h-6 w-6 items-center justify-center rounded-full text-base font-semibold shadow"
                 style={{
-                  background: isActive ? withAlpha(chipColor, 0.5) : withAlpha(chipColor, 0.18),
+                  backgroundColor: isActive ? withAlpha(chipColor, 0.55) : withAlpha(chipColor, 0.18),
                   color: isActive ? "rgba(15, 23, 42, 0.85)" : "rgba(255,255,255,0.92)",
                   boxShadow: isActive
-                    ? `0 10px 20px ${withAlpha(chipColor, 0.32)}`
-                    : "0 6px 14px rgba(15,23,42,0.32)",
+                    ? `0 12px 24px ${withAlpha(chipColor, 0.32)}`
+                    : "0 6px 14px rgba(15,23,42,0.28)",
                 }}
               >
                 {preview}
               </span>
-              <span className="hidden sm:block pr-1">{cat.name}</span>
-            </motion.button>
+              <span className="hidden pr-1 sm:block">{category.name}</span>
+            </button>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary
- refactor the dashboard skills carousel to use lean scrolling logic instead of the previous animation-heavy implementation
- add straightforward arrow controls, keyboard navigation, and color-accented tabs for selecting categories

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d22189c7d4832c90107b1cab8c5a03