### PR TITLE
Show only icon for reschedule button

### DIFF
--- a/src/components/schedule/RescheduleButton.tsx
+++ b/src/components/schedule/RescheduleButton.tsx
@@ -23,6 +23,7 @@ export function RescheduleButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-label={isRunning ? runningLabel : idleLabel}
       className={`group relative inline-flex items-center gap-2 rounded-full border border-white/40 bg-[linear-gradient(140deg,_#f4f5f9_0%,_#d6d9e0_45%,_#a1a6b4_100%)] px-5 py-2 text-sm font-semibold text-[#1f2733] shadow-[0_12px_26px_rgba(10,12,18,0.55),_0_5px_12px_rgba(0,0,0,0.35),_inset_0_1px_0_rgba(255,255,255,0.85)] transition-all duration-150 ease-out hover:-translate-y-0.5 hover:shadow-[0_18px_34px_rgba(8,10,16,0.6),_0_8px_18px_rgba(0,0,0,0.4),_inset_0_1px_0_rgba(255,255,255,0.9)] disabled:cursor-not-allowed disabled:translate-y-0 disabled:opacity-80 disabled:shadow-[0_12px_26px_rgba(10,12,18,0.4),_0_5px_12px_rgba(0,0,0,0.25),_inset_0_1px_0_rgba(255,255,255,0.6)] ${className}`}
       {...rest}
     >
@@ -34,9 +35,6 @@ export function RescheduleButton({
           } transition-transform duration-200 ease-out`}
         />
       </div>
-      <span className="tracking-wide">
-        {isRunning ? runningLabel : idleLabel}
-      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- hide the textual label in the rescheduler control so only the icon renders
- add an aria-label to preserve accessible button text while the icon is shown

## Testing
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d982e814c0832c8b4e61eb6c147340