### PR TITLE
Add confetti animation when marking schedule projects complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-query": "^5.85.5",
     "@tanstack/react-virtual": "^3.13.12",
     "autoprefixer": "^10.4.21",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      canvas-confetti:
+        specifier: ^1.9.3
+        version: 1.9.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1595,6 +1598,9 @@ packages:
 
   caniuse-lite@1.0.30001737:
     resolution: {integrity: sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==}
+
+  canvas-confetti@1.9.3:
+    resolution: {integrity: sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -4437,6 +4443,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001737: {}
+
+  canvas-confetti@1.9.3: {}
 
   chai@5.3.3:
     dependencies:

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -1047,6 +1047,25 @@ export default function SchedulePage() {
     return map
   }, [instances])
 
+  const launchCompletionConfetti = useCallback(() => {
+    if (prefersReducedMotion) return
+
+    void import('canvas-confetti')
+      .then(({ default: confetti }) =>
+        confetti({
+          particleCount: 140,
+          spread: 70,
+          scalar: 0.9,
+          disableForReducedMotion: true,
+          colors: ['#22c55e', '#16a34a', '#bbf7d0'],
+          origin: { y: 0.6 },
+        })
+      )
+      .catch(error => {
+        console.error('Failed to load confetti', error)
+      })
+  }, [prefersReducedMotion])
+
   const handleToggleInstanceCompletion = useCallback(
     async (instanceId: string, nextStatus: 'completed' | 'scheduled') => {
       if (!userId) {
@@ -1081,6 +1100,10 @@ export default function SchedulePage() {
               : inst
           )
         )
+
+        if (nextStatus === 'completed') {
+          launchCompletionConfetti()
+        }
       } catch (error) {
         console.error(error)
       } finally {
@@ -1091,7 +1114,7 @@ export default function SchedulePage() {
         })
       }
     },
-    [userId, setInstances]
+    [userId, setInstances, launchCompletionConfetti]
   )
 
   const renderInstanceActions = (


### PR DESCRIPTION
## Summary
- add the canvas-confetti dependency to support a celebratory animation
- launch a green confetti burst when a schedule project is marked complete while respecting reduced motion preferences

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da3a97c814832c8bd5de8b5e4afd28