### PR TITLE
Simplify Goal folder project sheet layout

### DIFF
--- a/src/components/goals/Folder.module.css
+++ b/src/components/goals/Folder.module.css
@@ -173,18 +173,14 @@
     rgba(15, 23, 42, 0.35);
 }
 
-.paper {
+.paper,
+.paperBare {
   position: absolute;
   inset: calc(26px * var(--folder-scale, 1)) calc(26px * var(--folder-scale, 1))
     calc(30px * var(--folder-scale, 1));
   display: flex;
   flex-direction: column;
-  gap: clamp(4px, calc(10px * var(--folder-scale, 1)), 18px);
   border-radius: clamp(9px, calc(15px * var(--folder-scale, 1)), 22px);
-  background: var(--paper-color, rgba(255, 255, 255, 0.96));
-  box-shadow: 0 calc(20px * var(--folder-scale, 1)) calc(40px * var(--folder-scale, 1))
-    rgba(15, 23, 42, 0.14);
-  padding: clamp(6px, calc(12px * var(--folder-scale, 1)), 16px);
   transform: translate3d(0, calc(24px * var(--folder-scale, 1)), 0) scale(0.9);
   opacity: 0;
   pointer-events: none;
@@ -201,7 +197,23 @@
   z-index: var(--paper-z);
 }
 
-.open .paper {
+.paper {
+  gap: clamp(4px, calc(10px * var(--folder-scale, 1)), 18px);
+  background: var(--paper-color, rgba(255, 255, 255, 0.96));
+  box-shadow: 0 calc(20px * var(--folder-scale, 1)) calc(40px * var(--folder-scale, 1))
+    rgba(15, 23, 42, 0.14);
+  padding: clamp(6px, calc(12px * var(--folder-scale, 1)), 16px);
+}
+
+.paperBare {
+  gap: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+.open .paper,
+.open .paperBare {
   opacity: 1;
   pointer-events: auto;
   transform: translate3d(
@@ -213,6 +225,10 @@
   box-shadow: 0 calc(26px * var(--folder-scale, 1)) calc(52px * var(--folder-scale, 1))
     rgba(15, 23, 42, 0.2);
   transition-delay: calc(var(--paper-delay) + 0.04s);
+}
+
+.open .paperBare {
+  box-shadow: none;
 }
 
 .paper:hover {

--- a/src/components/goals/Folder.tsx
+++ b/src/components/goals/Folder.tsx
@@ -14,6 +14,7 @@ type FolderProps = {
   items?: ReactNode[];
   label?: ReactNode;
   className?: string;
+  bareItems?: boolean;
 };
 
 const MAX_ITEMS = 5;
@@ -60,6 +61,7 @@ export function Folder({
   items = [],
   label,
   className,
+  bareItems = false,
 }: FolderProps) {
   const visibleItems = items.filter((item) => item != null).slice(0, MAX_ITEMS);
   const positions = computePositions(visibleItems.length);
@@ -146,7 +148,9 @@ export function Folder({
             return (
               <div
                 key={index}
-                className={styles.paper}
+                className={cn(
+                  bareItems ? styles.paperBare : styles.paper
+                )}
                 onMouseMove={(event) => handlePaperMouseMove(event, index)}
                 onMouseLeave={(event) => handlePaperMouseLeave(event, index)}
                 style={magnetStyle}

--- a/src/components/goals/GoalFolderCard.tsx
+++ b/src/components/goals/GoalFolderCard.tsx
@@ -60,20 +60,16 @@ export function GoalFolderCard({
     ? groupedProjects.map((sheet, sheetIndex) => (
         <div
           key={sheet[0]?.id ?? `sheet-${sheetIndex}`}
-          className="flex h-full w-full flex-col text-left text-slate-900"
+          className="grid h-full w-full grid-cols-2 gap-1 overflow-y-auto text-left text-slate-900"
         >
-          <div className="flex-1 overflow-hidden rounded-xl border border-slate-200/60 bg-white/85 p-1.5 shadow-sm">
-            <div className="grid h-full grid-cols-2 gap-1 overflow-y-auto pr-0.5">
-              {sheet.map((project) => (
-                <div
-                  key={project.id}
-                  className="flex aspect-square items-center justify-center rounded-lg bg-white text-center text-[9px] font-semibold leading-tight text-slate-900 shadow"
-                >
-                  <span className="line-clamp-3 px-1">{project.name}</span>
-                </div>
-              ))}
+          {sheet.map((project) => (
+            <div
+              key={project.id}
+              className="flex aspect-square items-center justify-center rounded-lg bg-white text-center text-[9px] font-semibold leading-tight text-slate-900 shadow"
+            >
+              <span className="line-clamp-3 px-1">{project.name}</span>
             </div>
-          </div>
+          ))}
         </div>
       ))
     : [

--- a/src/components/goals/GoalFolderCard.tsx
+++ b/src/components/goals/GoalFolderCard.tsx
@@ -65,9 +65,9 @@ export function GoalFolderCard({
           {sheet.map((project) => (
             <div
               key={project.id}
-              className="flex aspect-square items-center justify-center rounded-lg bg-white text-center text-[9px] font-semibold leading-tight text-slate-900 shadow"
+              className="flex aspect-square items-center justify-center rounded-lg bg-white px-1 text-center text-[9px] font-semibold leading-tight text-slate-900 shadow"
             >
-              <span className="line-clamp-3 px-1">{project.name}</span>
+              {project.name}
             </div>
           ))}
         </div>

--- a/src/components/goals/GoalFolderCard.tsx
+++ b/src/components/goals/GoalFolderCard.tsx
@@ -107,6 +107,7 @@ export function GoalFolderCard({
         items={folderItems}
         size={size}
         label={folderLabel}
+        bareItems
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- simplify project sheet rendering so only project tiles remain visible within each sheet

## Testing
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68d9e27ccaf0832cbd1b8c7a7cb1713c