### PR TITLE
Remove gradient background from profile layout

### DIFF
--- a/src/app/(app)/profile/LinkMeProfile.tsx
+++ b/src/app/(app)/profile/LinkMeProfile.tsx
@@ -130,7 +130,7 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
   const displayCards = contentCards.length > 0 ? contentCards : defaultContentCards;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50">
+    <div className="min-h-screen bg-white">
       {/* Top Navigation Bar */}
       <div className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-200">
         <div className="flex items-center justify-between px-4 py-3">


### PR DESCRIPTION
## Summary
- replace the blue gradient canvas on the profile page with a neutral white background to remove the blue canvas look

## Testing
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68d86b844d8c832cb72258d4dd3ce601