### PR TITLE
Revamp profile page hero and featured links layout

### DIFF
--- a/src/app/(app)/profile/[handle]/page.tsx
+++ b/src/app/(app)/profile/[handle]/page.tsx
@@ -7,7 +7,6 @@ import { Profile, SocialLink, ContentCard } from "@/lib/types";
 import { getProfileByHandle, getProfileLinks } from "@/lib/db";
 import { getSocialLinks } from "@/lib/db/profile-management";
 import HeroHeader from "@/components/profile/HeroHeader";
-import SocialPillsRow from "@/components/profile/SocialPillsRow";
 import LinkGrid from "@/components/profile/LinkGrid";
 import { ProfileSkeleton } from "@/components/profile/ProfileSkeleton";
 
@@ -140,37 +139,26 @@ export default function ProfileByHandlePage() {
   return (
     <div className="relative min-h-screen bg-slate-950 pb-[env(safe-area-inset-bottom)] text-white">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute left-1/2 top-[-18%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-blue-500/15 blur-[160px]" />
-        <div className="absolute bottom-[-25%] right-[-15%] h-[360px] w-[360px] rounded-full bg-purple-500/10 blur-[200px]" />
+        <div className="absolute -top-40 -left-24 h-[360px] w-[360px] rounded-full bg-gradient-to-br from-blue-500/30 via-purple-500/20 to-transparent blur-[140px]" />
+        <div className="absolute -top-32 right-[-10%] h-[300px] w-[300px] rounded-full bg-gradient-to-bl from-pink-500/25 via-purple-500/20 to-transparent blur-[160px]" />
+        <div className="absolute left-1/2 top-[15%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-blue-500/10 blur-[170px]" />
+        <div className="absolute bottom-[-25%] right-[-15%] h-[360px] w-[360px] rounded-full bg-purple-500/15 blur-[200px]" />
       </div>
 
-      <main className="relative z-10 py-12">
-        <HeroHeader profile={profile} onShare={handleShare} onBack={handleBack} />
+      <main className="relative z-10 py-14">
+        <HeroHeader
+          profile={profile}
+          socials={socialsData}
+          stats={{ linkCount: activeLinkCount, socialCount: activeSocialCount }}
+          onShare={handleShare}
+          onBack={handleBack}
+        />
 
-        <section className="mx-auto mt-10 w-full max-w-4xl px-4">
-          <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-6 shadow-[0_25px_45px_rgba(15,23,42,0.45)] backdrop-blur">
-            <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-white/60">
-              <div className="font-semibold uppercase tracking-[0.35em] text-white/50">
-                Connect
-              </div>
-              {activeSocialCount > 0 ? (
-                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white/60">
-                  {activeSocialCount} {activeSocialCount === 1 ? "network" : "networks"}
-                </span>
-              ) : null}
-            </div>
-
-            <div className="mt-4">
-              <SocialPillsRow socials={socialsData} />
-            </div>
-          </div>
-        </section>
-
-        <section className="mx-auto mt-12 w-full max-w-5xl px-4 pb-16">
+        <section className="mx-auto mt-14 w-full max-w-5xl px-4 pb-20">
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <h2 className="text-2xl font-semibold text-white">Featured links</h2>
-              <p className="mt-1 text-sm text-white/50">
+              <p className="mt-1 text-sm text-white/55">
                 {activeLinkCount > 0
                   ? "Curated highlights from across this creator's world."
                   : "Links you add will appear here for your audience."}
@@ -178,13 +166,14 @@ export default function ProfileByHandlePage() {
             </div>
 
             {activeLinkCount > 0 ? (
-              <span className="rounded-full border border-white/10 bg-white/5 px-4 py-1 text-sm font-medium text-white/70">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/75 shadow-[0_10px_25px_rgba(15,23,42,0.45)]">
+                <span className="inline-block h-2 w-2 rounded-full bg-blue-400" />
                 {activeLinkCount} {activeLinkCount === 1 ? "link" : "links"}
               </span>
             ) : null}
           </div>
 
-          <div className="mt-6">
+          <div className="mt-8">
             <LinkGrid links={contentCards} />
           </div>
         </section>

--- a/src/app/(app)/profile/[handle]/page.tsx
+++ b/src/app/(app)/profile/[handle]/page.tsx
@@ -103,8 +103,8 @@ export default function ProfileByHandlePage() {
     return (
       <div className="relative flex min-h-screen items-center justify-center bg-slate-950 px-4 text-white">
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
-          <div className="absolute left-1/2 top-[-20%] h-[320px] w-[320px] -translate-x-1/2 rounded-full bg-blue-500/10 blur-[160px]" />
-          <div className="absolute bottom-[-25%] right-[-15%] h-[260px] w-[260px] rounded-full bg-purple-500/10 blur-[200px]" />
+          <div className="absolute left-1/2 top-[-20%] h-[320px] w-[320px] -translate-x-1/2 rounded-full bg-neutral-500/15 blur-[160px]" />
+          <div className="absolute bottom-[-25%] right-[-15%] h-[260px] w-[260px] rounded-full bg-neutral-800/15 blur-[200px]" />
         </div>
 
         <div className="relative z-10 w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/70 p-8 text-center shadow-[0_25px_45px_rgba(15,23,42,0.45)] backdrop-blur">
@@ -114,7 +114,7 @@ export default function ProfileByHandlePage() {
           </p>
           <button
             onClick={() => router.push("/dashboard")}
-            className="mt-6 inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/25 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            className="mt-6 inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 transition-colors hover:border-white/20 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
           >
             Back to Dashboard
           </button>
@@ -139,10 +139,10 @@ export default function ProfileByHandlePage() {
   return (
     <div className="relative min-h-screen bg-slate-950 pb-[env(safe-area-inset-bottom)] text-white">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-40 -left-24 h-[360px] w-[360px] rounded-full bg-gradient-to-br from-blue-500/30 via-purple-500/20 to-transparent blur-[140px]" />
-        <div className="absolute -top-32 right-[-10%] h-[300px] w-[300px] rounded-full bg-gradient-to-bl from-pink-500/25 via-purple-500/20 to-transparent blur-[160px]" />
-        <div className="absolute left-1/2 top-[15%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-blue-500/10 blur-[170px]" />
-        <div className="absolute bottom-[-25%] right-[-15%] h-[360px] w-[360px] rounded-full bg-purple-500/15 blur-[200px]" />
+        <div className="absolute -top-40 -left-24 h-[360px] w-[360px] rounded-full bg-gradient-to-br from-neutral-700/30 via-neutral-900/25 to-transparent blur-[140px]" />
+        <div className="absolute -top-32 right-[-10%] h-[300px] w-[300px] rounded-full bg-gradient-to-bl from-neutral-800/30 via-neutral-950/25 to-transparent blur-[160px]" />
+        <div className="absolute left-1/2 top-[15%] h-[420px] w-[420px] -translate-x-1/2 rounded-full bg-neutral-500/15 blur-[170px]" />
+        <div className="absolute bottom-[-25%] right-[-15%] h-[360px] w-[360px] rounded-full bg-neutral-800/20 blur-[200px]" />
       </div>
 
       <main className="relative z-10 py-14">
@@ -167,7 +167,7 @@ export default function ProfileByHandlePage() {
 
             {activeLinkCount > 0 ? (
               <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/75 shadow-[0_10px_25px_rgba(15,23,42,0.45)]">
-                <span className="inline-block h-2 w-2 rounded-full bg-blue-400" />
+                <span className="inline-block h-2 w-2 rounded-full bg-white/60" />
                 {activeLinkCount} {activeLinkCount === 1 ? "link" : "links"}
               </span>
             ) : null}

--- a/src/components/profile/HeroHeader.tsx
+++ b/src/components/profile/HeroHeader.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   MapPin,
   Share2,
+  Sparkles,
 } from "lucide-react";
 import Image from "next/image";
 import { Profile } from "@/lib/types";
@@ -72,33 +73,23 @@ export default function HeroHeader({
   const socialCount = stats?.socialCount ?? 0;
 
   return (
-    <section className="relative mx-auto w-full max-w-5xl px-4">
-      <div className="absolute inset-x-0 -top-24 -z-10 flex justify-center">
-        <div className="h-56 w-56 rounded-full bg-neutral-500/20 blur-[140px]" />
+    <section className="relative mx-auto w-full max-w-6xl px-4">
+      <div className="absolute inset-x-0 -top-36 -z-10 flex justify-center">
+        <div className="h-72 w-72 rounded-full bg-gradient-to-br from-neutral-500/35 via-neutral-900/20 to-transparent blur-[160px]" />
       </div>
 
-      <article className="relative overflow-hidden rounded-[36px] border border-white/10 bg-black/70 shadow-[0_40px_70px_-20px_rgba(2,6,23,0.85)] backdrop-blur-2xl">
-        <div className="relative h-48 sm:h-60">
-          {profile.banner_url ? (
-            <Image
-              src={profile.banner_url}
-              alt="Profile banner"
-              fill
-              priority
-              unoptimized
-              sizes="(min-width: 640px) 1024px, 100vw"
-              className="object-cover"
-            />
-          ) : (
-            <div className="h-full w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
-          )}
+      <article className="relative overflow-hidden rounded-[44px] border border-white/12 bg-gradient-to-br from-[#050505] via-[#101010] to-[#1d1d1d] shadow-[0_60px_120px_-35px_rgba(2,6,23,0.9)]">
+        <div className="absolute inset-0">
+          <div className="absolute -left-12 -top-20 h-64 w-64 rounded-full bg-gradient-to-br from-white/10 via-white/0 to-transparent blur-[120px]" />
+          <div className="absolute right-[-15%] top-16 h-72 w-72 rounded-full bg-gradient-to-bl from-white/8 via-transparent to-transparent blur-[160px]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_58%)]" />
+        </div>
 
-          <div className="absolute inset-0 bg-gradient-to-b from-slate-950/10 via-slate-950/40 to-slate-950/80" />
-
-          <div className="absolute inset-x-6 top-6 flex items-center justify-between text-white">
-            <div className="inline-flex items-center gap-2 rounded-full bg-black/60 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/80">
-              <span className="h-2 w-2 rounded-full bg-white/50" />
-              <span>Bio Link</span>
+        <div className="relative flex flex-col gap-12 px-6 pb-12 pt-10 sm:px-10 md:px-14 md:pt-12">
+          <header className="flex flex-wrap items-center justify-between gap-4 text-white/80">
+            <div className="inline-flex items-center gap-3 rounded-full bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em]">
+              <Sparkles className="h-4 w-4 text-white/50" aria-hidden="true" />
+              <span>Creator Spotlight</span>
             </div>
 
             <div className="flex items-center gap-3">
@@ -106,7 +97,7 @@ export default function HeroHeader({
                 <button
                   type="button"
                   onClick={onBack}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/40 text-white/80 transition-colors hover:border-white/40 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors hover:border-white/30 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                   <span className="sr-only">Back</span>
@@ -117,113 +108,151 @@ export default function HeroHeader({
                 <button
                   type="button"
                   onClick={onShare}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/40 text-white/80 transition-colors hover:border-white/40 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors hover:border-white/30 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 >
                   <Share2 className="h-4 w-4" aria-hidden="true" />
                   <span className="sr-only">Share profile</span>
                 </button>
               ) : null}
             </div>
-          </div>
-        </div>
+          </header>
 
-        <div className="-mt-14 px-6 pb-10 sm:-mt-20 sm:px-10">
-          <div className="flex flex-col gap-7 sm:flex-row sm:items-end">
-            <div className="relative mx-auto flex items-center justify-center sm:mx-0">
-              <div className="absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-neutral-500/35 via-neutral-800/30 to-black/30 blur-xl" />
-              <div className="relative h-28 w-28 overflow-hidden rounded-[26px] border border-white/15 bg-black shadow-[0_30px_55px_rgba(2,6,23,0.65)] sm:h-32 sm:w-32">
-                {profile.avatar_url ? (
-                  <Image
-                    src={profile.avatar_url}
-                    alt={`${displayName}'s avatar`}
-                    fill
-                    sizes="(min-width: 640px) 128px, 112px"
-                    unoptimized
-                    className="object-cover"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center bg-slate-800 text-3xl font-bold text-white">
-                    {initials}
-                  </div>
-                )}
-              </div>
-            </div>
+          <div className="grid gap-10 text-white lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-start">
+            <div className="flex flex-col gap-10">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:gap-10">
+                <div className="relative mx-auto aspect-square w-36 overflow-hidden rounded-[32px] border border-white/15 bg-black shadow-[0_40px_90px_rgba(2,6,23,0.65)] lg:mx-0">
+                  {profile.avatar_url ? (
+                    <Image
+                      src={profile.avatar_url}
+                      alt={`${displayName}'s avatar`}
+                      fill
+                      sizes="(min-width: 1024px) 144px, (min-width: 640px) 160px, 144px"
+                      unoptimized
+                      className="object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-neutral-800 via-neutral-900 to-black text-4xl font-semibold text-white">
+                      {initials}
+                    </div>
+                  )}
+                  <div className="pointer-events-none absolute inset-0 rounded-[32px] ring-1 ring-white/10" />
+                </div>
 
-            <div className="flex-1 text-center sm:text-left">
-              <div className="mx-auto flex flex-col gap-4 sm:mx-0">
-                <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-start">
-                  <h1 className="text-3xl font-semibold text-white sm:text-4xl">{displayName}</h1>
-                  {profile.verified ? (
-                    <span className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/30 bg-black/80 shadow-[0_8px_16px_rgba(2,6,23,0.6)]">
-                      <svg className="h-3.5 w-3.5 text-white" fill="currentColor" viewBox="0 0 20 20">
-                        <path
-                          fillRule="evenodd"
-                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
+                <div className="flex-1 text-center lg:text-left">
+                  <div className="flex flex-col items-center gap-4 lg:items-start">
+                    <div className="flex flex-wrap items-center justify-center gap-3 lg:justify-start">
+                      <h1 className="text-3xl font-semibold sm:text-4xl">{displayName}</h1>
+                      {profile.verified ? (
+                        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-black/80 shadow-[0_12px_30px_rgba(2,6,23,0.55)]">
+                          <svg className="h-4 w-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                            <path
+                              fillRule="evenodd"
+                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      ) : null}
+                    </div>
+
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/80 shadow-[0_14px_32px_rgba(15,23,42,0.45)]">
+                      <ExternalLink className="h-4 w-4 text-white/40" aria-hidden="true" />
+                      @{profile.username}
                     </span>
+                  </div>
+
+                  <p className="mt-6 text-base leading-relaxed text-white/70">{tagline}</p>
+
+                  <div className="mt-6 flex flex-wrap justify-center gap-3 text-sm text-white/65 lg:justify-start">
+                    {profile.city ? (
+                      <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                        <MapPin className="h-4 w-4 text-white/55" aria-hidden="true" />
+                        <span>{profile.city}</span>
+                      </span>
+                    ) : null}
+
+                    {joinedDate ? (
+                      <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                        <Calendar className="h-4 w-4 text-white/55" aria-hidden="true" />
+                        <span>Joined {joinedDate}</span>
+                      </span>
+                    ) : null}
+                  </div>
+
+                  {bioSegments.length ? (
+                    <div className="mt-7 flex flex-wrap justify-center gap-2 lg:justify-start">
+                      {bioSegments.slice(0, 4).map((segment) => (
+                        <span
+                          key={segment}
+                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/55"
+                        >
+                          <span className="h-1.5 w-1.5 rounded-full bg-white/40" />
+                          {segment}
+                        </span>
+                      ))}
+                    </div>
                   ) : null}
                 </div>
+              </div>
 
-                <div className="flex justify-center sm:justify-start">
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/75 shadow-[0_8px_20px_rgba(15,23,42,0.35)]">
-                    <ExternalLink className="h-4 w-4 text-white/40" aria-hidden="true" />
-                    @{profile.username}
-                  </span>
+              <div className="flex flex-col gap-6">
+                <div className="flex flex-wrap justify-center gap-4 lg:justify-start">
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-transform duration-200 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  >
+                    Follow
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 transition-all duration-200 hover:border-white/35 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  >
+                    Message
+                  </button>
                 </div>
-              </div>
 
-              <p className="mt-6 mx-auto max-w-3xl text-base leading-relaxed text-white/75 sm:mx-0">
-                {tagline}
-              </p>
-
-              <div className="mt-5 flex flex-wrap justify-center gap-3 text-sm text-white/65 sm:justify-start">
-                {profile.city ? (
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                    <MapPin className="h-4 w-4 text-white/60" aria-hidden="true" />
-                    <span>{profile.city}</span>
-                  </span>
-                ) : null}
-
-                {joinedDate ? (
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                    <Calendar className="h-4 w-4 text-white/60" aria-hidden="true" />
-                    <span>Joined {joinedDate}</span>
-                  </span>
-                ) : null}
-              </div>
-
-              <div className="mt-7">
                 <SocialPillsRow socials={socials || {}} />
               </div>
+            </div>
 
-              <div className="mt-8 flex flex-wrap justify-center gap-4 sm:justify-start">
-                <div className="min-w-[160px] rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-left shadow-[0_18px_35px_rgba(15,23,42,0.45)]">
-                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/45">
-                    Featured
-                  </span>
-                  <span className="mt-2 block text-3xl font-semibold text-white">
-                    {linkCount}
-                  </span>
-                  <span className="text-xs text-white/55">
-                    {linkCount === 1 ? "live link" : "live links"}
+            <aside className="relative overflow-hidden rounded-[34px] border border-white/12 bg-gradient-to-br from-white/6 via-white/2 to-transparent px-8 py-9 shadow-[0_30px_60px_-25px_rgba(2,6,23,0.7)]">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.15),_transparent_70%)]" />
+              <div className="relative flex flex-col gap-8">
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">Snapshot</p>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/30 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/50">
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-400/70" />
+                    Live
                   </span>
                 </div>
 
-                <div className="min-w-[160px] rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-left shadow-[0_18px_35px_rgba(15,23,42,0.45)]">
-                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/45">
-                    Networks
-                  </span>
-                  <span className="mt-2 block text-3xl font-semibold text-white">
-                    {socialCount}
-                  </span>
-                  <span className="text-xs text-white/55">
-                    {socialCount === 1 ? "connected account" : "connected accounts"}
-                  </span>
+                <div className="grid gap-5 md:grid-cols-2">
+                  <div className="rounded-3xl border border-white/10 bg-black/60 px-5 py-6 text-center">
+                    <span className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">Featured</span>
+                    <p className="mt-3 text-4xl font-semibold text-white">{linkCount}</p>
+                    <p className="text-xs text-white/55">
+                      {linkCount === 1 ? "Curated link" : "Curated links"}
+                    </p>
+                  </div>
+
+                  <div className="rounded-3xl border border-white/10 bg-black/60 px-5 py-6 text-center">
+                    <span className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">Networks</span>
+                    <p className="mt-3 text-4xl font-semibold text-white">{socialCount}</p>
+                    <p className="text-xs text-white/55">
+                      {socialCount === 1 ? "Social channel" : "Social channels"}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-black/50 px-6 py-5 text-sm leading-relaxed text-white/70">
+                  <p>
+                    {profile.bio
+                      ? profile.bio
+                      : "Add a longer story in your bio to help visitors understand your craft, mission, and offerings."}
+                  </p>
                 </div>
               </div>
-            </div>
+            </aside>
           </div>
         </div>
       </article>

--- a/src/components/profile/HeroHeader.tsx
+++ b/src/components/profile/HeroHeader.tsx
@@ -78,26 +78,26 @@ export default function HeroHeader({
         <div className="h-72 w-72 rounded-full bg-gradient-to-br from-neutral-500/35 via-neutral-900/20 to-transparent blur-[160px]" />
       </div>
 
-      <article className="relative overflow-hidden rounded-[44px] border border-white/12 bg-gradient-to-br from-[#050505] via-[#101010] to-[#1d1d1d] shadow-[0_60px_120px_-35px_rgba(2,6,23,0.9)]">
+      <article className="relative overflow-hidden rounded-[28px] border border-white/12 bg-gradient-to-br from-[#050505] via-[#101010] to-[#1d1d1d] shadow-[0_60px_120px_-35px_rgba(2,6,23,0.9)] sm:rounded-[36px] md:rounded-[44px]">
         <div className="absolute inset-0">
           <div className="absolute -left-12 -top-20 h-64 w-64 rounded-full bg-gradient-to-br from-white/10 via-white/0 to-transparent blur-[120px]" />
           <div className="absolute right-[-15%] top-16 h-72 w-72 rounded-full bg-gradient-to-bl from-white/8 via-transparent to-transparent blur-[160px]" />
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_58%)]" />
         </div>
 
-        <div className="relative flex flex-col gap-12 px-6 pb-12 pt-10 sm:px-10 md:px-14 md:pt-12">
-          <header className="flex flex-wrap items-center justify-between gap-4 text-white/80">
-            <div className="inline-flex items-center gap-3 rounded-full bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em]">
-              <Sparkles className="h-4 w-4 text-white/50" aria-hidden="true" />
+        <div className="relative flex flex-col gap-10 px-5 pb-10 pt-8 sm:gap-12 sm:px-8 sm:pb-12 sm:pt-10 md:px-12 md:pt-12">
+          <header className="flex flex-col gap-3 text-white/80 sm:flex-row sm:items-center sm:justify-between">
+            <div className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1.5 text-[0.65rem] font-semibold uppercase tracking-[0.35em] sm:gap-3 sm:px-4 sm:text-xs">
+              <Sparkles className="h-3.5 w-3.5 text-white/50 sm:h-4 sm:w-4" aria-hidden="true" />
               <span>Creator Spotlight</span>
             </div>
 
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 sm:gap-3">
               {onBack ? (
                 <button
                   type="button"
                   onClick={onBack}
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors hover:border-white/30 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors hover:border-white/30 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:h-11 sm:w-11"
                 >
                   <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                   <span className="sr-only">Back</span>
@@ -108,7 +108,7 @@ export default function HeroHeader({
                 <button
                   type="button"
                   onClick={onShare}
-                  className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors hover:border-white/30 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors hover:border-white/30 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:h-11 sm:w-11"
                 >
                   <Share2 className="h-4 w-4" aria-hidden="true" />
                   <span className="sr-only">Share profile</span>
@@ -117,10 +117,10 @@ export default function HeroHeader({
             </div>
           </header>
 
-          <div className="grid gap-10 text-white lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-start">
-            <div className="flex flex-col gap-10">
+          <div className="grid gap-8 text-white sm:gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-start">
+            <div className="flex flex-col gap-8 sm:gap-10">
               <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:gap-10">
-                <div className="relative mx-auto aspect-square w-36 overflow-hidden rounded-[32px] border border-white/15 bg-black shadow-[0_40px_90px_rgba(2,6,23,0.65)] lg:mx-0">
+                <div className="relative mx-auto aspect-square w-32 overflow-hidden rounded-[26px] border border-white/15 bg-black shadow-[0_40px_90px_rgba(2,6,23,0.65)] sm:w-36 sm:rounded-[32px] lg:mx-0">
                   {profile.avatar_url ? (
                     <Image
                       src={profile.avatar_url}
@@ -135,13 +135,13 @@ export default function HeroHeader({
                       {initials}
                     </div>
                   )}
-                  <div className="pointer-events-none absolute inset-0 rounded-[32px] ring-1 ring-white/10" />
+                  <div className="pointer-events-none absolute inset-0 rounded-[26px] ring-1 ring-white/10 sm:rounded-[32px]" />
                 </div>
 
                 <div className="flex-1 text-center lg:text-left">
                   <div className="flex flex-col items-center gap-4 lg:items-start">
                     <div className="flex flex-wrap items-center justify-center gap-3 lg:justify-start">
-                      <h1 className="text-3xl font-semibold sm:text-4xl">{displayName}</h1>
+                      <h1 className="text-2xl font-semibold sm:text-3xl md:text-4xl">{displayName}</h1>
                       {profile.verified ? (
                         <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-black/80 shadow-[0_12px_30px_rgba(2,6,23,0.55)]">
                           <svg className="h-4 w-4 text-white" fill="currentColor" viewBox="0 0 20 20">
@@ -155,15 +155,15 @@ export default function HeroHeader({
                       ) : null}
                     </div>
 
-                    <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/80 shadow-[0_14px_32px_rgba(15,23,42,0.45)]">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-medium text-white/80 shadow-[0_14px_32px_rgba(15,23,42,0.45)] sm:px-4 sm:text-sm">
                       <ExternalLink className="h-4 w-4 text-white/40" aria-hidden="true" />
                       @{profile.username}
                     </span>
                   </div>
 
-                  <p className="mt-6 text-base leading-relaxed text-white/70">{tagline}</p>
+                  <p className="mt-5 text-sm leading-relaxed text-white/70 sm:mt-6 sm:text-base">{tagline}</p>
 
-                  <div className="mt-6 flex flex-wrap justify-center gap-3 text-sm text-white/65 lg:justify-start">
+                  <div className="mt-5 flex flex-wrap justify-center gap-3 text-xs text-white/65 sm:mt-6 sm:text-sm lg:justify-start">
                     {profile.city ? (
                       <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
                         <MapPin className="h-4 w-4 text-white/55" aria-hidden="true" />
@@ -180,11 +180,11 @@ export default function HeroHeader({
                   </div>
 
                   {bioSegments.length ? (
-                    <div className="mt-7 flex flex-wrap justify-center gap-2 lg:justify-start">
+                    <div className="mt-6 flex flex-wrap justify-center gap-2 lg:justify-start">
                       {bioSegments.slice(0, 4).map((segment) => (
                         <span
                           key={segment}
-                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.25em] text-white/55"
+                          className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[0.65rem] uppercase tracking-[0.25em] text-white/55"
                         >
                           <span className="h-1.5 w-1.5 rounded-full bg-white/40" />
                           {segment}
@@ -195,17 +195,17 @@ export default function HeroHeader({
                 </div>
               </div>
 
-              <div className="flex flex-col gap-6">
-                <div className="flex flex-wrap justify-center gap-4 lg:justify-start">
+              <div className="flex flex-col gap-5 sm:gap-6">
+                <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:justify-center sm:gap-4 lg:justify-start">
                   <button
                     type="button"
-                    className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-transform duration-200 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black transition-transform duration-200 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:w-auto"
                   >
                     Follow
                   </button>
                   <button
                     type="button"
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 transition-all duration-200 hover:border-white/35 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/20 bg-white/5 px-6 py-3 text-sm font-medium text-white/80 transition-all duration-200 hover:border-white/35 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:w-auto"
                   >
                     Message
                   </button>
@@ -215,37 +215,37 @@ export default function HeroHeader({
               </div>
             </div>
 
-            <aside className="relative overflow-hidden rounded-[34px] border border-white/12 bg-gradient-to-br from-white/6 via-white/2 to-transparent px-8 py-9 shadow-[0_30px_60px_-25px_rgba(2,6,23,0.7)]">
+            <aside className="relative overflow-hidden rounded-[28px] border border-white/12 bg-gradient-to-br from-white/6 via-white/2 to-transparent px-6 py-8 shadow-[0_30px_60px_-25px_rgba(2,6,23,0.7)] sm:rounded-[32px] sm:px-7 sm:py-9 lg:rounded-[34px] lg:px-8">
               <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.15),_transparent_70%)]" />
-              <div className="relative flex flex-col gap-8">
-                <div className="flex items-center justify-between">
-                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">Snapshot</p>
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/30 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/50">
+              <div className="relative flex flex-col gap-7 sm:gap-8">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/45 sm:text-xs">Snapshot</p>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/30 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/50 sm:text-[0.65rem]">
                     <span className="h-1.5 w-1.5 rounded-full bg-emerald-400/70" />
                     Live
                   </span>
                 </div>
 
-                <div className="grid gap-5 md:grid-cols-2">
-                  <div className="rounded-3xl border border-white/10 bg-black/60 px-5 py-6 text-center">
-                    <span className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">Featured</span>
-                    <p className="mt-3 text-4xl font-semibold text-white">{linkCount}</p>
+                <div className="grid gap-4 sm:grid-cols-2 sm:gap-5">
+                  <div className="rounded-3xl border border-white/10 bg-black/60 px-5 py-5 text-center">
+                    <span className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/45 sm:text-xs">Featured</span>
+                    <p className="mt-3 text-3xl font-semibold text-white sm:text-4xl">{linkCount}</p>
                     <p className="text-xs text-white/55">
                       {linkCount === 1 ? "Curated link" : "Curated links"}
                     </p>
                   </div>
 
-                  <div className="rounded-3xl border border-white/10 bg-black/60 px-5 py-6 text-center">
-                    <span className="text-xs font-semibold uppercase tracking-[0.35em] text-white/45">Networks</span>
-                    <p className="mt-3 text-4xl font-semibold text-white">{socialCount}</p>
+                  <div className="rounded-3xl border border-white/10 bg-black/60 px-5 py-5 text-center">
+                    <span className="text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/45 sm:text-xs">Networks</span>
+                    <p className="mt-3 text-3xl font-semibold text-white sm:text-4xl">{socialCount}</p>
                     <p className="text-xs text-white/55">
                       {socialCount === 1 ? "Social channel" : "Social channels"}
                     </p>
                   </div>
                 </div>
 
-                <div className="rounded-3xl border border-white/10 bg-black/50 px-6 py-5 text-sm leading-relaxed text-white/70">
-                  <p>
+                <div className="rounded-3xl border border-white/10 bg-black/50 px-5 py-5 text-sm leading-relaxed text-white/70 sm:px-6">
+                  <p className="text-[0.925rem] leading-relaxed text-white/70 sm:text-sm">
                     {profile.bio
                       ? profile.bio
                       : "Add a longer story in your bio to help visitors understand your craft, mission, and offerings."}

--- a/src/components/profile/HeroHeader.tsx
+++ b/src/components/profile/HeroHeader.tsx
@@ -74,10 +74,10 @@ export default function HeroHeader({
   return (
     <section className="relative mx-auto w-full max-w-5xl px-4">
       <div className="absolute inset-x-0 -top-24 -z-10 flex justify-center">
-        <div className="h-56 w-56 rounded-full bg-blue-500/25 blur-[140px]" />
+        <div className="h-56 w-56 rounded-full bg-neutral-500/20 blur-[140px]" />
       </div>
 
-      <article className="relative overflow-hidden rounded-[34px] border border-white/10 bg-slate-900/70 shadow-[0_35px_60px_-15px_rgba(15,23,42,0.75)] backdrop-blur-xl">
+      <article className="relative overflow-hidden rounded-[36px] border border-white/10 bg-black/70 shadow-[0_40px_70px_-20px_rgba(2,6,23,0.85)] backdrop-blur-2xl">
         <div className="relative h-48 sm:h-60">
           {profile.banner_url ? (
             <Image
@@ -96,8 +96,8 @@ export default function HeroHeader({
           <div className="absolute inset-0 bg-gradient-to-b from-slate-950/10 via-slate-950/40 to-slate-950/80" />
 
           <div className="absolute inset-x-6 top-6 flex items-center justify-between text-white">
-            <div className="inline-flex items-center gap-2 rounded-full bg-black/40 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/80">
-              <span className="h-2 w-2 rounded-full bg-blue-400" />
+            <div className="inline-flex items-center gap-2 rounded-full bg-black/60 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/80">
+              <span className="h-2 w-2 rounded-full bg-white/50" />
               <span>Bio Link</span>
             </div>
 
@@ -106,7 +106,7 @@ export default function HeroHeader({
                 <button
                   type="button"
                   onClick={onBack}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/35 text-white/80 transition-colors hover:border-white/40 hover:bg-black/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/40 text-white/80 transition-colors hover:border-white/40 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                 >
                   <ChevronLeft className="h-4 w-4" aria-hidden="true" />
                   <span className="sr-only">Back</span>
@@ -117,7 +117,7 @@ export default function HeroHeader({
                 <button
                   type="button"
                   onClick={onShare}
-                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/35 text-white/80 transition-colors hover:border-white/40 hover:bg-black/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/40 text-white/80 transition-colors hover:border-white/40 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
                 >
                   <Share2 className="h-4 w-4" aria-hidden="true" />
                   <span className="sr-only">Share profile</span>
@@ -130,8 +130,8 @@ export default function HeroHeader({
         <div className="-mt-14 px-6 pb-10 sm:-mt-20 sm:px-10">
           <div className="flex flex-col gap-7 sm:flex-row sm:items-end">
             <div className="relative mx-auto flex items-center justify-center sm:mx-0">
-              <div className="absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-blue-500/40 via-purple-500/30 to-pink-500/30 blur-xl" />
-              <div className="relative h-28 w-28 overflow-hidden rounded-[26px] border border-white/20 bg-slate-900 shadow-[0_25px_45px_rgba(15,23,42,0.6)] sm:h-32 sm:w-32">
+              <div className="absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-neutral-500/35 via-neutral-800/30 to-black/30 blur-xl" />
+              <div className="relative h-28 w-28 overflow-hidden rounded-[26px] border border-white/15 bg-black shadow-[0_30px_55px_rgba(2,6,23,0.65)] sm:h-32 sm:w-32">
                 {profile.avatar_url ? (
                   <Image
                     src={profile.avatar_url}
@@ -154,7 +154,7 @@ export default function HeroHeader({
                 <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-start">
                   <h1 className="text-3xl font-semibold text-white sm:text-4xl">{displayName}</h1>
                   {profile.verified ? (
-                    <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-blue-500 shadow-[0_8px_16px_rgba(37,99,235,0.45)]">
+                    <span className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-white/30 bg-black/80 shadow-[0_8px_16px_rgba(2,6,23,0.6)]">
                       <svg className="h-3.5 w-3.5 text-white" fill="currentColor" viewBox="0 0 20 20">
                         <path
                           fillRule="evenodd"
@@ -181,14 +181,14 @@ export default function HeroHeader({
               <div className="mt-5 flex flex-wrap justify-center gap-3 text-sm text-white/65 sm:justify-start">
                 {profile.city ? (
                   <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                    <MapPin className="h-4 w-4 text-blue-200" aria-hidden="true" />
+                    <MapPin className="h-4 w-4 text-white/60" aria-hidden="true" />
                     <span>{profile.city}</span>
                   </span>
                 ) : null}
 
                 {joinedDate ? (
                   <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                    <Calendar className="h-4 w-4 text-blue-200" aria-hidden="true" />
+                    <Calendar className="h-4 w-4 text-white/60" aria-hidden="true" />
                     <span>Joined {joinedDate}</span>
                   </span>
                 ) : null}

--- a/src/components/profile/HeroHeader.tsx
+++ b/src/components/profile/HeroHeader.tsx
@@ -9,15 +9,23 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { Profile } from "@/lib/types";
+import SocialPillsRow from "./SocialPillsRow";
 
 interface HeroHeaderProps {
   profile: Profile;
+  socials?: Record<string, string | undefined>;
+  stats?: {
+    linkCount: number;
+    socialCount: number;
+  };
   onShare?: () => void;
   onBack?: () => void;
 }
 
 export default function HeroHeader({
   profile,
+  socials,
+  stats,
   onShare,
   onBack,
 }: HeroHeaderProps) {
@@ -60,14 +68,17 @@ export default function HeroHeader({
       }).format(new Date(profile.created_at))
     : null;
 
+  const linkCount = stats?.linkCount ?? 0;
+  const socialCount = stats?.socialCount ?? 0;
+
   return (
-    <section className="relative mx-auto w-full max-w-4xl px-4">
-      <div className="absolute inset-0 -z-10 flex justify-center">
-        <div className="h-48 w-48 rounded-full bg-blue-500/20 blur-[120px]" />
+    <section className="relative mx-auto w-full max-w-5xl px-4">
+      <div className="absolute inset-x-0 -top-24 -z-10 flex justify-center">
+        <div className="h-56 w-56 rounded-full bg-blue-500/25 blur-[140px]" />
       </div>
 
-      <article className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 shadow-[0_25px_50px_-12px_rgba(15,23,42,0.65)] backdrop-blur-xl">
-        <div className="relative h-44 sm:h-52">
+      <article className="relative overflow-hidden rounded-[34px] border border-white/10 bg-slate-900/70 shadow-[0_35px_60px_-15px_rgba(15,23,42,0.75)] backdrop-blur-xl">
+        <div className="relative h-48 sm:h-60">
           {profile.banner_url ? (
             <Image
               src={profile.banner_url}
@@ -82,55 +93,56 @@ export default function HeroHeader({
             <div className="h-full w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
           )}
 
-          <div className="absolute inset-0 bg-gradient-to-t from-slate-950 via-slate-950/20 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-b from-slate-950/10 via-slate-950/40 to-slate-950/80" />
 
-          <div className="absolute inset-x-6 top-6 flex items-center gap-3 text-white">
-            {onBack ? (
-              <button
-                type="button"
-                onClick={onBack}
-                className="inline-flex items-center gap-2 rounded-full bg-black/40 px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
-              >
-                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-                <span className="hidden sm:inline">Back</span>
-              </button>
-            ) : null}
-
-            <div className="flex flex-1 justify-center">
-              <div className="flex flex-col items-center text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-white/60">
-                <span>Profile</span>
-                <div className="mt-2 h-px w-12 bg-white/30" />
-              </div>
+          <div className="absolute inset-x-6 top-6 flex items-center justify-between text-white">
+            <div className="inline-flex items-center gap-2 rounded-full bg-black/40 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/80">
+              <span className="h-2 w-2 rounded-full bg-blue-400" />
+              <span>Bio Link</span>
             </div>
 
-            {onShare ? (
-              <button
-                type="button"
-                onClick={onShare}
-                className="inline-flex items-center gap-2 rounded-full bg-black/40 px-4 py-2 text-sm font-medium text-white/80 transition-colors hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
-              >
-                <span className="hidden sm:inline">Share</span>
-                <Share2 className="h-4 w-4" aria-hidden="true" />
-              </button>
-            ) : null}
+            <div className="flex items-center gap-3">
+              {onBack ? (
+                <button
+                  type="button"
+                  onClick={onBack}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/35 text-white/80 transition-colors hover:border-white/40 hover:bg-black/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                >
+                  <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                  <span className="sr-only">Back</span>
+                </button>
+              ) : null}
+
+              {onShare ? (
+                <button
+                  type="button"
+                  onClick={onShare}
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/35 text-white/80 transition-colors hover:border-white/40 hover:bg-black/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+                >
+                  <Share2 className="h-4 w-4" aria-hidden="true" />
+                  <span className="sr-only">Share profile</span>
+                </button>
+              ) : null}
+            </div>
           </div>
         </div>
 
-        <div className="-mt-12 px-6 pb-8 sm:-mt-16">
-          <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
-            <div className="relative mx-auto sm:mx-0">
-              <div className="relative h-24 w-24 overflow-hidden rounded-2xl border border-white/20 bg-slate-800 shadow-[0_10px_40px_rgba(15,23,42,0.6)] sm:h-28 sm:w-28">
+        <div className="-mt-14 px-6 pb-10 sm:-mt-20 sm:px-10">
+          <div className="flex flex-col gap-7 sm:flex-row sm:items-end">
+            <div className="relative mx-auto flex items-center justify-center sm:mx-0">
+              <div className="absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-blue-500/40 via-purple-500/30 to-pink-500/30 blur-xl" />
+              <div className="relative h-28 w-28 overflow-hidden rounded-[26px] border border-white/20 bg-slate-900 shadow-[0_25px_45px_rgba(15,23,42,0.6)] sm:h-32 sm:w-32">
                 {profile.avatar_url ? (
                   <Image
                     src={profile.avatar_url}
                     alt={`${displayName}'s avatar`}
                     fill
-                    sizes="(min-width: 640px) 112px, 96px"
+                    sizes="(min-width: 640px) 128px, 112px"
                     unoptimized
                     className="object-cover"
                   />
                 ) : (
-                  <div className="flex h-full w-full items-center justify-center bg-slate-700 text-3xl font-bold text-white">
+                  <div className="flex h-full w-full items-center justify-center bg-slate-800 text-3xl font-bold text-white">
                     {initials}
                   </div>
                 )}
@@ -138,57 +150,77 @@ export default function HeroHeader({
             </div>
 
             <div className="flex-1 text-center sm:text-left">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="mx-auto flex flex-col gap-3 sm:mx-0">
-                  <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
-                    <h1 className="text-3xl font-semibold text-white sm:text-4xl">
-                      {displayName}
-                    </h1>
-                    {profile.verified && (
-                      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-blue-500">
-                        <svg
-                          className="h-3 w-3 text-white"
-                          fill="currentColor"
-                          viewBox="0 0 20 20"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
-                      </span>
-                    )}
-                  </div>
-
-                  <div className="flex justify-center sm:justify-start">
-                    <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-sm font-medium text-white/70">
-                      <ExternalLink className="h-4 w-4 text-white/40" aria-hidden="true" />
-                      @{profile.username}
+              <div className="mx-auto flex flex-col gap-4 sm:mx-0">
+                <div className="flex flex-wrap items-center justify-center gap-3 sm:justify-start">
+                  <h1 className="text-3xl font-semibold text-white sm:text-4xl">{displayName}</h1>
+                  {profile.verified ? (
+                    <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-blue-500 shadow-[0_8px_16px_rgba(37,99,235,0.45)]">
+                      <svg className="h-3.5 w-3.5 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        <path
+                          fillRule="evenodd"
+                          d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
                     </span>
-                  </div>
+                  ) : null}
+                </div>
+
+                <div className="flex justify-center sm:justify-start">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-1.5 text-sm font-medium text-white/75 shadow-[0_8px_20px_rgba(15,23,42,0.35)]">
+                    <ExternalLink className="h-4 w-4 text-white/40" aria-hidden="true" />
+                    @{profile.username}
+                  </span>
                 </div>
               </div>
 
-              <div className="mt-6 space-y-4">
-                <p className="mx-auto max-w-2xl text-base leading-relaxed text-white/70 sm:mx-0">
-                  {tagline}
-                </p>
+              <p className="mt-6 mx-auto max-w-3xl text-base leading-relaxed text-white/75 sm:mx-0">
+                {tagline}
+              </p>
 
-                <div className="flex flex-wrap justify-center gap-3 text-sm text-white/60 sm:justify-start">
-                  {profile.city ? (
-                    <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                      <MapPin className="h-4 w-4 text-blue-200" aria-hidden="true" />
-                      <span>{profile.city}</span>
-                    </span>
-                  ) : null}
+              <div className="mt-5 flex flex-wrap justify-center gap-3 text-sm text-white/65 sm:justify-start">
+                {profile.city ? (
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                    <MapPin className="h-4 w-4 text-blue-200" aria-hidden="true" />
+                    <span>{profile.city}</span>
+                  </span>
+                ) : null}
 
-                  {joinedDate ? (
-                    <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
-                      <Calendar className="h-4 w-4 text-blue-200" aria-hidden="true" />
-                      <span>Joined {joinedDate}</span>
-                    </span>
-                  ) : null}
+                {joinedDate ? (
+                  <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                    <Calendar className="h-4 w-4 text-blue-200" aria-hidden="true" />
+                    <span>Joined {joinedDate}</span>
+                  </span>
+                ) : null}
+              </div>
+
+              <div className="mt-7">
+                <SocialPillsRow socials={socials || {}} />
+              </div>
+
+              <div className="mt-8 flex flex-wrap justify-center gap-4 sm:justify-start">
+                <div className="min-w-[160px] rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-left shadow-[0_18px_35px_rgba(15,23,42,0.45)]">
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/45">
+                    Featured
+                  </span>
+                  <span className="mt-2 block text-3xl font-semibold text-white">
+                    {linkCount}
+                  </span>
+                  <span className="text-xs text-white/55">
+                    {linkCount === 1 ? "live link" : "live links"}
+                  </span>
+                </div>
+
+                <div className="min-w-[160px] rounded-2xl border border-white/10 bg-white/5 px-5 py-4 text-left shadow-[0_18px_35px_rgba(15,23,42,0.45)]">
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/45">
+                    Networks
+                  </span>
+                  <span className="mt-2 block text-3xl font-semibold text-white">
+                    {socialCount}
+                  </span>
+                  <span className="text-xs text-white/55">
+                    {socialCount === 1 ? "connected account" : "connected accounts"}
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/components/profile/LinkGrid.tsx
+++ b/src/components/profile/LinkGrid.tsx
@@ -15,12 +15,12 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
 
   if (loading) {
     return (
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-5 sm:gap-6 md:grid-cols-2">
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`link-skeleton-${index}`}
-            className="h-72 rounded-[36px] border border-white/12 bg-white/5 shadow-[0_32px_70px_rgba(2,6,23,0.55)]">
-            <div className="h-full w-full animate-pulse rounded-[36px] bg-gradient-to-br from-black/40 via-black/30 to-black/20" />
+            className="h-64 rounded-[28px] border border-white/12 bg-white/5 shadow-[0_32px_70px_rgba(2,6,23,0.55)] sm:h-72 sm:rounded-[34px]">
+            <div className="h-full w-full animate-pulse rounded-[28px] bg-gradient-to-br from-black/40 via-black/30 to-black/20 sm:rounded-[34px]" />
           </div>
         ))}
       </div>
@@ -29,8 +29,8 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
 
   if (activeLinks.length === 0) {
     return (
-      <div className="rounded-[38px] border border-white/12 bg-gradient-to-br from-[#090909] via-[#111111] to-[#1a1a1a] p-12 text-center text-white shadow-[0_40px_90px_-30px_rgba(2,6,23,0.65)]">
-        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-white/15 bg-black/50 text-white/60">
+      <div className="rounded-[30px] border border-white/12 bg-gradient-to-br from-[#090909] via-[#111111] to-[#1a1a1a] p-10 text-center text-white shadow-[0_40px_90px_-30px_rgba(2,6,23,0.65)] sm:rounded-[38px] sm:p-12">
+        <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-black/50 text-white/60 sm:h-16 sm:w-16">
           <svg
             className="h-8 w-8"
             fill="none"
@@ -45,7 +45,7 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
             />
           </svg>
         </div>
-        <h3 className="text-xl font-semibold">No links yet</h3>
+        <h3 className="text-lg font-semibold sm:text-xl">No links yet</h3>
         <p className="mt-3 text-sm text-white/60">
           Publish your first link to unveil the experiences you want to spotlight.
         </p>
@@ -54,7 +54,7 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
   }
 
   return (
-    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-5 sm:gap-6 md:grid-cols-2">
       {activeLinks.map((link) => (
         <LinkTile
           key={link.id}

--- a/src/components/profile/LinkGrid.tsx
+++ b/src/components/profile/LinkGrid.tsx
@@ -15,60 +15,54 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
 
   if (loading) {
     return (
-      <div className="px-4">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {Array.from({ length: 4 }).map((_, index) => (
-            <div
-              key={`link-skeleton-${index}`}
-              className="h-44 rounded-3xl bg-white/5 animate-pulse"
-            />
-          ))}
-        </div>
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={`link-skeleton-${index}`}
+            className="h-64 rounded-[30px] border border-white/10 bg-white/5 animate-pulse"
+          />
+        ))}
       </div>
     );
   }
 
   if (activeLinks.length === 0) {
     return (
-      <div className="px-4">
-        <div className="rounded-3xl border border-white/10 bg-slate-900/70 p-10 text-center shadow-[0_25px_45px_rgba(15,23,42,0.45)]">
-          <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-white/5 text-white/50">
-            <svg
-              className="h-8 w-8"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
-          </div>
-          <h3 className="text-lg font-semibold text-white">No links yet</h3>
-          <p className="mt-2 text-sm text-white/50">
-            Publish your first link to showcase what you are working on.
-          </p>
+      <div className="rounded-[32px] border border-white/10 bg-slate-900/70 p-10 text-center shadow-[0_25px_45px_rgba(15,23,42,0.45)]">
+        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-white/5 text-white/50">
+          <svg
+            className="h-8 w-8"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
         </div>
+        <h3 className="text-lg font-semibold text-white">No links yet</h3>
+        <p className="mt-2 text-sm text-white/50">
+          Publish your first link to showcase what you are working on.
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="px-4">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {activeLinks.map((link) => (
-          <LinkTile
-            key={link.id}
-            title={link.title}
-            url={link.url}
-            thumbUrl={link.thumbnail_url || undefined}
-            description={link.description || undefined}
-          />
-        ))}
-      </div>
+    <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+      {activeLinks.map((link) => (
+        <LinkTile
+          key={link.id}
+          title={link.title}
+          url={link.url}
+          thumbUrl={link.thumbnail_url || undefined}
+          description={link.description || undefined}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/profile/LinkGrid.tsx
+++ b/src/components/profile/LinkGrid.tsx
@@ -15,12 +15,13 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
 
   if (loading) {
     return (
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`link-skeleton-${index}`}
-            className="h-64 rounded-[32px] border border-white/10 bg-black/50 animate-pulse"
-          />
+            className="h-72 rounded-[36px] border border-white/12 bg-white/5 shadow-[0_32px_70px_rgba(2,6,23,0.55)]">
+            <div className="h-full w-full animate-pulse rounded-[36px] bg-gradient-to-br from-black/40 via-black/30 to-black/20" />
+          </div>
         ))}
       </div>
     );
@@ -28,8 +29,8 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
 
   if (activeLinks.length === 0) {
     return (
-      <div className="rounded-[34px] border border-white/10 bg-black/65 p-10 text-center shadow-[0_32px_70px_rgba(2,6,23,0.6)]">
-        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white/50">
+      <div className="rounded-[38px] border border-white/12 bg-gradient-to-br from-[#090909] via-[#111111] to-[#1a1a1a] p-12 text-center text-white shadow-[0_40px_90px_-30px_rgba(2,6,23,0.65)]">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-white/15 bg-black/50 text-white/60">
           <svg
             className="h-8 w-8"
             fill="none"
@@ -44,16 +45,16 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
             />
           </svg>
         </div>
-        <h3 className="text-lg font-semibold text-white">No links yet</h3>
-        <p className="mt-2 text-sm text-white/50">
-          Publish your first link to showcase what you are working on.
+        <h3 className="text-xl font-semibold">No links yet</h3>
+        <p className="mt-3 text-sm text-white/60">
+          Publish your first link to unveil the experiences you want to spotlight.
         </p>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
       {activeLinks.map((link) => (
         <LinkTile
           key={link.id}

--- a/src/components/profile/LinkGrid.tsx
+++ b/src/components/profile/LinkGrid.tsx
@@ -19,7 +19,7 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`link-skeleton-${index}`}
-            className="h-64 rounded-[30px] border border-white/10 bg-white/5 animate-pulse"
+            className="h-64 rounded-[32px] border border-white/10 bg-black/50 animate-pulse"
           />
         ))}
       </div>
@@ -28,8 +28,8 @@ export default function LinkGrid({ links, loading = false }: LinkGridProps) {
 
   if (activeLinks.length === 0) {
     return (
-      <div className="rounded-[32px] border border-white/10 bg-slate-900/70 p-10 text-center shadow-[0_25px_45px_rgba(15,23,42,0.45)]">
-        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-white/5 text-white/50">
+      <div className="rounded-[34px] border border-white/10 bg-black/65 p-10 text-center shadow-[0_32px_70px_rgba(2,6,23,0.6)]">
+        <div className="mx-auto mb-5 flex h-16 w-16 items-center justify-center rounded-full border border-white/10 bg-black/60 text-white/50">
           <svg
             className="h-8 w-8"
             fill="none"

--- a/src/components/profile/LinkTile.tsx
+++ b/src/components/profile/LinkTile.tsx
@@ -22,9 +22,9 @@ export default function LinkTile({
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
     >
-      <article className="relative flex h-72 flex-col overflow-hidden rounded-[30px] border border-white/10 bg-slate-900/70 shadow-[0_28px_60px_rgba(15,23,42,0.55)] transition-all duration-300 hover:-translate-y-1 hover:border-white/25 hover:shadow-[0_32px_80px_rgba(15,23,42,0.6)]">
+      <article className="relative flex h-72 flex-col overflow-hidden rounded-[32px] border border-white/10 bg-black/70 shadow-[0_32px_70px_rgba(2,6,23,0.65)] transition-all duration-300 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_36px_90px_rgba(2,6,23,0.7)]">
         <div className="absolute inset-0">
           {thumbUrl ? (
             <Image
@@ -43,7 +43,7 @@ export default function LinkTile({
         <div className="absolute inset-0 bg-gradient-to-b from-slate-900/10 via-slate-900/40 to-slate-950/85" />
 
         <div className="absolute right-5 top-5">
-          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors duration-200 group-hover:border-white/35 group-hover:bg-black/55">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-black/50 text-white transition-colors duration-200 group-hover:border-white/30 group-hover:bg-black/70">
             <ExternalLink className="h-4 w-4" aria-hidden="true" />
           </span>
         </div>

--- a/src/components/profile/LinkTile.tsx
+++ b/src/components/profile/LinkTile.tsx
@@ -17,14 +17,22 @@ export default function LinkTile({
   thumbUrl,
   description,
 }: LinkTileProps) {
+  const displayHost = (() => {
+    try {
+      return new URL(url).hostname.replace(/^www\./, "");
+    } catch (_error) {
+      return url.replace(/^https?:\/\//, "");
+    }
+  })();
+
   return (
     <Link
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+      className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
     >
-      <article className="relative flex h-72 flex-col overflow-hidden rounded-[32px] border border-white/10 bg-black/70 shadow-[0_32px_70px_rgba(2,6,23,0.65)] transition-all duration-300 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_36px_90px_rgba(2,6,23,0.7)]">
+      <article className="relative flex h-80 flex-col overflow-hidden rounded-[38px] border border-white/12 bg-gradient-to-br from-[#0a0a0a] via-[#121212] to-[#1f1f1f] shadow-[0_38px_90px_-30px_rgba(2,6,23,0.75)] transition-all duration-300 hover:-translate-y-1 hover:border-white/25 hover:shadow-[0_42px_110px_-28px_rgba(2,6,23,0.85)]">
         <div className="absolute inset-0">
           {thumbUrl ? (
             <Image
@@ -36,34 +44,45 @@ export default function LinkTile({
               className="object-cover"
             />
           ) : (
-            <div className="h-full w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
+            <div className="h-full w-full bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_65%)]" />
           )}
         </div>
 
-        <div className="absolute inset-0 bg-gradient-to-b from-slate-900/10 via-slate-900/40 to-slate-950/85" />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/10 via-black/55 to-black/85" />
 
-        <div className="absolute right-5 top-5">
-          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-black/50 text-white transition-colors duration-200 group-hover:border-white/30 group-hover:bg-black/70">
-            <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          </span>
+        <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-white/30 via-transparent to-white/20 opacity-50 transition-opacity duration-300 group-hover:opacity-100" />
+
+        <div className="absolute right-6 top-6 inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/50 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/60 transition-colors duration-200 group-hover:border-white/30 group-hover:bg-black/70">
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          Visit
         </div>
 
-        <div className="relative mt-auto flex flex-col gap-4 p-6">
-          <h3 className="text-xl font-semibold text-white transition-colors duration-200 group-hover:text-white/90">
-            {title}
-          </h3>
+        <div className="relative mt-auto flex flex-col gap-5 px-7 pb-8 pt-28">
+          <div className="flex flex-col gap-3">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[0.65rem] uppercase tracking-[0.35em] text-white/55">
+              Highlight
+            </span>
+            <h3 className="text-2xl font-semibold text-white transition-colors duration-200 group-hover:text-white/90">
+              {title}
+            </h3>
+          </div>
 
           {description ? (
-            <p className="text-sm leading-relaxed text-white/75 line-clamp-3">
+            <p className="line-clamp-3 text-sm leading-relaxed text-white/70">
               {description}
             </p>
           ) : (
-            <p className="text-sm text-white/60">Tap to open this link in a new tab.</p>
+            <p className="text-sm text-white/55">Tap to explore this feature in a new window.</p>
           )}
 
-          <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/50">
-            <span className="h-px w-8 bg-white/30" />
-            <span>Open link</span>
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+            <div className="flex items-center gap-2">
+              <span className="h-1 w-6 rounded-full bg-white/30" />
+              <span>Open link</span>
+            </div>
+            <span className="text-[0.6rem] text-white/40 transition-colors duration-200 group-hover:text-white/70">
+              {displayHost}
+            </span>
           </div>
         </div>
       </article>

--- a/src/components/profile/LinkTile.tsx
+++ b/src/components/profile/LinkTile.tsx
@@ -24,45 +24,45 @@ export default function LinkTile({
       rel="noopener noreferrer"
       className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
     >
-      <article className="flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 shadow-[0_20px_45px_rgba(15,23,42,0.45)] transition-all duration-200 hover:border-white/25 hover:shadow-[0_28px_60px_rgba(15,23,42,0.55)]">
-        <div className="relative h-32 w-full overflow-hidden">
+      <article className="relative flex h-72 flex-col overflow-hidden rounded-[30px] border border-white/10 bg-slate-900/70 shadow-[0_28px_60px_rgba(15,23,42,0.55)] transition-all duration-300 hover:-translate-y-1 hover:border-white/25 hover:shadow-[0_32px_80px_rgba(15,23,42,0.6)]">
+        <div className="absolute inset-0">
           {thumbUrl ? (
             <Image
               src={thumbUrl}
               alt={`${title} preview`}
               fill
-              sizes="(min-width: 640px) 50vw, 100vw"
+              sizes="(min-width: 768px) 40vw, 100vw"
               unoptimized
               className="object-cover"
             />
           ) : (
             <div className="h-full w-full bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950" />
           )}
-
-          <div className="absolute inset-0 bg-gradient-to-t from-slate-950/60 via-slate-950/10 to-transparent" />
-
-          <div className="absolute right-4 top-4">
-            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-black/30 text-white transition-colors group-hover:border-white/30 group-hover:bg-black/50">
-              <ExternalLink className="h-4 w-4" aria-hidden="true" />
-            </span>
-          </div>
         </div>
 
-        <div className="flex flex-1 flex-col gap-3 p-5">
-          <h3 className="text-lg font-semibold text-white transition-colors group-hover:text-white/90">
+        <div className="absolute inset-0 bg-gradient-to-b from-slate-900/10 via-slate-900/40 to-slate-950/85" />
+
+        <div className="absolute right-5 top-5">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-black/40 text-white transition-colors duration-200 group-hover:border-white/35 group-hover:bg-black/55">
+            <ExternalLink className="h-4 w-4" aria-hidden="true" />
+          </span>
+        </div>
+
+        <div className="relative mt-auto flex flex-col gap-4 p-6">
+          <h3 className="text-xl font-semibold text-white transition-colors duration-200 group-hover:text-white/90">
             {title}
           </h3>
 
           {description ? (
-            <p className="text-sm leading-relaxed text-white/70 line-clamp-3">
+            <p className="text-sm leading-relaxed text-white/75 line-clamp-3">
               {description}
             </p>
           ) : (
-            <p className="text-sm text-white/40">Tap to open this link in a new tab.</p>
+            <p className="text-sm text-white/60">Tap to open this link in a new tab.</p>
           )}
 
-          <div className="mt-auto flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-white/40">
-            <span className="h-px w-6 bg-white/20" />
+          <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.25em] text-white/50">
+            <span className="h-px w-8 bg-white/30" />
             <span>Open link</span>
           </div>
         </div>

--- a/src/components/profile/LinkTile.tsx
+++ b/src/components/profile/LinkTile.tsx
@@ -32,7 +32,7 @@ export default function LinkTile({
       rel="noopener noreferrer"
       className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
     >
-      <article className="relative flex h-80 flex-col overflow-hidden rounded-[38px] border border-white/12 bg-gradient-to-br from-[#0a0a0a] via-[#121212] to-[#1f1f1f] shadow-[0_38px_90px_-30px_rgba(2,6,23,0.75)] transition-all duration-300 hover:-translate-y-1 hover:border-white/25 hover:shadow-[0_42px_110px_-28px_rgba(2,6,23,0.85)]">
+      <article className="relative flex h-64 flex-col overflow-hidden rounded-[30px] border border-white/12 bg-gradient-to-br from-[#0a0a0a] via-[#121212] to-[#1f1f1f] shadow-[0_38px_90px_-30px_rgba(2,6,23,0.75)] transition-all duration-300 hover:-translate-y-1 hover:border-white/25 hover:shadow-[0_42px_110px_-28px_rgba(2,6,23,0.85)] sm:h-72 sm:rounded-[34px] lg:h-80 lg:rounded-[38px]">
         <div className="absolute inset-0">
           {thumbUrl ? (
             <Image
@@ -52,30 +52,30 @@ export default function LinkTile({
 
         <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-white/30 via-transparent to-white/20 opacity-50 transition-opacity duration-300 group-hover:opacity-100" />
 
-        <div className="absolute right-6 top-6 inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/50 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-white/60 transition-colors duration-200 group-hover:border-white/30 group-hover:bg-black/70">
+        <div className="absolute right-5 top-5 inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/50 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.3em] text-white/60 transition-colors duration-200 group-hover:border-white/30 group-hover:bg-black/70 sm:right-6 sm:top-6 sm:text-[0.65rem]">
           <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
           Visit
         </div>
 
-        <div className="relative mt-auto flex flex-col gap-5 px-7 pb-8 pt-28">
+        <div className="relative mt-auto flex flex-col gap-5 px-6 pb-7 pt-24 sm:px-7 sm:pb-8 sm:pt-28">
           <div className="flex flex-col gap-3">
-            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[0.65rem] uppercase tracking-[0.35em] text-white/55">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[0.6rem] uppercase tracking-[0.35em] text-white/55 sm:text-[0.65rem]">
               Highlight
             </span>
-            <h3 className="text-2xl font-semibold text-white transition-colors duration-200 group-hover:text-white/90">
+            <h3 className="text-xl font-semibold text-white transition-colors duration-200 group-hover:text-white/90 sm:text-2xl">
               {title}
             </h3>
           </div>
 
           {description ? (
-            <p className="line-clamp-3 text-sm leading-relaxed text-white/70">
+            <p className="line-clamp-3 text-sm leading-relaxed text-white/75">
               {description}
             </p>
           ) : (
             <p className="text-sm text-white/55">Tap to explore this feature in a new window.</p>
           )}
 
-          <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-white/50">
+          <div className="flex items-center justify-between text-[0.65rem] uppercase tracking-[0.3em] text-white/50">
             <div className="flex items-center gap-2">
               <span className="h-1 w-6 rounded-full bg-white/30" />
               <span>Open link</span>

--- a/src/components/profile/ProfileSkeleton.tsx
+++ b/src/components/profile/ProfileSkeleton.tsx
@@ -4,17 +4,17 @@ export function ProfileSkeleton() {
   return (
     <div className="relative min-h-screen bg-slate-950 pb-[env(safe-area-inset-bottom)]">
       <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute left-1/2 top-[-20%] h-96 w-96 -translate-x-1/2 rounded-full bg-blue-500/15 blur-[160px]" />
-        <div className="absolute bottom-[-25%] right-[-15%] h-80 w-80 rounded-full bg-purple-500/10 blur-[180px]" />
+        <div className="absolute left-1/2 top-[-20%] h-96 w-96 -translate-x-1/2 rounded-full bg-neutral-500/15 blur-[160px]" />
+        <div className="absolute bottom-[-25%] right-[-15%] h-80 w-80 rounded-full bg-neutral-800/15 blur-[180px]" />
       </div>
 
       <div className="relative mx-auto w-full max-w-4xl px-4 pt-12">
-        <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 backdrop-blur-xl shadow-[0_25px_50px_-12px_rgba(15,23,42,0.65)]">
-          <div className="h-44 w-full bg-slate-800/70 animate-pulse sm:h-52" />
+        <div className="overflow-hidden rounded-[36px] border border-white/10 bg-black/70 backdrop-blur-2xl shadow-[0_35px_70px_-15px_rgba(2,6,23,0.7)]">
+          <div className="h-44 w-full bg-black/50 animate-pulse sm:h-52" />
 
           <div className="-mt-12 px-6 pb-8 sm:-mt-16">
             <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
-              <div className="mx-auto h-24 w-24 rounded-2xl bg-slate-800 animate-pulse sm:mx-0 sm:h-28 sm:w-28" />
+              <div className="mx-auto h-24 w-24 rounded-[26px] bg-black/60 animate-pulse sm:mx-0 sm:h-28 sm:w-28" />
 
               <div className="flex-1 space-y-4 text-center sm:text-left">
                 <div className="mx-auto h-8 w-48 rounded-full bg-white/10 animate-pulse sm:mx-0" />
@@ -31,7 +31,7 @@ export function ProfileSkeleton() {
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={`social-skeleton-${index}`}
-              className="h-10 w-32 rounded-full bg-white/5 animate-pulse"
+              className="h-10 w-32 rounded-full bg-black/50 animate-pulse"
             />
           ))}
         </div>
@@ -42,7 +42,7 @@ export function ProfileSkeleton() {
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={`link-card-skeleton-${index}`}
-              className="h-44 rounded-3xl bg-white/5 animate-pulse"
+              className="h-44 rounded-[32px] bg-black/50 animate-pulse"
             />
           ))}
         </div>

--- a/src/components/profile/ProfileSkeleton.tsx
+++ b/src/components/profile/ProfileSkeleton.tsx
@@ -8,42 +8,47 @@ export function ProfileSkeleton() {
         <div className="absolute bottom-[-25%] right-[-15%] h-80 w-80 rounded-full bg-neutral-800/15 blur-[180px]" />
       </div>
 
-      <div className="relative mx-auto w-full max-w-4xl px-4 pt-12">
-        <div className="overflow-hidden rounded-[36px] border border-white/10 bg-black/70 backdrop-blur-2xl shadow-[0_35px_70px_-15px_rgba(2,6,23,0.7)]">
-          <div className="h-44 w-full bg-black/50 animate-pulse sm:h-52" />
+      <div className="relative mx-auto w-full max-w-6xl px-4 pt-14">
+        <div className="overflow-hidden rounded-[44px] border border-white/12 bg-black/60 backdrop-blur-2xl shadow-[0_60px_120px_-40px_rgba(2,6,23,0.85)]">
+          <div className="h-20 w-full bg-black/40" />
 
-          <div className="-mt-12 px-6 pb-8 sm:-mt-16">
-            <div className="flex flex-col gap-6 sm:flex-row sm:items-end">
-              <div className="mx-auto h-24 w-24 rounded-[26px] bg-black/60 animate-pulse sm:mx-0 sm:h-28 sm:w-28" />
+          <div className="grid gap-10 px-8 pb-12 pt-10 sm:px-12 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+            <div className="flex flex-col gap-8">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:gap-8">
+                <div className="mx-auto h-32 w-32 rounded-[32px] bg-white/10 lg:mx-0" />
+                <div className="flex-1 space-y-5 text-center lg:text-left">
+                  <div className="mx-auto h-8 w-48 rounded-full bg-white/10 sm:mx-0" />
+                  <div className="mx-auto h-4 w-40 rounded-full bg-white/10 sm:mx-0" />
+                  <div className="mx-auto h-20 w-full max-w-md rounded-[24px] bg-white/5 sm:mx-0" />
+                </div>
+              </div>
 
-              <div className="flex-1 space-y-4 text-center sm:text-left">
-                <div className="mx-auto h-8 w-48 rounded-full bg-white/10 animate-pulse sm:mx-0" />
-                <div className="mx-auto h-3 w-40 rounded-full bg-white/10 animate-pulse sm:mx-0" />
-                <div className="mx-auto h-20 w-full max-w-md rounded-2xl bg-white/5 animate-pulse sm:mx-0" />
+              <div className="mx-auto h-12 w-full max-w-sm rounded-full bg-white/5 lg:mx-0" />
+
+              <div className="flex flex-wrap justify-center gap-4 lg:justify-start">
+                {Array.from({ length: 3 }).map((_, index) => (
+                  <div
+                    key={`social-chip-${index}`}
+                    className="h-12 w-36 rounded-full bg-white/5"
+                  />
+                ))}
               </div>
             </div>
+
+            <div className="hidden h-full rounded-[34px] bg-white/5 lg:block" />
           </div>
         </div>
       </div>
 
-      <div className="relative mx-auto mt-10 w-full max-w-4xl px-4">
-        <div className="flex flex-wrap justify-center gap-3">
-          {Array.from({ length: 4 }).map((_, index) => (
-            <div
-              key={`social-skeleton-${index}`}
-              className="h-10 w-32 rounded-full bg-black/50 animate-pulse"
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="relative mx-auto mt-12 w-full max-w-5xl px-4 pb-16">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="relative mx-auto mt-12 w-full max-w-6xl px-4 pb-16">
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={`link-card-skeleton-${index}`}
-              className="h-44 rounded-[32px] bg-black/50 animate-pulse"
-            />
+              className="h-80 rounded-[38px] border border-white/12 bg-white/5"
+            >
+              <div className="h-full w-full animate-pulse rounded-[38px] bg-gradient-to-br from-black/40 via-black/30 to-black/20" />
+            </div>
           ))}
         </div>
       </div>

--- a/src/components/profile/SocialPillsRow.tsx
+++ b/src/components/profile/SocialPillsRow.tsx
@@ -23,8 +23,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   const platformConfig = {
     instagram: {
       icon: Instagram,
-      color:
-        "bg-gradient-to-br from-[#ff9a9e] via-[#fad0c4] to-[#fad0c4]/80 text-black",
+      color: "bg-gradient-to-br from-neutral-900 via-neutral-800 to-neutral-700",
       label: "Instagram",
     },
     x: {
@@ -34,12 +33,12 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     twitter: {
       icon: Twitter,
-      color: "bg-[#1d9bf0]",
+      color: "bg-neutral-900",
       label: "Twitter",
     },
     youtube: {
       icon: Youtube,
-      color: "bg-[#ff0000]",
+      color: "bg-neutral-900",
       label: "YouTube",
     },
     tiktok: {
@@ -49,32 +48,32 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     linkedin: {
       icon: Linkedin,
-      color: "bg-[#0a66c2]",
+      color: "bg-neutral-900",
       label: "LinkedIn",
     },
     email: {
       icon: Mail,
-      color: "bg-slate-600",
+      color: "bg-neutral-800",
       label: "Email",
     },
     website: {
       icon: Globe,
-      color: "bg-gradient-to-br from-blue-500 to-purple-500",
+      color: "bg-gradient-to-br from-black via-neutral-900 to-neutral-700",
       label: "Website",
     },
     github: {
       icon: Github,
-      color: "bg-slate-900",
+      color: "bg-black",
       label: "GitHub",
     },
     discord: {
       icon: MessageCircle,
-      color: "bg-[#5865f2]",
+      color: "bg-neutral-900",
       label: "Discord",
     },
     facebook: {
       icon: Facebook,
-      color: "bg-[#1877f2]",
+      color: "bg-neutral-900",
       label: "Facebook",
     },
   } as const;
@@ -126,7 +125,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
             target="_blank"
             rel="noopener noreferrer"
             title={config.label}
-            className="group relative inline-flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-white/10 shadow-[0_18px_35px_rgba(15,23,42,0.45)] transition-all duration-200 hover:-translate-y-1 hover:border-white/35 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            className="group relative inline-flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-black/40 shadow-[0_22px_40px_rgba(2,6,23,0.55)] transition-all duration-200 hover:-translate-y-1 hover:border-white/25 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
           >
             <span
               className={`inline-flex h-11 w-11 items-center justify-center rounded-full text-white shadow-lg transition-transform duration-200 group-hover:scale-[1.05] ${config.color}`}

--- a/src/components/profile/SocialPillsRow.tsx
+++ b/src/components/profile/SocialPillsRow.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import {
+  Facebook,
   Github,
   Globe,
   Instagram,
@@ -22,7 +23,8 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   const platformConfig = {
     instagram: {
       icon: Instagram,
-      color: "bg-gradient-to-r from-purple-500 to-pink-500",
+      color:
+        "bg-gradient-to-br from-[#ff9a9e] via-[#fad0c4] to-[#fad0c4]/80 text-black",
       label: "Instagram",
     },
     x: {
@@ -32,12 +34,12 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     twitter: {
       icon: Twitter,
-      color: "bg-blue-400",
+      color: "bg-[#1d9bf0]",
       label: "Twitter",
     },
     youtube: {
       icon: Youtube,
-      color: "bg-red-600",
+      color: "bg-[#ff0000]",
       label: "YouTube",
     },
     tiktok: {
@@ -47,60 +49,70 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
     },
     linkedin: {
       icon: Linkedin,
-      color: "bg-blue-700",
+      color: "bg-[#0a66c2]",
       label: "LinkedIn",
     },
     email: {
       icon: Mail,
-      color: "bg-gray-600",
+      color: "bg-slate-600",
       label: "Email",
     },
     website: {
       icon: Globe,
-      color: "bg-blue-500",
+      color: "bg-gradient-to-br from-blue-500 to-purple-500",
       label: "Website",
     },
     github: {
       icon: Github,
-      color: "bg-gray-800",
+      color: "bg-slate-900",
       label: "GitHub",
     },
     discord: {
       icon: MessageCircle,
-      color: "bg-indigo-600",
+      color: "bg-[#5865f2]",
       label: "Discord",
     },
-  };
+    facebook: {
+      icon: Facebook,
+      color: "bg-[#1877f2]",
+      label: "Facebook",
+    },
+  } as const;
 
   // Filter out undefined URLs and sort by platform priority
+  const priority = [
+    "instagram",
+    "x",
+    "twitter",
+    "youtube",
+    "tiktok",
+    "linkedin",
+    "facebook",
+    "email",
+    "website",
+    "github",
+    "discord",
+  ];
+
+  const getPriority = (platform: string) => {
+    const index = priority.indexOf(platform);
+    return index === -1 ? priority.length : index;
+  };
+
   const availableSocials = Object.entries(socials)
     .filter(([, url]) => url && url !== "#")
-    .sort(([a], [b]) => {
-      const priority = [
-        "instagram",
-        "x",
-        "twitter",
-        "youtube",
-        "tiktok",
-        "linkedin",
-        "email",
-        "website",
-        "github",
-        "discord",
-      ];
-      return priority.indexOf(a) - priority.indexOf(b);
-    });
+    .sort(([a], [b]) => getPriority(a) - getPriority(b));
 
   if (availableSocials.length === 0) {
     return (
-      <div className="text-center py-8">
-        <p className="text-white/50 text-sm">No social links added yet</p>
+      <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-5 text-center text-sm text-white/60">
+        No social links added yet
       </div>
     );
   }
 
   return (
-    <div className="flex flex-wrap justify-center gap-3">
+    <div className="flex flex-wrap justify-center gap-4">
       {availableSocials.map(([platform, url]) => {
         const config = platformConfig[platform as keyof typeof platformConfig];
         if (!config || !url) return null;
@@ -113,14 +125,15 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group inline-flex items-center gap-3 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white/80 transition-all hover:border-white/30 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            title={config.label}
+            className="group relative inline-flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-white/10 shadow-[0_18px_35px_rgba(15,23,42,0.45)] transition-all duration-200 hover:-translate-y-1 hover:border-white/35 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
           >
             <span
-              className={`inline-flex h-8 w-8 items-center justify-center rounded-full text-white shadow-lg ${config.color}`}
+              className={`inline-flex h-11 w-11 items-center justify-center rounded-full text-white shadow-lg transition-transform duration-200 group-hover:scale-[1.05] ${config.color}`}
             >
-              <IconComponent className="h-4 w-4" aria-hidden="true" />
+              <IconComponent className="h-5 w-5" aria-hidden="true" />
             </span>
-            <span>{config.label}</span>
+            <span className="sr-only">{config.label}</span>
           </Link>
         );
       })}

--- a/src/components/profile/SocialPillsRow.tsx
+++ b/src/components/profile/SocialPillsRow.tsx
@@ -23,57 +23,46 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   const platformConfig = {
     instagram: {
       icon: Instagram,
-      color: "bg-gradient-to-br from-neutral-900 via-neutral-800 to-neutral-700",
       label: "Instagram",
     },
     x: {
       icon: Twitter,
-      color: "bg-black",
       label: "X (Twitter)",
     },
     twitter: {
       icon: Twitter,
-      color: "bg-neutral-900",
       label: "Twitter",
     },
     youtube: {
       icon: Youtube,
-      color: "bg-neutral-900",
       label: "YouTube",
     },
     tiktok: {
       icon: Music,
-      color: "bg-black",
       label: "TikTok",
     },
     linkedin: {
       icon: Linkedin,
-      color: "bg-neutral-900",
       label: "LinkedIn",
     },
     email: {
       icon: Mail,
-      color: "bg-neutral-800",
       label: "Email",
     },
     website: {
       icon: Globe,
-      color: "bg-gradient-to-br from-black via-neutral-900 to-neutral-700",
       label: "Website",
     },
     github: {
       icon: Github,
-      color: "bg-black",
       label: "GitHub",
     },
     discord: {
       icon: MessageCircle,
-      color: "bg-neutral-900",
       label: "Discord",
     },
     facebook: {
       icon: Facebook,
-      color: "bg-neutral-900",
       label: "Facebook",
     },
   } as const;
@@ -111,7 +100,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   }
 
   return (
-    <div className="flex flex-wrap justify-center gap-4">
+    <div className="flex flex-wrap justify-center gap-3 lg:justify-start">
       {availableSocials.map(([platform, url]) => {
         const config = platformConfig[platform as keyof typeof platformConfig];
         if (!config || !url) return null;
@@ -125,14 +114,14 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
             target="_blank"
             rel="noopener noreferrer"
             title={config.label}
-            className="group relative inline-flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-black/40 shadow-[0_22px_40px_rgba(2,6,23,0.55)] transition-all duration-200 hover:-translate-y-1 hover:border-white/25 hover:bg-black/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+            className="group inline-flex items-center gap-3 rounded-full border border-white/12 bg-white/5 px-4 py-2 text-sm font-medium text-white/75 shadow-[0_16px_36px_rgba(2,6,23,0.55)] transition-all duration-200 hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
           >
-            <span
-              className={`inline-flex h-11 w-11 items-center justify-center rounded-full text-white shadow-lg transition-transform duration-200 group-hover:scale-[1.05] ${config.color}`}
-            >
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white shadow-[0_12px_24px_rgba(2,6,23,0.6)] transition-transform duration-200 group-hover:scale-105">
               <IconComponent className="h-5 w-5" aria-hidden="true" />
             </span>
-            <span className="sr-only">{config.label}</span>
+            <span className="pr-1 text-xs uppercase tracking-[0.25em] text-white/60 transition-colors duration-200 group-hover:text-white/80">
+              {config.label}
+            </span>
           </Link>
         );
       })}

--- a/src/components/profile/SocialPillsRow.tsx
+++ b/src/components/profile/SocialPillsRow.tsx
@@ -100,7 +100,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
   }
 
   return (
-    <div className="flex flex-wrap justify-center gap-3 lg:justify-start">
+    <div className="-mx-2 flex snap-x snap-mandatory items-stretch gap-3 overflow-x-auto px-2 pb-2 sm:mx-0 sm:flex-wrap sm:justify-center sm:overflow-visible sm:px-0 lg:justify-start">
       {availableSocials.map(([platform, url]) => {
         const config = platformConfig[platform as keyof typeof platformConfig];
         if (!config || !url) return null;
@@ -114,7 +114,7 @@ export default function SocialPillsRow({ socials }: SocialPillsRowProps) {
             target="_blank"
             rel="noopener noreferrer"
             title={config.label}
-            className="group inline-flex items-center gap-3 rounded-full border border-white/12 bg-white/5 px-4 py-2 text-sm font-medium text-white/75 shadow-[0_16px_36px_rgba(2,6,23,0.55)] transition-all duration-200 hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            className="group inline-flex min-w-[13.5rem] snap-center items-center gap-3 rounded-full border border-white/12 bg-white/5 px-4 py-2 text-sm font-medium text-white/75 shadow-[0_16px_36px_rgba(2,6,23,0.55)] transition-all duration-200 hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-200 focus-visible:ring-offset-2 focus-visible:ring-offset-black sm:min-w-0"
           >
             <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white shadow-[0_12px_24px_rgba(2,6,23,0.6)] transition-transform duration-200 group-hover:scale-105">
               <IconComponent className="h-5 w-5" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- redesign the profile hero card with integrated social icons, stats, and share/back actions to mirror the reference design
- restyle the social link pills to brand-colored icon buttons and refresh the featured links grid and tiles for a richer presentation
- update the public profile page background gradients and counters to align with the new visual language

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68d74be4f74c832c94dca1c0d0d7f001