### PR TITLE
Default schedule page to today view

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -378,7 +378,7 @@ export default function SchedulePage() {
   const initialView: ScheduleView =
     initialViewParam && ['year', 'month', 'day', 'focus'].includes(initialViewParam)
       ? initialViewParam
-      : 'year'
+      : 'day'
   const initialDate = searchParams.get('date')
 
   const [currentDate, setCurrentDate] = useState(


### PR DESCRIPTION
## Summary
- default the schedule page to open in the day view when no explicit view is requested

## Testing
- `vitest run test/env.spec.ts` (from pre-commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68d74a358d8c832c938751ddc41061bd