### PR TITLE
Limit goal previews on detail pages

### DIFF
--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -29,4 +29,5 @@ export interface Goal {
   monumentId?: string | null;
   /** Associated skill IDs */
   skills?: string[];
+  weight?: number;
 }

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -31,6 +31,8 @@ export type GoalItem = {
   created_at: string;
   status?: string | null;
   active?: boolean | null;
+  weight_snapshot?: number | null;
+  weight?: number | null;
 };
 
 export type DashboardData = {


### PR DESCRIPTION
## Summary
- default the monument and skill detail goal grids to show only the three highest-weight goal folders with an expand toggle
- surface optional weight metadata on goal items and fold it into the local goal model so folders can be sorted by weight with priority fallbacks
- update the filtered goals query to request weight columns when available while gracefully falling back if the schema does not expose them

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d71fc61f04832ca702ce8c94a62ee7