### PR TITLE
feat: add animated project card completion reward

### DIFF
--- a/components/ParticleBurst.tsx
+++ b/components/ParticleBurst.tsx
@@ -1,0 +1,169 @@
+import confetti, { type CreateTypes } from "canvas-confetti";
+
+export type ParticleBurstOrigin = { x: number; y: number };
+
+export interface ParticleBurstOptions {
+  container: HTMLElement;
+  origin: ParticleBurstOrigin;
+  particleCount?: number;
+  reducedMotion?: boolean;
+  palette?: string[];
+}
+
+type ExtendedConfetti = typeof confetti & {
+  shapeFromPath?: (path: string) => CreateTypes.Shape;
+  shapeFromText?: (input: {
+    text: string;
+    scalar?: number;
+    color?: string;
+    fontFamily?: string;
+  }) => CreateTypes.Shape;
+};
+
+const DEFAULT_COLORS = ["#1a6b52", "#22c55e", "#9ae6b4"];
+const extendedConfetti = confetti as ExtendedConfetti;
+
+let cachedShapes: {
+  circle?: CreateTypes.Shape;
+  xpGlyph?: CreateTypes.Shape;
+  leaf?: CreateTypes.Shape;
+} | null = null;
+
+function ensureShapes() {
+  if (cachedShapes) return cachedShapes;
+
+  const shapes: typeof cachedShapes = {};
+
+  if (extendedConfetti.shapeFromPath) {
+    shapes.circle = extendedConfetti.shapeFromPath(
+      "M 6 0 A 6 6 0 1 0 -6 0 A 6 6 0 1 0 6 0 Z"
+    );
+    shapes.leaf = extendedConfetti.shapeFromPath(
+      "M 0 -7 C 5 -7, 7 -2, 0 7 C -7 -2, -5 -7, 0 -7 Z"
+    );
+  }
+
+  if (extendedConfetti.shapeFromText) {
+    shapes.xpGlyph = extendedConfetti.shapeFromText({
+      text: "+XP",
+      scalar: 0.85,
+      fontFamily: "'Inter', 'Segoe UI', sans-serif",
+    });
+  }
+
+  cachedShapes = shapes;
+  return shapes;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function randomInRange(min: number, max: number) {
+  return Math.random() * (max - min) + min;
+}
+
+function buildShapePool(): Array<CreateTypes.Shape | "circle" | "square"> {
+  const shapes = ensureShapes();
+  const pool: Array<CreateTypes.Shape | "circle" | "square"> = [];
+  const circleShape = shapes.circle ?? "circle";
+  const xpShape = shapes.xpGlyph ?? "square";
+  const leafShape = shapes.leaf ?? "circle";
+
+  for (let i = 0; i < 6; i += 1) pool.push(circleShape);
+  for (let i = 0; i < 3; i += 1) pool.push(xpShape);
+  for (let i = 0; i < 2; i += 1) pool.push(leafShape);
+
+  return pool;
+}
+
+export function particleBurst({
+  container,
+  origin,
+  particleCount,
+  reducedMotion = false,
+  palette = DEFAULT_COLORS,
+}: ParticleBurstOptions): Promise<void> | void {
+  if (typeof window === "undefined" || reducedMotion) {
+    return;
+  }
+
+  if (!container) return;
+
+  const rect = container.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) return;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = rect.width * (window.devicePixelRatio || 1);
+  canvas.height = rect.height * (window.devicePixelRatio || 1);
+  canvas.style.width = `${rect.width}px`;
+  canvas.style.height = `${rect.height}px`;
+  canvas.style.position = "absolute";
+  canvas.style.inset = "0";
+  canvas.style.pointerEvents = "none";
+  canvas.style.mixBlendMode = "screen";
+  canvas.style.zIndex = "30";
+
+  container.appendChild(canvas);
+
+  const context = canvas.getContext("2d");
+  const dpr = window.devicePixelRatio || 1;
+  if (context) {
+    context.scale(dpr, dpr);
+  }
+
+  const normalizedX = clamp((origin.x - rect.left) / Math.max(rect.width, 1), 0, 1);
+  const normalizedY = clamp((origin.y - rect.top) / Math.max(rect.height, 1), 0, 1);
+
+  const lowPower =
+    typeof navigator !== "undefined" &&
+    typeof navigator.hardwareConcurrency === "number" &&
+    navigator.hardwareConcurrency > 0 &&
+    navigator.hardwareConcurrency <= 4;
+
+  const baseCount = particleCount ?? 70;
+  const effectiveCount = lowPower
+    ? Math.min(40, Math.max(24, Math.round(baseCount * 0.6)))
+    : clamp(baseCount, 40, 80);
+
+  const shapePool = buildShapePool();
+
+  const create = confetti.create(canvas, {
+    resize: false,
+    useWorker: true,
+  });
+
+  const burst = create({
+    particleCount: effectiveCount,
+    spread: randomInRange(60, 90),
+    startVelocity: randomInRange(35, 55),
+    decay: 0.92,
+    gravity: 0.9,
+    ticks: Math.round(randomInRange(120, 180)),
+    scalar: randomInRange(0.8, 1.2),
+    origin: {
+      x: normalizedX,
+      y: normalizedY,
+    },
+    colors: palette,
+    shapes: shapePool,
+    drift: randomInRange(-1.2, 1.2),
+  });
+
+  return new Promise(resolve => {
+    const cleanup = () => {
+      requestAnimationFrame(() => {
+        canvas.remove();
+        resolve();
+      });
+    };
+
+    if (burst && typeof (burst as PromiseLike<unknown>).then === "function") {
+      (burst as PromiseLike<unknown>).then(cleanup, cleanup);
+    } else {
+      cleanup();
+    }
+  });
+}
+
+export default particleBurst;

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ChangeEvent,
+} from "react";
+import { motion, useAnimationControls } from "framer-motion";
+import { Check, Sparkles, Undo2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { particleBurst } from "@/components/ParticleBurst";
+import { Shimmer } from "@/components/Shimmer";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
+const PARTICLE_COLORS = ["#1a6b52", "#22c55e", "#9ae6b4"];
+
+export interface ProjectCardProps {
+  id: string;
+  title: string;
+  timeRange?: string;
+  completedAt?: string | null;
+  completed?: boolean;
+  onComplete?: (id: string) => void;
+  onUndo?: (id: string) => void;
+  disabled?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function ProjectCard({
+  id,
+  title,
+  timeRange,
+  completedAt,
+  completed,
+  onComplete,
+  onUndo,
+  disabled = false,
+  className,
+  style,
+}: ProjectCardProps) {
+  const checkboxRef = useRef<HTMLInputElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const undoTimerRef = useRef<number | null>(null);
+  const controls = useAnimationControls();
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const completedFromProps = useMemo(() => {
+    if (typeof completed === "boolean") return completed;
+    return Boolean(completedAt);
+  }, [completed, completedAt]);
+
+  const [optimisticCompleted, setOptimisticCompleted] = useState<boolean | null>(
+    () => (completedFromProps ? true : null)
+  );
+  const [isCompleting, setIsCompleting] = useState(false);
+  const [showShimmer, setShowShimmer] = useState(false);
+  const [showStaticSparkle, setShowStaticSparkle] = useState(false);
+  const [showUndo, setShowUndo] = useState(false);
+
+  const isCompleted = (optimisticCompleted ?? completedFromProps) === true;
+  const isInteractionLocked = disabled || isCompleting;
+
+  useEffect(() => {
+    if (optimisticCompleted === null) return;
+    if (completedFromProps === optimisticCompleted) {
+      setOptimisticCompleted(null);
+    }
+  }, [completedFromProps, optimisticCompleted]);
+
+  useEffect(() => {
+    controls.set({ scale: 1, rotate: 0 });
+  }, [controls]);
+
+  useEffect(() => {
+    if (isCompleted && prefersReducedMotion) {
+      setShowStaticSparkle(true);
+    }
+    if (!isCompleted) {
+      setShowStaticSparkle(false);
+      setShowShimmer(false);
+    }
+  }, [isCompleted, prefersReducedMotion]);
+
+  useEffect(() => {
+    if (undoTimerRef.current) {
+      window.clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    if (isCompleted) {
+      setShowUndo(true);
+      undoTimerRef.current = window.setTimeout(() => {
+        setShowUndo(false);
+        undoTimerRef.current = null;
+      }, 2000);
+    } else {
+      setShowUndo(false);
+    }
+
+    return () => {
+      if (undoTimerRef.current) {
+        window.clearTimeout(undoTimerRef.current);
+        undoTimerRef.current = null;
+      }
+    };
+  }, [isCompleted]);
+
+  const runCompletionSequence = useCallback(async () => {
+    if (isInteractionLocked || isCompleted) return;
+
+    setIsCompleting(true);
+    setOptimisticCompleted(true);
+
+    try {
+      if (prefersReducedMotion) {
+        setShowStaticSparkle(true);
+      }
+
+      const cardEl = cardRef.current;
+      const checkboxEl = checkboxRef.current;
+      const cardRect = cardEl?.getBoundingClientRect();
+
+      if (!prefersReducedMotion) {
+        await controls.start({
+          scale: 0.98,
+          transition: { duration: 0.08, ease: [0.42, 0, 1, 1] },
+        });
+      }
+
+      setShowShimmer(!prefersReducedMotion);
+      onComplete?.(id);
+
+      if (!prefersReducedMotion && cardEl && cardRect) {
+        const checkboxRect = checkboxEl?.getBoundingClientRect();
+        const originRect = checkboxRect ?? cardRect;
+        void particleBurst({
+          container: cardEl,
+          origin: {
+            x: originRect.left + originRect.width / 2,
+            y: originRect.top + originRect.height / 2,
+          },
+          palette: PARTICLE_COLORS,
+          reducedMotion: prefersReducedMotion,
+        });
+
+        await controls.start({
+          scale: 1.04,
+          transition: { duration: 0.16, ease: [0.16, 1, 0.3, 1] },
+        });
+        await controls.start({
+          scale: 1,
+          transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] },
+        });
+      }
+    } finally {
+      setIsCompleting(false);
+    }
+  }, [
+    controls,
+    id,
+    isCompleted,
+    isInteractionLocked,
+    prefersReducedMotion,
+    onComplete,
+  ]);
+
+  const handleUndo = useCallback(() => {
+    if (!isCompleted || disabled) return;
+
+    setOptimisticCompleted(false);
+    setShowStaticSparkle(false);
+    setShowShimmer(false);
+    setShowUndo(false);
+
+    if (!prefersReducedMotion) {
+      void controls
+        .start({
+          scale: 0.94,
+          rotate: -3,
+          transition: { duration: 0.12, ease: [0.4, 0, 1, 1] },
+        })
+        .then(() =>
+          controls.start({
+            scale: 1,
+            rotate: 0,
+            transition: { duration: 0.18, ease: [0.16, 1, 0.3, 1] },
+          })
+        );
+    }
+
+    onUndo?.(id);
+  }, [controls, disabled, id, isCompleted, onUndo, prefersReducedMotion]);
+
+  const handleCheckboxChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      if (event.target.checked) {
+        void runCompletionSequence();
+      } else {
+        handleUndo();
+      }
+    },
+    [handleUndo, runCompletionSequence]
+  );
+
+  const baseCardClasses = cn(
+    "relative isolate flex w-full items-center gap-3 overflow-hidden rounded-xl border px-3 py-2 shadow-[0_14px_32px_rgba(11,24,18,0.38)] transition-colors duration-200",
+    "focus-within:ring-1 focus-within:ring-emerald-400/60",
+    isCompleted
+      ? "border-[#1a6b52]/60 bg-gradient-to-br from-[#0e3b2e] to-[#1a6b52] text-[#E6F4EF]"
+      : "border-white/10 bg-zinc-900/70 text-white hover:border-emerald-400/40",
+    disabled ? "opacity-70" : "",
+    className
+  );
+
+  const timeClass = cn(
+    "text-xs",
+    isCompleted ? "text-[#E6F4EF]/80" : "text-zinc-300/70"
+  );
+
+  return (
+    <motion.div
+      ref={cardRef}
+      data-testid="project-card"
+      data-completed={isCompleted ? "true" : "false"}
+      role="group"
+      className={baseCardClasses}
+      style={style}
+      animate={controls}
+      initial={false}
+    >
+      <label
+        className={cn(
+          "relative flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md border transition-colors",
+          isCompleted
+            ? "border-[#E6F4EF]/40 bg-emerald-400/20"
+            : "border-emerald-400/30 bg-black/40",
+          disabled
+            ? "cursor-not-allowed"
+            : "cursor-pointer focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-emerald-300/80"
+        )}
+      >
+        <input
+          ref={checkboxRef}
+          type="checkbox"
+          className="peer sr-only"
+          aria-label={`Mark ${title} complete`}
+          checked={isCompleted}
+          onChange={handleCheckboxChange}
+          disabled={isInteractionLocked}
+        />
+        <motion.span
+          className="pointer-events-none absolute inset-0 rounded-md"
+          initial={false}
+          animate={{
+            backgroundColor: isCompleted ? "rgba(34,197,94,0.35)" : "rgba(12,24,20,0.65)",
+          }}
+          transition={{ duration: 0.18, ease: [0.4, 0, 0.2, 1] }}
+        />
+        <motion.span
+          className="pointer-events-none text-[#E6F4EF]"
+          initial={false}
+          animate={{ scale: isCompleted ? [0.6, 1.05, 1] : 0.8, opacity: isCompleted ? 1 : 0 }}
+          transition={{ duration: 0.24, ease: [0.16, 1, 0.3, 1] }}
+        >
+          <Check className="h-4 w-4" strokeWidth={2.5} />
+        </motion.span>
+      </label>
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold leading-tight">{title}</p>
+        {timeRange ? <p className={timeClass}>{timeRange}</p> : null}
+      </div>
+
+      {showStaticSparkle && (
+        <Sparkles
+          aria-hidden
+          className="h-4 w-4 flex-shrink-0 text-[#E6F4EF]/80"
+        />
+      )}
+
+      {showUndo && (
+        <button
+          type="button"
+          onClick={handleUndo}
+          className="flex items-center gap-1 rounded-full bg-black/30 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-100/90 shadow-inner shadow-emerald-500/20 transition-opacity hover:opacity-100"
+        >
+          <Undo2 className="h-3 w-3" />
+          Undo
+        </button>
+      )}
+
+      {showShimmer && !prefersReducedMotion ? (
+        <Shimmer onComplete={() => setShowShimmer(false)} />
+      ) : null}
+    </motion.div>
+  );
+}
+
+export default ProjectCard;

