### PR TITLE
Add animated indicator to iOS segmented control

### DIFF
--- a/src/components/schedule/SegmentedControlIOS.tsx
+++ b/src/components/schedule/SegmentedControlIOS.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+
 import { cn } from "@/lib/utils";
 
 interface SegmentedControlIOSProps {
@@ -17,10 +19,78 @@ export function SegmentedControlIOS({
   value,
   onChange,
 }: SegmentedControlIOSProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const refs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [indicatorRect, setIndicatorRect] = useState<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const segmentsKey = segments.join("|");
+
+  useLayoutEffect(() => {
+    const updateRect = () => {
+      const container = containerRef.current;
+      const activeButton = refs.current[value];
+
+      if (!container || !activeButton) {
+        setIndicatorRect(null);
+        return;
+      }
+
+      const containerRect = container.getBoundingClientRect();
+      const buttonRect = activeButton.getBoundingClientRect();
+
+      setIndicatorRect({
+        left: buttonRect.left - containerRect.left,
+        top: buttonRect.top - containerRect.top,
+        width: buttonRect.width,
+        height: buttonRect.height,
+      });
+    };
+
+    updateRect();
+    window.addEventListener("resize", updateRect);
+
+    return () => {
+      window.removeEventListener("resize", updateRect);
+    };
+  }, [value, segmentsKey]);
 
   return (
-    <div role="tablist" className="flex rounded-md bg-zinc-900 p-1">
+    <div
+      ref={containerRef}
+      role="tablist"
+      className="relative flex overflow-hidden rounded-md bg-zinc-900 p-1"
+    >
+      {indicatorRect ? (
+        <motion.div
+          aria-hidden
+          className="absolute rounded-md bg-zinc-800 pointer-events-none"
+          initial={false}
+          animate={{
+            x: indicatorRect.left,
+            y: indicatorRect.top,
+            width: indicatorRect.width,
+            height: indicatorRect.height,
+          }}
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { type: "spring", stiffness: 360, damping: 32 }
+          }
+          style={{
+            left: 0,
+            top: 0,
+            zIndex: 0,
+            width: indicatorRect.width,
+            height: indicatorRect.height,
+          }}
+        />
+      ) : null}
       {segments.map((label, i) => (
         <button
           key={label}
@@ -31,8 +101,8 @@ export function SegmentedControlIOS({
           role="tab"
           aria-selected={value === i}
           className={cn(
-            "flex-1 rounded-md px-2 py-1 text-xs",
-            value === i ? "bg-zinc-800 text-white" : "text-zinc-400"
+            "relative z-10 flex-1 rounded-md px-2 py-1 text-xs transition-colors",
+            value === i ? "text-white" : "text-zinc-400"
           )}
           onClick={() => onChange?.(i)}
         >


### PR DESCRIPTION
## Summary
- add a framer-motion powered pill indicator that slides behind the active iOS segmented control button
- measure the active button rect to keep the indicator aligned within the rounded container and respect reduced-motion preferences
- update button styles to rely on the indicator background while keeping text contrast on the active segment

## Testing
- `vitest run test/env.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68dd4ca1ad70832cb05b5d540ea27022