### PR TITLE
Implement dynamic habits dashboard and creation form

### DIFF
--- a/src/app/(app)/habits/new/page.tsx
+++ b/src/app/(app)/habits/new/page.tsx
@@ -1,20 +1,287 @@
 "use client";
 
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageHeader } from "@/components/ui";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useToastHelpers } from "@/components/ui/toast";
+import { createRecord } from "@/lib/db";
+import type {
+  HabitInput,
+  HabitRecurrence,
+  HabitRow,
+  HabitType,
+} from "@/lib/types/habit";
+import { cn } from "@/lib/utils";
+
+const HABIT_TYPE_OPTIONS: { value: HabitType; label: string; helper: string }[] = [
+  {
+    value: "HABIT",
+    label: "Habit",
+    helper: "Track ongoing routines that move you forward.",
+  },
+  {
+    value: "CHORE",
+    label: "Chore",
+    helper: "Manage maintenance tasks that keep life running.",
+  },
+];
+
+const RECURRENCE_OPTIONS: {
+  value: HabitRecurrence;
+  label: string;
+  helper: string;
+}[] = [
+  { value: "daily", label: "Daily", helper: "Repeats every day." },
+  { value: "weekly", label: "Weekly", helper: "Repeats every week." },
+  {
+    value: "bi-weekly",
+    label: "Bi-weekly",
+    helper: "Occurs every other week.",
+  },
+  { value: "monthly", label: "Monthly", helper: "Repeats once a month." },
+  {
+    value: "bi-monthly",
+    label: "Bi-monthly",
+    helper: "Happens every other month.",
+  },
+  { value: "yearly", label: "Yearly", helper: "Repeats once a year." },
+  {
+    value: "every x days",
+    label: "Custom cadence",
+    helper: "Use this for flexible spacing (set details in your notes).",
+  },
+];
+
+type FormState = {
+  name: string;
+  description: string;
+  habitType: HabitType;
+  recurrence: HabitRecurrence;
+};
+
+type FormErrors = Partial<Record<keyof FormState, string>>;
 
 export default function NewHabitPage() {
+  const router = useRouter();
+  const toast = useToastHelpers();
+  const [form, setForm] = useState<FormState>({
+    name: "",
+    description: "",
+    habitType: "HABIT",
+    recurrence: "daily",
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setServerError(null);
+
+    const nextErrors: FormErrors = {};
+    if (!form.name.trim()) {
+      nextErrors.name = "Give your habit a name.";
+    }
+
+    if (!form.recurrence) {
+      nextErrors.recurrence = "Pick how often this habit repeats.";
+    }
+
+    setErrors(nextErrors);
+
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    const payload: HabitInput = {
+      name: form.name.trim(),
+      description: form.description.trim() || null,
+      habit_type: form.habitType,
+      recurrence: form.recurrence,
+    };
+
+    setSubmitting(true);
+    try {
+      const { error } = await createRecord<HabitRow>(
+        "habits",
+        payload,
+        { includeUpdatedAt: true }
+      );
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      toast.success("Habit created", "Your new routine is ready to track.");
+      router.push("/habits");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to create habit.";
+      setServerError(message);
+      toast.error("Could not create habit", message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gray-900 text-white">
-        <div className="container mx-auto px-4 py-6">
+      <div className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto w-full max-w-3xl px-4 py-10 sm:px-6 lg:px-8">
           <PageHeader
-            title="Create New Habit"
-            description="Build a new habit to improve your life"
+            title="Create a habit"
+            description="Define the cadence and intent for a new routine you want to keep."
           />
-          <div className="text-center py-12">
-            <p className="text-gray-400">Habit creation form coming soon...</p>
-          </div>
+
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-8 rounded-2xl border border-border/60 bg-card/60 p-6 shadow-sm sm:p-8"
+          >
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="habit-name">Habit name</Label>
+                <Input
+                  id="habit-name"
+                  placeholder="e.g. Morning reading"
+                  value={form.name}
+                  onChange={(event) =>
+                    setForm((prev) => ({ ...prev, name: event.target.value }))
+                  }
+                  aria-invalid={errors.name ? "true" : "false"}
+                  aria-describedby={errors.name ? "habit-name-error" : undefined}
+                />
+                {errors.name && (
+                  <p
+                    id="habit-name-error"
+                    className="text-sm text-destructive"
+                  >
+                    {errors.name}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="habit-description">Description (optional)</Label>
+                <Textarea
+                  id="habit-description"
+                  placeholder="What does success look like for this routine?"
+                  value={form.description}
+                  onChange={(event) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      description: event.target.value,
+                    }))
+                  }
+                  className="min-h-[120px]"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Add context, milestones, or instructions you want to remember.
+                </p>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Habit type</Label>
+                  <Select
+                    value={form.habitType}
+                    onValueChange={(value) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        habitType: value as HabitType,
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="h-11 rounded-xl border border-border/60 bg-background text-left text-sm text-foreground focus:border-primary focus-visible:ring-0">
+                      <SelectValue placeholder="Select type" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#0b101b] text-sm text-white">
+                      {HABIT_TYPE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div>
+                            <p className="font-medium text-white">{option.label}</p>
+                            <p className="text-xs text-zinc-400">{option.helper}</p>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Recurrence</Label>
+                  <Select
+                    value={form.recurrence}
+                    onValueChange={(value) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        recurrence: value as HabitRecurrence,
+                      }))
+                    }
+                  >
+                    <SelectTrigger
+                      className={cn(
+                        "h-11 rounded-xl border border-border/60 bg-background text-left text-sm text-foreground focus:border-primary focus-visible:ring-0",
+                        errors.recurrence && "border-destructive"
+                      )}
+                      aria-invalid={errors.recurrence ? "true" : "false"}
+                      aria-describedby={
+                        errors.recurrence ? "habit-recurrence-error" : undefined
+                      }
+                    >
+                      <SelectValue placeholder="Choose cadence" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#0b101b] text-sm text-white">
+                      {RECURRENCE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          <div>
+                            <p className="font-medium text-white">{option.label}</p>
+                            <p className="text-xs text-zinc-400">{option.helper}</p>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {errors.recurrence && (
+                    <p
+                      id="habit-recurrence-error"
+                      className="text-sm text-destructive"
+                    >
+                      {errors.recurrence}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {serverError && (
+              <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {serverError}
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              <Button variant="outline" type="button" asChild>
+                <Link href="/habits">Cancel</Link>
+              </Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? "Creating..." : "Create habit"}
+              </Button>
+            </div>
+          </form>
         </div>
       </div>
     </ProtectedRoute>

--- a/src/app/(app)/habits/page.tsx
+++ b/src/app/(app)/habits/page.tsx
@@ -1,260 +1,324 @@
 "use client";
 
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { LucideIcon } from "lucide-react";
+import {
+  CalendarCheck,
+  ListChecks,
+  RefreshCw,
+  Sparkles,
+  Sun,
+  Plus,
+  Clock3,
+} from "lucide-react";
+
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
-import { PageHeader, SectionHeader } from "@/components/ui";
+import {
+  ContentCard,
+  GridContainer,
+  PageHeader,
+  SectionHeader,
+} from "@/components/ui";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { HabitsEmptyState } from "@/components/ui/empty-state";
+import { GridSkeleton } from "@/components/ui/skeleton";
+import { useToastHelpers } from "@/components/ui/toast";
+import { getHabitsForUser } from "@/lib/queries/habits";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import type { HabitRecurrence, HabitRow } from "@/lib/types/habit";
+import { cn } from "@/lib/utils";
 
-const summaryCards = [
-  {
-    id: "streak",
-    label: "Active streak",
-    value: "24 days",
-    detail: "Longest streak in progress",
-    accent: "from-emerald-500/25 via-emerald-500/5 to-transparent",
-    glow: "bg-emerald-500/40",
-  },
-  {
-    id: "consistency",
-    label: "Consistency",
-    value: "86%",
-    detail: "Completion over the last 30 days",
-    accent: "from-sky-500/25 via-sky-500/5 to-transparent",
-    glow: "bg-sky-500/40",
-  },
-  {
-    id: "checkins",
-    label: "Check-ins",
-    value: "5 today",
-    detail: "Moments of progress logged",
-    accent: "from-amber-500/25 via-amber-500/5 to-transparent",
-    glow: "bg-amber-500/40",
-  },
-];
+type SummaryCard = {
+  id: string;
+  label: string;
+  value: number;
+  description: string;
+  accent: string;
+  Icon: LucideIcon;
+};
 
-const habitHighlights = [
-  {
-    id: "morning-reading",
-    name: "Morning Reading",
-    description: "Ease into the day with focused, intentional reading.",
-    emoji: "📚",
-    frequency: "Daily · Morning",
-    streak: 12,
-    bestStreak: 30,
-    completionRate: 82,
-    lastCompleted: "2 hours ago",
-    tags: ["Mindset", "Focus"],
-    iconBg: "bg-amber-500/15 text-amber-200",
-    progressColor: "from-amber-400 via-amber-300 to-amber-200",
-    ctaClass: "bg-amber-500/20 text-amber-100 hover:bg-amber-500/30",
-  },
-  {
-    id: "deep-work",
-    name: "Deep Work Sprint",
-    description: "Protect 90 minutes for uninterrupted creation time.",
-    emoji: "⚡",
-    frequency: "Weekdays · 9am",
-    streak: 7,
-    bestStreak: 18,
-    completionRate: 74,
-    lastCompleted: "Yesterday",
-    tags: ["Creation", "Distraction-free"],
-    iconBg: "bg-purple-500/15 text-purple-200",
-    progressColor: "from-purple-400 via-purple-300 to-purple-200",
-    ctaClass: "bg-purple-500/20 text-purple-100 hover:bg-purple-500/30",
-  },
-  {
-    id: "training",
-    name: "Marathon Prep",
-    description: "Stack endurance with alternating run and strength days.",
-    emoji: "🏃",
-    frequency: "5× weekly",
-    streak: 9,
-    bestStreak: 21,
-    completionRate: 68,
-    lastCompleted: "This morning",
-    tags: ["Energy", "Discipline"],
-    iconBg: "bg-emerald-500/15 text-emerald-200",
-    progressColor: "from-emerald-400 via-emerald-300 to-emerald-200",
-    ctaClass: "bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30",
-  },
-  {
-    id: "language",
-    name: "Spanish Sessions",
-    description: "Practice with Duolingo and a five-minute voice note recap.",
-    emoji: "🗣️",
-    frequency: "Daily · Evening",
-    streak: 16,
-    bestStreak: 34,
-    completionRate: 91,
-    lastCompleted: "Last night",
-    tags: ["Language", "Consistency"],
-    iconBg: "bg-sky-500/15 text-sky-200",
-    progressColor: "from-sky-400 via-sky-300 to-sky-200",
-    ctaClass: "bg-sky-500/20 text-sky-100 hover:bg-sky-500/30",
-  },
-  {
-    id: "recovery",
-    name: "Wind-Down Ritual",
-    description: "Low lights, reflection journal, and zero screens by 10pm.",
-    emoji: "🌙",
-    frequency: "Daily · Night",
-    streak: 22,
-    bestStreak: 40,
-    completionRate: 88,
-    lastCompleted: "10 hours ago",
-    tags: ["Recovery", "Sleep"],
-    iconBg: "bg-indigo-500/15 text-indigo-200",
-    progressColor: "from-indigo-400 via-indigo-300 to-indigo-200",
-    ctaClass: "bg-indigo-500/20 text-indigo-100 hover:bg-indigo-500/30",
-  },
-  {
-    id: "reflection",
-    name: "Daily Reflection",
-    description: "Capture one win, one lesson, and tomorrow's priority.",
-    emoji: "📝",
-    frequency: "Daily · Night",
-    streak: 28,
-    bestStreak: 45,
-    completionRate: 94,
-    lastCompleted: "Last night",
-    tags: ["Clarity", "Momentum"],
-    iconBg: "bg-rose-500/15 text-rose-200",
-    progressColor: "from-rose-400 via-rose-300 to-rose-200",
-    ctaClass: "bg-rose-500/20 text-rose-100 hover:bg-rose-500/30",
-  },
-];
+const RECURRENCE_LABELS: Record<HabitRecurrence, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  "bi-weekly": "Bi-weekly",
+  monthly: "Monthly",
+  "bi-monthly": "Bi-monthly",
+  yearly: "Yearly",
+  "every x days": "Custom cadence",
+};
+
+function formatRecurrence(recurrence: HabitRow["recurrence"]): string {
+  if (!recurrence) {
+    return "No cadence set";
+  }
+
+  return RECURRENCE_LABELS[recurrence] ?? recurrence;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "Unknown";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
 
 export default function HabitsPage() {
+  const router = useRouter();
+  const toast = useToastHelpers();
+  const toastRef = useRef(toast);
+  const [habits, setHabits] = useState<HabitRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    toastRef.current = toast;
+  }, [toast]);
+
+  const loadHabits = useCallback(async () => {
+    setLoading(true);
+    const supabase = getSupabaseBrowser();
+
+    if (!supabase) {
+      const message = "Supabase client is not configured.";
+      setHabits([]);
+      setErrorMessage(message);
+      toastRef.current.error("Unable to load habits", message);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setHabits([]);
+        setErrorMessage(null);
+        setLoading(false);
+        return;
+      }
+
+      const data = await getHabitsForUser(user.id);
+      setHabits(data);
+      setErrorMessage(null);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Something went wrong";
+      setErrorMessage(message);
+      toastRef.current.error(
+        "Failed to load habits",
+        message,
+        () => void loadHabits()
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadHabits();
+  }, [loadHabits]);
+
+  const summaryCards: SummaryCard[] = useMemo(() => {
+    const total = habits.length;
+    const daily = habits.filter((habit) => habit.recurrence === "daily").length;
+    const weekly = habits.filter((habit) =>
+      habit.recurrence === "weekly" || habit.recurrence === "bi-weekly"
+    ).length;
+    const chores = habits.filter((habit) => habit.habit_type === "CHORE").length;
+
+    return [
+      {
+        id: "total",
+        label: "Active routines",
+        value: total,
+        description:
+          total === 1 ? "habit currently tracked" : "habits currently tracked",
+        accent: "bg-blue-500/10 text-blue-400",
+        Icon: ListChecks,
+      },
+      {
+        id: "daily",
+        label: "Daily cadence",
+        value: daily,
+        description: daily === 1 ? "daily habit" : "daily habits",
+        accent: "bg-amber-500/10 text-amber-400",
+        Icon: Sun,
+      },
+      {
+        id: "weekly",
+        label: "Weekly focus",
+        value: weekly,
+        description: weekly === 1 ? "weekly habit" : "weekly habits",
+        accent: "bg-purple-500/10 text-purple-400",
+        Icon: CalendarCheck,
+      },
+      {
+        id: "chores",
+        label: "Chores",
+        value: chores,
+        description: chores === 1 ? "active chore" : "active chores",
+        accent: "bg-emerald-500/10 text-emerald-400",
+        Icon: Sparkles,
+      },
+    ];
+  }, [habits]);
+
+  const handleRefresh = () => {
+    void loadHabits();
+  };
+
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-[#05070c] pb-16 text-white">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 pb-10 pt-8 sm:px-6 lg:px-8">
+      <div className="min-h-screen bg-background text-foreground">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 py-10 sm:px-6 lg:px-8">
           <PageHeader
-            title={<span className="bg-gradient-to-r from-white to-white/60 bg-clip-text text-transparent">Habits</span>}
-            description="Design your routines, track the streaks that matter, and celebrate the momentum you are building."
+            title="Habits"
+            description="Track the routines that keep your momentum and refine the cadence that works for you."
           >
-            <Link
-              href="/habits/new"
-              className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-medium text-white transition hover:border-white/20 hover:bg-white/[0.08]"
-            >
-              <span className="text-lg leading-none">＋</span>
-              <span>Create habit</span>
-            </Link>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                variant="outline"
+                onClick={handleRefresh}
+                disabled={loading}
+              >
+                <RefreshCw
+                  className={cn(
+                    "h-4 w-4",
+                    loading ? "animate-spin" : "text-muted-foreground"
+                  )}
+                />
+                Refresh
+              </Button>
+              <Button asChild>
+                <Link href="/habits/new">
+                  <Plus className="h-4 w-4" />
+                  Create habit
+                </Link>
+              </Button>
+            </div>
           </PageHeader>
 
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {summaryCards.map((card) => (
-              <div
-                key={card.id}
-                className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_20px_35px_-25px_rgba(15,23,42,0.65)]"
-              >
-                <div
-                  className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${card.accent} opacity-80`}
-                  aria-hidden
-                />
-                <div className="relative flex flex-col gap-4">
-                  <div className="flex items-center gap-3 text-sm font-medium uppercase tracking-[0.2em] text-white/60">
-                    <span className="h-1.5 w-1.5 rounded-full bg-white/70 shadow-[0_0_20px_6px_rgba(255,255,255,0.15)]" />
-                    {card.label}
-                  </div>
-                  <div className="flex items-end justify-between">
-                    <span className="text-3xl font-semibold tracking-tight text-white">{card.value}</span>
-                    <span className="rounded-full bg-white/5 px-3 py-1 text-xs text-white/70">{card.detail}</span>
-                  </div>
-                  <div className="h-1 w-full overflow-hidden rounded-full bg-white/10">
-                    <div className={`h-full w-1/3 ${card.glow} blur-md`} aria-hidden />
-                  </div>
-                </div>
-              </div>
-            ))}
+          {errorMessage && (
+            <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {errorMessage}
+            </div>
+          )}
+
+          <div className="space-y-6">
+            <SectionHeader
+              title="Overview"
+              description="Understand how your routines are distributed across cadence and type."
+            />
+
+            {loading ? (
+              <GridSkeleton cols={4} rows={1} />
+            ) : (
+              <GridContainer cols={4} gap="lg">
+                {summaryCards.map(({ id, label, value, description, accent, Icon }) => (
+                  <ContentCard
+                    key={id}
+                    className="border border-border/60 bg-card/60 shadow-sm"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                          {label}
+                        </p>
+                        <p className="mt-3 text-3xl font-semibold text-foreground">
+                          {value}
+                        </p>
+                      </div>
+                      <span
+                        className={cn(
+                          "inline-flex items-center justify-center rounded-full p-3",
+                          accent
+                        )}
+                      >
+                        <Icon className="h-5 w-5" />
+                      </span>
+                    </div>
+                    <p className="mt-4 text-sm text-muted-foreground">{description}</p>
+                  </ContentCard>
+                ))}
+              </GridContainer>
+            )}
           </div>
 
-          <SectionHeader
-            title="Your daily rhythm"
-            description="Track streaks, consistency, and the rituals that keep you moving."
-            className="text-white"
-          />
+          <div className="space-y-6">
+            <SectionHeader
+              title="Your routines"
+              description="Review the cadence, type, and recent activity for each habit."
+            />
 
-          <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
-            {habitHighlights.map((habit) => (
-              <article
-                key={habit.id}
-                className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_18px_45px_-25px_rgba(15,23,42,0.6)] transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_28px_55px_-20px_rgba(15,23,42,0.7)]"
-              >
-                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.18),transparent_60%)] opacity-0 transition duration-300 group-hover:opacity-100" />
-                <div className="relative flex items-start justify-between gap-4">
-                  <div className={`flex h-12 w-12 items-center justify-center rounded-xl text-2xl ${habit.iconBg}`}>
-                    <span role="img" aria-label="habit icon">
-                      {habit.emoji}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70">
-                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                    {habit.frequency}
-                  </div>
-                </div>
-
-                <div className="relative mt-6 space-y-2">
-                  <h3 className="text-xl font-semibold tracking-tight text-white">{habit.name}</h3>
-                  <p className="text-sm text-white/70">{habit.description}</p>
-                </div>
-
-                <div className="relative mt-6 space-y-4">
-                  <div className="grid grid-cols-3 gap-3 text-xs text-white/60">
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-3">
-                      <p className="font-medium text-white/80">{habit.streak} days</p>
-                      <p>Current streak</p>
-                    </div>
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-3">
-                      <p className="font-medium text-white/80">{habit.bestStreak} days</p>
-                      <p>Best streak</p>
-                    </div>
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-3">
-                      <p className="font-medium text-white/80">{habit.completionRate}%</p>
-                      <p>Consistency</p>
-                    </div>
-                  </div>
-
-                  <div>
-                    <div className="flex items-center justify-between text-xs text-white/60">
-                      <span>Progress this week</span>
-                      <span className="font-semibold text-white/80">{habit.completionRate}%</span>
-                    </div>
-                    <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-white/10">
-                      <div
-                        className={`h-full rounded-full bg-gradient-to-r ${habit.progressColor}`}
-                        style={{ width: `${habit.completionRate}%` }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap gap-2">
-                    {habit.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-white/60"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="relative mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-white/5 pt-5 text-xs text-white/60">
-                  <div className="flex items-center gap-2">
-                    <span className="text-base">🕒</span>
-                    <span>Last check-in {habit.lastCompleted}</span>
-                  </div>
-                  <button
-                    type="button"
-                    className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition ${habit.ctaClass}`}
+            {loading ? (
+              <GridSkeleton cols={3} rows={2} />
+            ) : habits.length === 0 ? (
+              <HabitsEmptyState
+                onAction={() => {
+                  router.push("/habits/new");
+                }}
+              />
+            ) : (
+              <GridContainer cols={3} gap="lg">
+                {habits.map((habit) => (
+                  <ContentCard
+                    key={habit.id}
+                    className="flex h-full flex-col gap-4 border border-border/60 bg-card/60 shadow-sm"
                   >
-                    <span>Mark complete</span>
-                    <span aria-hidden>→</span>
-                  </button>
-                </div>
-              </article>
-            ))}
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="space-y-2">
+                        <h3 className="text-lg font-semibold text-foreground">
+                          {habit.name}
+                        </h3>
+                        <p className="text-sm text-muted-foreground">
+                          {habit.description?.trim() || "No description added yet."}
+                        </p>
+                      </div>
+                      <Badge
+                        variant={habit.habit_type === "CHORE" ? "secondary" : "outline"}
+                        className={cn(
+                          habit.habit_type === "CHORE"
+                            ? "border-transparent bg-emerald-500/15 text-emerald-400"
+                            : "border-border/60 text-muted-foreground"
+                        )}
+                      >
+                        {habit.habit_type === "CHORE" ? "Chore" : "Habit"}
+                      </Badge>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/20 px-3 py-1.5">
+                        <CalendarCheck className="h-4 w-4" />
+                        <span>{formatRecurrence(habit.recurrence)}</span>
+                      </div>
+                      <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/20 px-3 py-1.5">
+                        <Clock3 className="h-4 w-4" />
+                        <span>Created {formatDate(habit.created_at)}</span>
+                      </div>
+                      {habit.updated_at && habit.updated_at !== habit.created_at && (
+                        <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/20 px-3 py-1.5">
+                          <RefreshCw className="h-4 w-4" />
+                          <span>Updated {formatDate(habit.updated_at)}</span>
+                        </div>
+                      )}
+                    </div>
+                  </ContentCard>
+                ))}
+              </GridContainer>
+            )}
           </div>
         </div>
       </div>

--- a/src/lib/queries/habits.ts
+++ b/src/lib/queries/habits.ts
@@ -1,0 +1,24 @@
+import { getSupabaseBrowser } from "@/lib/supabase";
+import type { HabitRow } from "@/lib/types/habit";
+
+export async function getHabitsForUser(userId: string): Promise<HabitRow[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    throw new Error("Supabase client not available");
+  }
+
+  const { data, error } = await supabase
+    .from("habits")
+    .select(
+      "id, user_id, name, description, habit_type, recurrence, created_at, updated_at"
+    )
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching habits:", error);
+    throw error;
+  }
+
+  return (data ?? []) as HabitRow[];
+}

--- a/src/lib/types/habit.ts
+++ b/src/lib/types/habit.ts
@@ -1,0 +1,28 @@
+export type HabitType = "HABIT" | "CHORE";
+
+export type HabitRecurrence =
+  | "daily"
+  | "weekly"
+  | "bi-weekly"
+  | "monthly"
+  | "bi-monthly"
+  | "yearly"
+  | "every x days";
+
+export type HabitRow = {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  habit_type: HabitType;
+  recurrence: HabitRecurrence | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type HabitInput = {
+  name: string;
+  description: string | null;
+  habit_type: HabitType;
+  recurrence: HabitRecurrence;
+};


### PR DESCRIPTION
## Summary
- replace the habits dashboard with a Supabase-backed view and refreshed UI that surfaces real habit data and stats
- add reusable habit query and type definitions for accessing user routines
- implement a full habit creation form with validation, cadence selection, and Supabase insertion

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68df6ac5e5f0832ca683c6d0ab45d94b