--- a/components/Shimmer.tsx
+++ b/components/Shimmer.tsx
@@ -1,0 +1,43 @@
+import { motion } from "framer-motion";
+import { useEffect } from "react";
+
+interface ShimmerProps {
+  durationMs?: number;
+  onComplete?: () => void;
+}
+
+export function Shimmer({ durationMs = 260, onComplete }: ShimmerProps) {
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      onComplete?.();
+    }, durationMs);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [durationMs, onComplete]);
+
+  return (
+    <motion.div
+      role="presentation"
+      className="pointer-events-none absolute inset-0 overflow-hidden"
+      style={{ borderRadius: "inherit" }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: [0, 0.6, 0] }}
+      transition={{ duration: durationMs / 1000, ease: "easeOut", times: [0, 0.35, 1] }}
+    >
+      <motion.div
+        className="absolute inset-y-0 left-0 w-1/2"
+        style={{
+          background:
+            "linear-gradient(120deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.25) 45%, rgba(255,255,255,0) 100%)",
+          mixBlendMode: "screen",
+        }}
+        initial={{ x: "-120%" }}
+        animate={{ x: "120%" }}
+        transition={{ duration: durationMs / 1000, ease: "easeOut" }}
+      />
+    </motion.div>
+  );
+}
+
+export default Shimmer;

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(QUERY);
+
+    const update = () => {
+      setPrefersReducedMotion(mediaQueryList.matches);
+    };
+
+    update();
+
+    const listener = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    if (typeof mediaQueryList.addEventListener === "function") {
+      mediaQueryList.addEventListener("change", listener);
+    } else {
+      mediaQueryList.addListener(listener);
+    }
+
+    return () => {
+      if (typeof mediaQueryList.removeEventListener === "function") {
+        mediaQueryList.removeEventListener("change", listener);
+      } else {
+        mediaQueryList.removeListener(listener);
+      }
+    };
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export default usePrefersReducedMotion;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-virtual": "^3.13.12",
     "autoprefixer": "^10.4.21",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
