### PR TITLE
Add animated completion state to project card

### DIFF
--- a/components/ui/ProjectCard.tsx
+++ b/components/ui/ProjectCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId, useState } from "react";
 import { MoreHorizontal } from "lucide-react";
 import FlameEmber, { type FlameLevel } from "@/components/FlameEmber";
 import { Badge } from "./badge";
@@ -10,6 +11,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 interface ProjectCardProps {
   project: {
@@ -23,26 +25,87 @@ interface ProjectCardProps {
 }
 
 export function ProjectCard({ project }: ProjectCardProps) {
+  const [isCompleted, setIsCompleted] = useState(false);
+  const checkboxId = useId();
+
   const handleEdit = () => {
     // Placeholder for future edit functionality
     console.log("Edit project", project.id);
   };
 
   return (
-    <Card className="hover:bg-gray-800/50 transition-colors">
+    <Card
+      className={cn(
+        "transition-colors duration-500",
+        isCompleted
+          ? "bg-gradient-to-br from-emerald-600 via-emerald-500 to-emerald-700 border-emerald-300/60 text-emerald-50 shadow-lg shadow-emerald-900/30"
+          : "hover:bg-gray-800/50"
+      )}
+    >
       <CardContent className="p-4">
         <div className="flex items-start justify-between mb-2">
-          <h3 className="font-medium text-white">{project.name}</h3>
+          <div className="flex items-center gap-3">
+            <div className="relative flex items-center">
+              <input
+                id={checkboxId}
+                type="checkbox"
+                checked={isCompleted}
+                onChange={(event) => setIsCompleted(event.target.checked)}
+                className={cn(
+                  "h-5 w-5 cursor-pointer appearance-none rounded-md border transition-all",
+                  "border-gray-600 bg-transparent",
+                  "checked:border-emerald-200 checked:bg-emerald-400/90",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/70"
+                )}
+                aria-label={`Mark ${project.name} as complete`}
+              />
+              <svg
+                className={cn(
+                  "pointer-events-none absolute inset-0 m-auto h-3 w-3 text-emerald-950 transition-opacity",
+                  isCompleted ? "opacity-100" : "opacity-0"
+                )}
+                viewBox="0 0 12 10"
+                aria-hidden="true"
+              >
+                <path
+                  d="M1 5.5 4.5 9 11 1"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+            <label
+              htmlFor={checkboxId}
+              className={cn(
+                "cursor-pointer select-none font-medium transition-colors",
+                isCompleted ? "text-emerald-50" : "text-white"
+              )}
+            >
+              {project.name}
+            </label>
+          </div>
           <div className="flex items-center gap-2">
             <FlameEmber level={project.energy as FlameLevel} size="sm" />
-            <Badge variant="outline" className="text-xs">
+            <Badge
+              variant="outline"
+              className={cn(
+                "text-xs",
+                isCompleted && "border-emerald-200/70 text-emerald-50"
+              )}
+            >
               {project.goal_name}
             </Badge>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   aria-label="Project actions"
-                  className="p-1 rounded bg-gray-700"
+                  className={cn(
+                    "p-1 rounded transition-colors",
+                    isCompleted ? "bg-emerald-700/60 text-emerald-50" : "bg-gray-700"
+                  )}
                 >
                   <MoreHorizontal className="w-4 h-4" />
                 </button>
@@ -56,13 +119,24 @@ export function ProjectCard({ project }: ProjectCardProps) {
           </div>
         </div>
         <div className="flex gap-2">
-          <Badge variant={getPriorityVariant(project.priority)}>
+          <Badge
+            variant={getPriorityVariant(project.priority)}
+            className={cn(isCompleted && "bg-emerald-600/30 text-emerald-50")}
+          >
             {project.priority}
           </Badge>
-          <Badge variant={getEnergyVariant(project.energy)}>
+          <Badge
+            variant={getEnergyVariant(project.energy)}
+            className={cn(isCompleted && "bg-emerald-600/30 text-emerald-50")}
+          >
             {project.energy}
           </Badge>
-          <Badge variant="secondary">{project.stage}</Badge>
+          <Badge
+            variant="secondary"
+            className={cn(isCompleted && "bg-emerald-600/30 text-emerald-50")}
+          >
+            {project.stage}
+          </Badge>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- add a completion checkbox to each project card that animates into a pine green gradient when checked
- tune supporting badge and action styling so content stays legible against the completed gradient background

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d9d0e2afa8832c9975edc3cd9d575e