### PR TITLE
feat: allow custom emoji for cat skill cards

### DIFF
--- a/add_cats_system_simple.sql
+++ b/add_cats_system_simple.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS public.cats (
   name text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   color_hex text DEFAULT '#000000'::text,
+  emoji text,
   sort_order integer,
   UNIQUE(user_id, name)
 );
@@ -47,6 +48,7 @@ SELECT
   c.name as cat_name,
   c.user_id,
   COALESCE(c.color_hex, '#000000') as color_hex,
+  c.emoji,
   c.sort_order,
   COUNT(s.id) as skill_count,
   ARRAY_AGG(
@@ -60,7 +62,7 @@ SELECT
   ) FILTER (WHERE s.id IS NOT NULL) as skills
 FROM public.cats c
 LEFT JOIN public.skills s ON c.id = s.cat_id
-GROUP BY c.id, c.name, c.user_id, c.color_hex, c.sort_order
+GROUP BY c.id, c.name, c.user_id, c.color_hex, c.emoji, c.sort_order
 ORDER BY c.sort_order NULLS LAST, c.name;
 
 -- 6. Grant permissions on new view

--- a/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
+++ b/src/app/(app)/dashboard/_skills/SkillsCarousel.tsx
@@ -37,7 +37,7 @@ function withAlpha(hex: string | null | undefined, alpha: number) {
 }
 
 export default function SkillsCarousel() {
-  const { categories, skillsByCategory, isLoading } = useSkillsData();
+  const { categories, skillsByCategory, isLoading, refresh } = useSkillsData();
   const router = useRouter();
   const search = useSearchParams();
 
@@ -285,6 +285,7 @@ export default function SkillsCarousel() {
                   skills={skillsByCategory[category.id] || []}
                   active={isActive}
                   onSkillDrag={setSkillDragging}
+                  onCategoryUpdate={refresh}
                 />
               </div>
             );
@@ -294,8 +295,9 @@ export default function SkillsCarousel() {
       <div className="mt-6 flex flex-wrap justify-center gap-2.5" role="tablist">
         {categories.map((category, idx) => {
           const isActive = idx === activeIndex;
+          const previewEmoji = category.emoji?.trim();
           const previewSkill = (skillsByCategory[category.id] || []).find((skill) => skill.emoji)?.emoji;
-          const preview = previewSkill || category.name.charAt(0).toUpperCase();
+          const preview = previewEmoji || previewSkill || category.name.charAt(0).toUpperCase();
           const chipColor = category.color_hex || FALLBACK_COLOR;
 
           return (

--- a/src/app/(app)/dashboard/loaders.ts
+++ b/src/app/(app)/dashboard/loaders.ts
@@ -109,7 +109,7 @@ export async function getSkillsAndGoals(
   const [catsRes, goalsRes] = await Promise.all([
     supabase
       .from("skills_by_cats_v")
-      .select("cat_id,cat_name,user_id,skill_count,skills"),
+      .select("cat_id,cat_name,user_id,skill_count,skills,color_hex,sort_order,emoji"),
     supabase.from("goals").select("id,name,created_at").limit(3),
   ]);
 

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -36,7 +36,7 @@ export async function GET() {
       .order("created_at", { ascending: false }),
     supabase
       .from("cats")
-      .select("id,name,user_id,color_hex,sort_order")
+      .select("id,name,user_id,color_hex,sort_order,emoji")
       .eq("user_id", user.id)
       .order("sort_order", { ascending: true, nullsFirst: false }),
   ]);
@@ -60,12 +60,14 @@ export async function GET() {
         user_id: string;
         color_hex?: string | null;
         sort_order?: number | null;
+        emoji?: string | null;
       }) => cat.id === skill.cat_id
     );
     return {
       ...skill,
       cat_name: category?.name || "Uncategorized",
       cat_color_hex: category?.color_hex || "#000000",
+      cat_emoji: category?.emoji || null,
     };
   });
 
@@ -111,7 +113,11 @@ export async function GET() {
   const skillsByCategory = skillsData.reduce(
     (
       acc: Record<string, CatItem>,
-      skill: SkillRow & { cat_name: string; cat_color_hex: string | null }
+      skill: SkillRow & {
+        cat_name: string;
+        cat_color_hex: string | null;
+        cat_emoji: string | null;
+      }
     ) => {
       const catId = skill.cat_id;
       const catName = catId ? skill.cat_name : "Uncategorized";
@@ -124,6 +130,7 @@ export async function GET() {
           user_id: skill.user_id,
           skill_count: 0,
           color_hex: catId ? skill.cat_color_hex || "#000000" : "#000000",
+          emoji: catId ? skill.cat_emoji || null : null,
           skills: [],
         };
       }
@@ -154,6 +161,7 @@ export async function GET() {
     user_id: string;
     color_hex?: string | null;
     sort_order?: number | null;
+    emoji?: string | null;
   }[];
 
   // Create a complete list of CATs with their skills (or empty skills array)
@@ -164,6 +172,7 @@ export async function GET() {
       return {
         ...catSkills,
         color_hex: cat.color_hex || catSkills.color_hex || "#000000",
+        emoji: cat.emoji ?? catSkills.emoji ?? null,
         order: cat.sort_order ?? null,
       }; // Return CAT with its skills
     } else {
@@ -174,6 +183,7 @@ export async function GET() {
         user_id: cat.user_id,
         skill_count: 0,
         color_hex: cat.color_hex || "#000000",
+        emoji: cat.emoji || null,
         order: cat.sort_order ?? null,
         skills: [],
       };
@@ -186,6 +196,7 @@ export async function GET() {
     catsOut.push({
       ...uncategorizedCat,
       color_hex: uncategorizedCat.color_hex || "#000000",
+      emoji: null,
       order: null,
     });
   }

--- a/src/lib/data/cats.ts
+++ b/src/lib/data/cats.ts
@@ -7,7 +7,7 @@ export async function getCatsForUser(userId: string) {
 
   const { data, error } = await sb
     .from("cats")
-    .select("id,name,user_id,created_at,color_hex,sort_order")
+    .select("id,name,user_id,created_at,color_hex,sort_order,emoji")
     .eq("user_id", userId)
     .order("sort_order", { ascending: true, nullsFirst: false })
     .order("created_at", { ascending: false });
@@ -16,6 +16,7 @@ export async function getCatsForUser(userId: string) {
   return (data ?? []).map((c) => ({
     ...c,
     color_hex: c.color_hex || "#000000",
+    emoji: c.emoji || null,
   })) as CatRow[];
 }
 
@@ -35,6 +36,16 @@ export async function updateCatOrder(catId: string, order: number) {
   const { error } = await sb
     .from("cats")
     .update({ sort_order: order })
+    .eq("id", catId);
+  if (error) throw error;
+}
+
+export async function updateCatEmoji(catId: string, emoji: string | null) {
+  const sb = getSupabaseBrowser();
+  if (!sb) throw new Error("Supabase client not available");
+  const { error } = await sb
+    .from("cats")
+    .update({ emoji })
     .eq("id", catId);
   if (error) throw error;
 }

--- a/src/lib/types/cat.ts
+++ b/src/lib/types/cat.ts
@@ -5,4 +5,5 @@ export type CatRow = {
   created_at?: string | null;
   color_hex?: string | null;
   sort_order?: number | null;
+  emoji?: string | null;
 };

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -19,6 +19,7 @@ export type CatItem = {
   skill_count: number;
   color_hex?: string | null;
   order?: number | null;
+  emoji?: string | null;
   skills: SkillItem[];
 };
 

--- a/supabase/migrations/20250827050222_remote_schema.sql
+++ b/supabase/migrations/20250827050222_remote_schema.sql
@@ -23,6 +23,7 @@ create table "public"."cats" (
   "name" text not null,
   "created_at" timestamp with time zone not null default now(),
   "color_hex" text default '#000000'::text,
+  "emoji" text,
   "sort_order" integer
 );
 

--- a/supabase/migrations/20250827050222_remote_schema_clean.sql
+++ b/supabase/migrations/20250827050222_remote_schema_clean.sql
@@ -23,6 +23,7 @@ create table "public"."cats" (
   "name" text not null,
   "created_at" timestamp with time zone not null default now(),
   "color_hex" text default '#000000'::text,
+  "emoji" text,
   "sort_order" integer
 );
 

--- a/supabase/migrations/20250901000000_add_cat_emoji.sql
+++ b/supabase/migrations/20250901000000_add_cat_emoji.sql
@@ -1,16 +1,17 @@
--- Migration to add the skills_by_cats_v view after remote schema is applied
--- This assumes the cats table and skills table with uuid IDs exist from remote schema
+-- Add emoji column for cat cards
+ALTER TABLE public.cats ADD COLUMN IF NOT EXISTS emoji text;
 
--- Create the skills_by_cats_v view
-CREATE OR REPLACE VIEW public.skills_by_cats_v AS
+-- Update skills_by_cats_v to expose cat emoji
+DROP VIEW IF EXISTS public.skills_by_cats_v;
+CREATE VIEW public.skills_by_cats_v AS
 SELECT
-  c.id as cat_id,
-  c.name as cat_name,
+  c.id AS cat_id,
+  c.name AS cat_name,
   c.user_id,
   COALESCE(c.color_hex, '#000000') AS color_hex,
   c.emoji,
   c.sort_order,
-  COUNT(s.id) as skill_count,
+  COUNT(s.id) AS skill_count,
   ARRAY_AGG(
     json_build_object(
       'skill_id', s.id,
@@ -19,11 +20,10 @@ SELECT
       'level', COALESCE(s.level, 1),
       'progress', GREATEST(0, LEAST(100, COALESCE(s.progress, 0)))::int
     ) ORDER BY COALESCE(s.name, 'Unnamed Skill')
-  ) FILTER (WHERE s.id IS NOT NULL) as skills
+  ) FILTER (WHERE s.id IS NOT NULL) AS skills
 FROM public.cats c
 LEFT JOIN public.skills s ON c.id = s.cat_id
 GROUP BY c.id, c.name, c.user_id, c.color_hex, c.emoji, c.sort_order
 ORDER BY c.sort_order NULLS LAST, c.name;
 
--- Grant permissions on the view
 GRANT SELECT ON public.skills_by_cats_v TO authenticated;


### PR DESCRIPTION
## Summary
- add emoji metadata to cat categories including dashboard API, hooks, and client data utilities
- allow changing and displaying category emojis directly from the dashboard cat card and quick-select chips
- extend Supabase schema and migrations so cats store an optional emoji and expose it via skills_by_cats_v

## Testing
- pnpm lint
- vitest run test/env.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68d9689a30a8832caf516c5d2339b2b7