@@ -49,6 +50,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.0",
     "@tailwindcss/postcss": "^4.0.0",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      canvas-confetti:
+        specifier: ^1.9.3
+        version: 1.9.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -84,6 +87,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.1.12
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.11
@@ -129,6 +135,18 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1243,8 +1261,30 @@ packages:
   '@tanstack/virtual-core@3.13.12':
     resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1478,9 +1518,17 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1488,6 +1536,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1595,6 +1646,9 @@ packages:
 
   caniuse-lite@1.0.30001737:
     resolution: {integrity: sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==}
+
+  canvas-confetti@1.9.3:
+    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1708,6 +1762,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
@@ -1718,6 +1776,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -2368,6 +2429,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
@@ -2562,6 +2627,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2579,6 +2648,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3119,6 +3191,16 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/runtime@7.28.4': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -4046,10 +4128,33 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.12': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.11))(@types/react@19.1.11)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.11
+      '@types/react-dom': 19.1.7(@types/react@19.1.11)
+
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -4290,15 +4395,23 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -4438,6 +4551,8 @@ snapshots:
 
   caniuse-lite@1.0.30001737: {}
 
+  canvas-confetti@1.9.3: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -4549,6 +4664,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
@@ -4556,6 +4673,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@16.6.1: {}
 
@@ -5371,6 +5490,8 @@ snapshots:
     dependencies:
       react: 19.1.1
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.18:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -5552,6 +5673,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5568,6 +5695,8 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.1.11)(react@19.1.1):
     dependencies:

