### PR TITLE
Fix dashboard monument cards goal count display

### DIFF
--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -23,7 +23,7 @@ export function MonumentContainer() {
                 id: m.id,
                 emoji: m.emoji || "\uD83C\uDFDB\uFE0F",
                 title: m.title,
-                stats: "0 Goals",
+                stats: `${m.goalCount} Goal${m.goalCount === 1 ? "" : "s"}`,
               }))}
             />
           </div>


### PR DESCRIPTION
## Summary
- extend the monuments list loader to fetch related goal counts for each monument
- show the formatted goal total on the dashboard monument cards instead of a hardcoded value

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68dcbdf2f7a0832c82a030c787f292e3