### PR TITLE
Preload monument detail on server

### DIFF
--- a/src/app/(app)/monuments/[id]/page.tsx
+++ b/src/app/(app)/monuments/[id]/page.tsx
@@ -1,11 +1,35 @@
-"use client";
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
 
-import { useParams } from "next/navigation";
+import { getSupabaseServer } from "@/lib/supabase";
 import { MonumentDetail } from "@/components/monuments/MonumentDetail";
 
-export default function MonumentDetailPage() {
-  const params = useParams();
-  const id = params.id as string;
-  return <MonumentDetail id={id} />;
+interface MonumentDetailPageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default async function MonumentDetailPage({
+  params,
+}: MonumentDetailPageProps) {
+  const cookieStore = cookies();
+  const supabase = getSupabaseServer(cookieStore);
+
+  if (!supabase) {
+    redirect("/auth");
+  }
+
+  const { data: monument, error } = await supabase
+    .from("monuments")
+    .select("id,title,emoji")
+    .eq("id", params.id)
+    .single();
+
+  if (error || !monument) {
+    notFound();
+  }
+
+  return <MonumentDetail monument={monument} />;
 }
 

--- a/src/components/MonumentGridWithSharedTransition.tsx
+++ b/src/components/MonumentGridWithSharedTransition.tsx
@@ -4,12 +4,12 @@ import { useState, useEffect, useRef } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
-import { MonumentDetail } from "@/components/monuments/MonumentDetail";
+import {
+  MonumentDetail,
+  type MonumentDetailMonument,
+} from "@/components/monuments/MonumentDetail";
 
-export interface Monument {
-  id: string;
-  emoji: string;
-  title: string;
+export interface Monument extends MonumentDetailMonument {
   stats: string; // e.g. "12 Goals"
 }
 
@@ -50,7 +50,7 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
             className="card flex aspect-square w-full flex-col items-center justify-center p-1 transition-colors hover:bg-white/5"
           >
             <motion.div layoutId={`emoji-${m.id}`} className="mb-1 text-lg">
-              {m.emoji}
+              {m.emoji ?? "\uD83C\uDFDB\uFE0F"}
             </motion.div>
             <motion.h3
               layoutId={`title-${m.id}`}
@@ -92,7 +92,7 @@ export function MonumentGridWithSharedTransition({ monuments }: MonumentGridProp
               >
                 <X className="h-4 w-4" />
               </Button>
-              <MonumentDetail id={selected.id} />
+              <MonumentDetail monument={selected} />
             </motion.div>
           </motion.div>
         )}

--- a/src/components/monuments/MonumentDetail.tsx
+++ b/src/components/monuments/MonumentDetail.tsx
@@ -1,129 +1,29 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, BatteryCharging, Flame } from "lucide-react";
 
-import { getSupabaseBrowser } from "@/lib/supabase";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import ActivityPanel from "./ActivityPanel";
 import { FilteredGoalsGrid } from "@/components/goals/FilteredGoalsGrid";
 import { MonumentNotesGrid } from "@/components/notes/MonumentNotesGrid";
 
-interface Monument {
+export interface MonumentDetailMonument {
   id: string;
   title: string;
   emoji: string | null;
 }
 
 interface MonumentDetailProps {
-  id: string;
+  monument: MonumentDetailMonument;
 }
 
-export function MonumentDetail({ id }: MonumentDetailProps) {
-  const [monument, setMonument] = useState<Monument | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const supabase = getSupabaseBrowser();
+export function MonumentDetail({ monument }: MonumentDetailProps) {
   const router = useRouter();
   const noteInputRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function load() {
-      if (!supabase || !id) return;
-      setLoading(true);
-      setError(null);
-      try {
-        await supabase.auth.getSession();
-        const { data, error } = await supabase
-          .from("monuments")
-          .select("id,title,emoji")
-          .eq("id", id)
-          .single();
-        if (!cancelled) {
-          if (error) {
-            setError("Failed to load monument");
-          } else {
-            setMonument(data);
-          }
-          setLoading(false);
-        }
-      } catch {
-        if (!cancelled) {
-          setError("Failed to load monument");
-          setLoading(false);
-        }
-      }
-    }
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [supabase, id]);
-
-  if (loading) {
-    return (
-      <main className="px-4 py-6 sm:px-6 lg:px-8">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-          <Skeleton className="h-8 w-32 rounded-full bg-white/10" />
-          <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-[#141414] p-6 shadow-[0_30px_90px_-45px_rgba(0,0,0,0.85)] sm:p-8">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.14),_transparent_65%)] opacity-60" />
-            <div className="relative flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-start gap-4">
-                <Skeleton className="h-16 w-16 rounded-2xl bg-white/10" />
-                <div className="space-y-2">
-                  <Skeleton className="h-6 w-48 rounded-full" />
-                  <Skeleton className="h-4 w-36 rounded-full" />
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Skeleton className="h-9 w-28 rounded-full" />
-                <Skeleton className="h-9 w-32 rounded-full" />
-              </div>
-            </div>
-            <div className="relative mt-6 grid gap-3 sm:grid-cols-3">
-              {Array.from({ length: 3 }).map((_, index) => (
-                <div
-                  key={index}
-                  className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur"
-                >
-                  <Skeleton className="h-4 w-24 rounded-full" />
-                  <Skeleton className="mt-3 h-4 w-20 rounded-full" />
-                </div>
-              ))}
-            </div>
-          </div>
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
-            <Skeleton className="h-64 rounded-3xl bg-[#141414]" />
-            <Skeleton className="h-64 rounded-3xl bg-[#141414]" />
-          </div>
-        </div>
-      </main>
-    );
-  }
-
-  if (error || !monument) {
-    return (
-      <main className="px-4 py-6 sm:px-6 lg:px-8">
-        <div className="mx-auto w-full max-w-3xl">
-          <div className="rounded-3xl border border-white/10 bg-gradient-to-br from-[#080808] via-[#101010] to-[#181818] p-8 text-center shadow-[0_24px_60px_-30px_rgba(0,0,0,0.8)]">
-            <h2 className="text-lg font-semibold text-white">We couldn&apos;t find that monument</h2>
-            <p className="mt-2 text-sm text-white/70">
-              {error || "The monument you&apos;re looking for may have been removed."}
-            </p>
-            <div className="mt-5 flex justify-center">
-              <Button asChild size="sm" className="rounded-full px-6">
-                <Link href="/monuments">Back to Monuments</Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </main>
-    );
-  }
+  const { id } = monument;
 
   const handleAddNote = () => {
     noteInputRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/src/components/ui/MonumentContainer.tsx
+++ b/src/components/ui/MonumentContainer.tsx
@@ -21,7 +21,7 @@ export function MonumentContainer() {
             <MonumentGridWithSharedTransition
               monuments={monuments.map<MonumentCard>((m) => ({
                 id: m.id,
-                emoji: m.emoji || "\uD83C\uDFDB\uFE0F",
+                emoji: m.emoji ?? null,
                 title: m.title,
                 stats: `${m.goalCount} Goal${m.goalCount === 1 ? "" : "s"}`,
               }))}


### PR DESCRIPTION
## Summary
- load monument details on the server route using Supabase cookies and return 404 for missing records
- refactor the monument detail UI into a client component that accepts preloaded data
- update the shared transition overlay to reuse the refactored monument detail component with the full monument payload

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dccbc9985c832c960077564b02120d