--- a/src/components/schedule/FocusTimeline.tsx
+++ b/src/components/schedule/FocusTimeline.tsx
@@ -1,40 +1,96 @@
 "use client";
 
-import {
-  Children,
-  cloneElement,
-  isValidElement,
-  type ReactNode,
-  type CSSProperties,
-} from "react";
-import { cn } from "@/lib/utils";
+import { useMemo, type ReactNode } from "react";
+import { ProjectCard } from "@/components/ProjectCard";
 import { DayTimeline } from "./DayTimeline";
 
+export interface FocusTimelineEntry {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  completedAt?: string | null;
+  completed?: boolean;
+  isPending?: boolean;
+}
+
 interface FocusTimelineProps {
+  entries?: FocusTimelineEntry[];
+  onComplete?: (id: string) => void;
+  onUndo?: (id: string) => void;
   children?: ReactNode;
 }
 
-export function FocusTimeline({ children }: FocusTimelineProps) {
+export function FocusTimeline({
+  entries = [],
+  onComplete,
+  onUndo,
+  children,
+}: FocusTimelineProps) {
   const now = new Date();
   const startHour = now.getHours() + now.getMinutes() / 60;
   const endHour = startHour + 3;
+  const pxPerMin = 2;
 
-  const enhancedChildren = Children.map(children, child => {
-    if (!isValidElement(child)) return child;
-    const props = child.props as { className?: string; style?: CSSProperties };
-    return cloneElement(
-      child as React.ReactElement<{ className?: string; style?: CSSProperties }>,
-      {
-        className: cn(props.className, "px-3 py-2"),
-        style: { ...props.style, boxShadow: "var(--elev-overlay)" },
-      }
+  const sortedEntries = useMemo(() => {
+    return [...entries].sort(
+      (a, b) => a.start.getTime() - b.start.getTime()
     );
-  });
+  }, [entries]);
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    []
+  );
 
   return (
     <div className="-ml-4 -mr-2 sm:mx-0">
-      <DayTimeline startHour={startHour} endHour={endHour} date={now}>
-        {enhancedChildren}
+      <DayTimeline
+        startHour={startHour}
+        endHour={endHour}
+        pxPerMin={pxPerMin}
+        date={now}
+      >
+        {sortedEntries.map(entry => {
+          const startOffsetMin =
+            (entry.start.getHours() * 60 + entry.start.getMinutes()) -
+            startHour * 60;
+          const durationMinutes = Math.max(
+            1,
+            (entry.end.getTime() - entry.start.getTime()) / 60000
+          );
+          const top = Math.max(0, startOffsetMin * pxPerMin);
+          const height = Math.max(durationMinutes * pxPerMin, 60);
+          const timeRange = `${timeFormatter.format(entry.start)} – ${timeFormatter.format(entry.end)}`;
+
+          return (
+            <div
+              key={entry.id}
+              className="absolute left-16 right-3 flex items-stretch"
+              style={{ top, height }}
+            >
+              <ProjectCard
+                id={entry.id}
+                title={entry.title}
+                timeRange={timeRange}
+                completedAt={entry.completedAt}
+                completed={entry.completed}
+                disabled={entry.isPending}
+                className="h-full w-full"
+                style={{ height: "100%" }}
+                onComplete={
+                  onComplete ? () => onComplete(entry.id) : undefined
+                }
+                onUndo={onUndo ? () => onUndo(entry.id) : undefined}
+              />
+            </div>
+          );
+        })}
+        {children}
       </DayTimeline>
     </div>
   );

--- a/test/ui/ProjectCard.spec.tsx
+++ b/test/ui/ProjectCard.spec.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { ProjectCard } from "@/components/ProjectCard";
+
+vi.mock("canvas-confetti", () => {
+  const factory = () => Promise.resolve();
+  const create = vi.fn(() => () => Promise.resolve());
+  return {
+    __esModule: true,
+    default: Object.assign(factory, {
+      create,
+      shapeFromPath: vi.fn(() => ({})),
+      shapeFromText: vi.fn(() => ({})),
+    }),
+  };
+});
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+if (typeof window !== "undefined" && !window.requestAnimationFrame) {
+  window.requestAnimationFrame = callback => window.setTimeout(() => callback(Date.now()), 0);
+}
+
+describe("ProjectCard", () => {
+  beforeEach(() => {
+    mockMatchMedia(false);
+  });
+
+  it("marks the project as completed when the checkbox is toggled", async () => {
+    const handleComplete = vi.fn();
+
+    render(
+      <ProjectCard id="card-1" title="Write summary" onComplete={handleComplete} />
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /mark write summary complete/i,
+    });
+
+    fireEvent.click(checkbox);
+
+    const card = screen.getByTestId("project-card");
+
+    await waitFor(() => {
+      expect(card).toHaveAttribute("data-completed", "true");
+    });
+
+    expect(handleComplete).toHaveBeenCalledWith("card-1");
+  });
+
+  it("skips particle canvas when reduced motion is preferred", async () => {
+    mockMatchMedia(true);
+
+    render(<ProjectCard id="card-2" title="Deep work" />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /mark deep work complete/i,
+    });
+
+    fireEvent.click(checkbox);
+
+    const card = screen.getByTestId("project-card");
+
+    await waitFor(() => {
+      expect(card).toHaveAttribute("data-completed", "true");
+    });
+
+    expect(card.querySelector("canvas")).toBeNull();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "paths": {
       "@/*": ["./src/*", "./components/*", "./lib/*"],
       "@/components/*": ["./src/components/*", "./components/*"],
+      "@/hooks/*": ["./hooks/*", "./src/hooks/*"],
       "@/lib/*": ["./src/lib/*", "./lib/*"],
       "@/types/*": ["./src/types/*"]
     }


### PR DESCRIPTION
## Summary
- add an animated ProjectCard microinteraction with particle burst, shimmer sweep, gradient completion state, and undo affordance
- add particleBurst utility, shimmer overlay, and a prefers-reduced-motion hook to drive the animation sequence safely
- update the focus timeline to render the enhanced ProjectCard entries and cover the behaviour with a React Testing Library spec

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d9d2d92bb8832cbde894f1feac78c9