### PR TITLE
Clamp midnight-spanning window availability

### DIFF
--- a/src/lib/scheduler/reschedule.ts
+++ b/src/lib/scheduler/reschedule.ts
@@ -550,8 +550,14 @@ async function fetchCompatibleWindowsForItem(
 
     if (typeof nowMs === 'number' && endMs <= nowMs) continue
 
-    const baseAvailableStartMs =
+    let baseAvailableStartMs =
       typeof nowMs === 'number' ? Math.max(startMs, nowMs) : startMs
+    if (win.fromPrevDay) {
+      const dayStartMs = startOfDayInTimeZone(date, timeZone).getTime()
+      if (baseAvailableStartMs < dayStartMs) {
+        baseAvailableStartMs = dayStartMs
+      }
+    }
     const carriedStartMs = availability?.get(key)?.getTime()
     const availableStartMs =
       typeof carriedStartMs === 'number'


### PR DESCRIPTION
## Summary
- clamp availability when evaluating overnight windows so next-day passes cannot start before local midnight
- ensure scheduling uses the clamped availability and cover the behavior with a midnight window regression test

## Testing
- pnpm vitest run test/lib/scheduler/reschedule.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d862352220832c923ff1f87807e95a