### PR TITLE
Allow editing goal projects and tasks from goals page

### DIFF
--- a/src/app/(app)/goals/components/GoalDrawer.tsx
+++ b/src/app/(app)/goals/components/GoalDrawer.tsx
@@ -503,7 +503,14 @@ export function GoalDrawer({
                 type="submit"
                 size="sm"
                 disabled={!canSubmit}
-                className="hidden sm:inline-flex"
+                className={cn(
+                  "relative hidden overflow-hidden rounded-lg border border-white/10 text-sm font-semibold text-white transition-[filter,transform,box-shadow] duration-300",
+                  "bg-[linear-gradient(135deg,#9ca3af_0%,#6b7280_22%,#1f2937_58%,#0b0f19_100%)] bg-[length:250%_250%] shadow-[0_18px_42px_-26px_rgba(8,13,23,0.85)]",
+                  "hover:scale-[1.02] hover:brightness-110 hover:shadow-[0_24px_60px_-30px_rgba(8,13,23,0.95)] active:scale-[0.98]",
+                  "motion-safe:animate-[steel-shimmer_6s_linear_infinite] motion-reduce:animate-none motion-reduce:transition-none motion-reduce:hover:scale-100 motion-reduce:hover:brightness-100",
+                  "disabled:animate-none disabled:brightness-100 disabled:opacity-60 disabled:shadow-none",
+                  "sm:inline-flex"
+                )}
               >
                 Save changes
               </Button>

--- a/src/app/(app)/goals/components/GoalDrawer.tsx
+++ b/src/app/(app)/goals/components/GoalDrawer.tsx
@@ -165,6 +165,7 @@ export function GoalDrawer({
   onUpdate,
   monuments = [],
 }: GoalDrawerProps) {
+  const formId = "goal-editor-form";
   const [title, setTitle] = useState("");
   const [emoji, setEmoji] = useState("");
   const [priority, setPriority] = useState<Goal["priority"]>("Low");
@@ -492,15 +493,28 @@ export function GoalDrawer({
         className="border-l border-white/10 bg-[#060911]/95 text-white shadow-[0_40px_120px_-60px_rgba(99,102,241,0.65)] sm:max-w-xl"
       >
         <SheetHeader className="px-6 pt-8">
-          <SheetTitle className="text-left text-2xl font-semibold tracking-tight text-white">
-            {editing ? "Edit goal" : "Create a goal"}
-          </SheetTitle>
+          <div className="flex items-center justify-between gap-3">
+            <SheetTitle className="text-left text-2xl font-semibold tracking-tight text-white">
+              {editing ? "Edit goal" : "Create a goal"}
+            </SheetTitle>
+            {editing ? (
+              <Button
+                form={formId}
+                type="submit"
+                size="sm"
+                disabled={!canSubmit}
+                className="hidden sm:inline-flex"
+              >
+                Save changes
+              </Button>
+            ) : null}
+          </div>
           <SheetDescription className="text-left text-sm text-white/60">
             Shape the focus, energy, and storyline for this goal. Everything you
             update is saved instantly once you hit save.
           </SheetDescription>
         </SheetHeader>
-        <form onSubmit={submit} className="flex h-full flex-col">
+        <form id={formId} onSubmit={submit} className="flex h-full flex-col">
           <div className="flex-1 space-y-8 overflow-y-auto px-6 pb-8 pt-6">
             <div className="grid grid-cols-1 gap-6">
               <div className="grid grid-cols-[90px,1fr] gap-4">

--- a/src/app/(app)/goals/components/GoalDrawer.tsx
+++ b/src/app/(app)/goals/components/GoalDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { Plus, X } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -15,17 +16,23 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { Goal } from "../types";
+import type { Goal, Project, Task } from "../types";
+
+export interface GoalUpdateContext {
+  projects: (Project & { tasks: (Task & { isNew?: boolean })[] })[];
+  removedProjectIds: string[];
+  removedTaskIds: string[];
+}
 
 interface GoalDrawerProps {
   open: boolean;
   onClose(): void;
   /** Callback when creating a new goal */
-  onAdd(goal: Goal): void;
+  onAdd(goal: Goal, context: GoalUpdateContext): void;
   /** Existing goal to edit */
   initialGoal?: Goal | null;
   /** Callback when updating an existing goal */
-  onUpdate?(goal: Goal): void;
+  onUpdate?(goal: Goal, context: GoalUpdateContext): void;
   monuments?: { id: string; title: string }[];
 }
 
@@ -72,6 +79,84 @@ const ENERGY_OPTIONS: {
   },
 ];
 
+const PROJECT_STAGE_OPTIONS = [
+  { value: "RESEARCH", label: "Research" },
+  { value: "TEST", label: "Test" },
+  { value: "BUILD", label: "Build" },
+  { value: "REFINE", label: "Refine" },
+  { value: "RELEASE", label: "Release" },
+];
+
+const TASK_STAGE_OPTIONS = [
+  { value: "PREPARE", label: "Prepare" },
+  { value: "PRODUCE", label: "Produce" },
+  { value: "PERFECT", label: "Perfect" },
+];
+
+const DEFAULT_PROJECT_STAGE = "RESEARCH";
+const DEFAULT_TASK_STAGE = "PREPARE";
+
+const projectStageToStatus = (stage: string): Project["status"] => {
+  switch (stage) {
+    case "RESEARCH":
+      return "Todo";
+    case "RELEASE":
+      return "Done";
+    default:
+      return "In-Progress";
+  }
+};
+
+const projectStatusToStage = (status: Project["status"]): string => {
+  switch (status) {
+    case "Todo":
+      return "RESEARCH";
+    case "Done":
+      return "RELEASE";
+    default:
+      return "BUILD";
+  }
+};
+
+const energyToDbValue = (energy: Goal["energy"]): string => {
+  switch (energy) {
+    case "Extreme":
+      return "EXTREME";
+    case "Ultra":
+      return "ULTRA";
+    case "High":
+      return "HIGH";
+    case "Medium":
+      return "MEDIUM";
+    case "Low":
+      return "LOW";
+    default:
+      return "NO";
+  }
+};
+
+const computeProjectProgress = (tasks: Task[]): number => {
+  if (tasks.length === 0) {
+    return 0;
+  }
+  const completed = tasks.filter((task) => task.stage === "PERFECT").length;
+  return Math.round((completed / tasks.length) * 100);
+};
+
+const computeGoalProgress = (projects: Project[]): number => {
+  if (projects.length === 0) {
+    return 0;
+  }
+  const total = projects.reduce((sum, project) => sum + project.progress, 0);
+  return Math.round(total / projects.length);
+};
+
+type EditableTask = Task & { isNew?: boolean };
+type EditableProject = Project & {
+  tasks: EditableTask[];
+  isNew?: boolean;
+};
+
 export function GoalDrawer({
   open,
   onClose,
@@ -87,6 +172,9 @@ export function GoalDrawer({
   const [active, setActive] = useState(true);
   const [why, setWhy] = useState("");
   const [monumentId, setMonumentId] = useState<string>("");
+  const [projectsState, setProjectsState] = useState<EditableProject[]>([]);
+  const [removedProjectIds, setRemovedProjectIds] = useState<string[]>([]);
+  const [removedTaskIds, setRemovedTaskIds] = useState<string[]>([]);
 
   const editing = Boolean(initialGoal);
 
@@ -99,6 +187,27 @@ export function GoalDrawer({
       setActive(initialGoal.active ?? true);
       setWhy(initialGoal.why || "");
       setMonumentId(initialGoal.monumentId || "");
+      setProjectsState(
+        (initialGoal.projects || []).map((project) => {
+          const stage = project.stage ?? projectStatusToStage(project.status);
+          const tasks = (project.tasks || []).map((task) => ({
+            ...task,
+            isNew: false,
+          }));
+          const progress = computeProjectProgress(tasks);
+          return {
+            ...project,
+            stage,
+            status: projectStageToStatus(stage),
+            energy: project.energy,
+            energyCode: project.energyCode ?? energyToDbValue(project.energy),
+            priorityCode: project.priorityCode,
+            progress,
+            tasks,
+            isNew: false,
+          } satisfies EditableProject;
+        })
+      );
     } else {
       setTitle("");
       setEmoji("");
@@ -107,7 +216,10 @@ export function GoalDrawer({
       setActive(true);
       setWhy("");
       setMonumentId("");
+      setProjectsState([]);
     }
+    setRemovedProjectIds([]);
+    setRemovedTaskIds([]);
   }, [initialGoal, open]);
 
   const monumentOptions = useMemo(() => {
@@ -115,7 +227,183 @@ export function GoalDrawer({
     return [...monuments].sort((a, b) => a.title.localeCompare(b.title));
   }, [monuments]);
 
-  const canSubmit = title.trim().length > 0;
+  const projectsValid = projectsState.every((project) => {
+    const hasValidName = project.name.trim().length > 0;
+    const tasksValid = project.tasks.every(
+      (task) => task.name.trim().length > 0
+    );
+    return hasValidName && tasksValid;
+  });
+
+  const canSubmit = title.trim().length > 0 && projectsValid;
+
+  const generateId = () =>
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+
+  const handleAddProject = () => {
+    const stage = DEFAULT_PROJECT_STAGE;
+    const nextProject: EditableProject = {
+      id: generateId(),
+      name: "",
+      status: projectStageToStatus(stage),
+      progress: 0,
+      energy: "No",
+      energyCode: energyToDbValue("No"),
+      tasks: [],
+      stage,
+      priorityCode: "NO",
+      isNew: true,
+    };
+    setProjectsState((projects) => [...projects, nextProject]);
+  };
+
+  const handleProjectNameChange = (projectId: string, value: string) => {
+    setProjectsState((projects) =>
+      projects.map((project) =>
+        project.id === projectId ? { ...project, name: value } : project
+      )
+    );
+  };
+
+  const handleProjectStageChange = (projectId: string, stage: string) => {
+    setProjectsState((projects) =>
+      projects.map((project) =>
+        project.id === projectId
+          ? {
+              ...project,
+              stage,
+              status: projectStageToStatus(stage),
+            }
+          : project
+      )
+    );
+  };
+
+  const handleProjectEnergyChange = (
+    projectId: string,
+    energyValue: Goal["energy"]
+  ) => {
+    setProjectsState((projects) =>
+      projects.map((project) =>
+        project.id === projectId
+          ? {
+              ...project,
+              energy: energyValue,
+              energyCode: energyToDbValue(energyValue),
+            }
+          : project
+      )
+    );
+  };
+
+  const handleRemoveProject = (projectId: string) => {
+    let removedProject: EditableProject | null = null;
+    setProjectsState((projects) => {
+      removedProject = projects.find((project) => project.id === projectId) ?? null;
+      return projects.filter((project) => project.id !== projectId);
+    });
+    if (removedProject && !removedProject.isNew) {
+      setRemovedProjectIds((ids) =>
+        ids.includes(projectId) ? ids : [...ids, projectId]
+      );
+      const existingTaskIds = removedProject.tasks
+        .filter((task) => !task.isNew)
+        .map((task) => task.id);
+      if (existingTaskIds.length > 0) {
+        setRemovedTaskIds((ids) => {
+          const unique = new Set(ids);
+          existingTaskIds.forEach((id) => unique.add(id));
+          return Array.from(unique);
+        });
+      }
+    }
+  };
+
+  const handleAddTask = (projectId: string) => {
+    const newTask: EditableTask = {
+      id: generateId(),
+      name: "",
+      stage: DEFAULT_TASK_STAGE,
+      isNew: true,
+    };
+    setProjectsState((projects) =>
+      projects.map((project) => {
+        if (project.id !== projectId) return project;
+        const nextTasks = [...project.tasks, newTask];
+        return {
+          ...project,
+          tasks: nextTasks,
+          progress: computeProjectProgress(nextTasks),
+        };
+      })
+    );
+  };
+
+  const handleTaskNameChange = (
+    projectId: string,
+    taskId: string,
+    value: string
+  ) => {
+    setProjectsState((projects) =>
+      projects.map((project) => {
+        if (project.id !== projectId) return project;
+        const nextTasks = project.tasks.map((task) =>
+          task.id === taskId ? { ...task, name: value } : task
+        );
+        return {
+          ...project,
+          tasks: nextTasks,
+          progress: computeProjectProgress(nextTasks),
+        };
+      })
+    );
+  };
+
+  const handleTaskStageChange = (
+    projectId: string,
+    taskId: string,
+    stage: string
+  ) => {
+    setProjectsState((projects) =>
+      projects.map((project) => {
+        if (project.id !== projectId) return project;
+        const nextTasks = project.tasks.map((task) =>
+          task.id === taskId ? { ...task, stage } : task
+        );
+        return {
+          ...project,
+          tasks: nextTasks,
+          progress: computeProjectProgress(nextTasks),
+        };
+      })
+    );
+  };
+
+  const handleRemoveTask = (projectId: string, taskId: string) => {
+    let removedExisting = false;
+    setProjectsState((projects) =>
+      projects.map((project) => {
+        if (project.id !== projectId) return project;
+        const taskToRemove = project.tasks.find((task) => task.id === taskId);
+        if (taskToRemove && !taskToRemove.isNew) {
+          removedExisting = true;
+        }
+        const nextTasks = project.tasks.filter((task) => task.id !== taskId);
+        return {
+          ...project,
+          tasks: nextTasks,
+          progress: computeProjectProgress(nextTasks),
+        };
+      })
+    );
+    if (removedExisting) {
+      setRemovedTaskIds((ids) =>
+        ids.includes(taskId) ? ids : [...ids, taskId]
+      );
+    }
+  };
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -128,6 +416,42 @@ export function GoalDrawer({
         : preservedStatus
       : "Inactive";
     const computedActive = computedStatus !== "Inactive";
+
+    const preparedProjects: Project[] = projectsState.map((project) => {
+      const stage = project.stage ?? projectStatusToStage(project.status);
+      const sanitizedTasks = project.tasks.map((task) => ({
+        id: task.id,
+        name: task.name.trim(),
+        stage: task.stage,
+        skillId: task.skillId,
+      }));
+      const progress = computeProjectProgress(sanitizedTasks);
+      return {
+        id: project.id,
+        name: project.name.trim(),
+        status: projectStageToStatus(stage),
+        progress,
+        dueDate: project.dueDate,
+        energy: project.energy,
+        energyCode: project.energyCode ?? energyToDbValue(project.energy),
+        tasks: sanitizedTasks,
+        stage,
+        priorityCode: project.priorityCode,
+        isNew: project.isNew,
+      };
+    });
+
+    const goalProgress = computeGoalProgress(preparedProjects);
+
+    const context: GoalUpdateContext = {
+      projects: projectsState.map((project) => ({
+        ...project,
+        tasks: project.tasks.map((task) => ({ ...task })),
+      })),
+      removedProjectIds,
+      removedTaskIds,
+    };
+
     const nextGoal: Goal = {
       id: initialGoal?.id || Date.now().toString(),
       title: title.trim(),
@@ -135,11 +459,11 @@ export function GoalDrawer({
       dueDate: initialGoal?.dueDate,
       priority,
       energy,
-      progress: initialGoal?.progress ?? 0,
+      progress: goalProgress,
       status: computedStatus,
       active: computedActive,
       updatedAt: new Date().toISOString(),
-      projects: initialGoal?.projects ?? [],
+      projects: preparedProjects,
       monumentId: monumentId || null,
       skills: initialGoal?.skills,
       weight: initialGoal?.weight,
@@ -147,9 +471,9 @@ export function GoalDrawer({
     };
 
     if (editing && onUpdate) {
-      onUpdate(nextGoal);
+      onUpdate(nextGoal, context);
     } else {
-      onAdd(nextGoal);
+      onAdd(nextGoal, context);
     }
     onClose();
   };
@@ -309,6 +633,236 @@ export function GoalDrawer({
                   placeholder="Capture the purpose or narrative behind this goal."
                   className="min-h-[120px] rounded-xl border-white/10 bg-white/[0.04] text-sm"
                 />
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <Label className="text-white/70">Projects &amp; tasks</Label>
+                    <p className="text-xs text-white/60">
+                      Manage the projects and tasks connected to this goal without
+                      leaving the page.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-9 rounded-full border-white/20 bg-white/[0.04] text-xs font-medium text-white/80 hover:border-indigo-400/50 hover:text-white"
+                    onClick={handleAddProject}
+                  >
+                    <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+                    Add project
+                  </Button>
+                </div>
+
+                {projectsState.length === 0 ? (
+                  <div className="rounded-2xl border border-dashed border-white/15 bg-white/[0.02] p-4 text-sm text-white/60">
+                    No projects linked yet. Add one to keep your plan in sync with
+                    this goal.
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {projectsState.map((project, index) => {
+                      const stageValue =
+                        project.stage ?? projectStatusToStage(project.status);
+                      return (
+                        <div
+                          key={project.id}
+                          className="space-y-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="flex-1 space-y-2">
+                              <div className="flex items-center justify-between gap-3">
+                                <Label className="text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
+                                  Project {index + 1}
+                                </Label>
+                                <span className="rounded-full border border-white/10 bg-white/[0.05] px-2 py-0.5 text-[11px] text-white/60">
+                                  {project.progress}% progress
+                                </span>
+                              </div>
+                              <Input
+                                value={project.name}
+                                onChange={(event) =>
+                                  handleProjectNameChange(
+                                    project.id,
+                                    event.target.value
+                                  )
+                                }
+                                placeholder="Name this project"
+                                className="h-11 rounded-xl border-white/10 bg-white/[0.05] text-sm"
+                              />
+                            </div>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="mt-1 size-8 rounded-full border border-white/10 bg-white/[0.04] text-white/60 hover:border-rose-400/50 hover:text-rose-200"
+                              onClick={() => handleRemoveProject(project.id)}
+                              aria-label={`Remove project ${index + 1}`}
+                            >
+                              <X className="h-4 w-4" aria-hidden="true" />
+                            </Button>
+                          </div>
+
+                          <div className="grid gap-4 sm:grid-cols-2">
+                            <div className="space-y-1">
+                              <Label className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/60">
+                                Stage
+                              </Label>
+                              <Select
+                                value={stageValue}
+                                onValueChange={(value) =>
+                                  handleProjectStageChange(project.id, value)
+                                }
+                                triggerClassName="h-10 rounded-xl border-white/10 bg-white/[0.04] text-left text-sm"
+                              >
+                                <SelectContent className="bg-[#0f172a] text-sm text-white">
+                                  {PROJECT_STAGE_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            <div className="space-y-1">
+                              <Label className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/60">
+                                Energy
+                              </Label>
+                              <Select
+                                value={project.energy}
+                                onValueChange={(value) =>
+                                  handleProjectEnergyChange(
+                                    project.id,
+                                    value as Goal["energy"]
+                                  )
+                                }
+                                triggerClassName="h-10 rounded-xl border-white/10 bg-white/[0.04] text-left text-sm"
+                              >
+                                <SelectContent className="bg-[#0f172a] text-sm text-white">
+                                  {ENERGY_OPTIONS.map((option) => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                      {option.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          </div>
+
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between gap-3">
+                              <Label className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/60">
+                                Tasks
+                              </Label>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-8 rounded-lg border-white/20 bg-white/[0.04] px-3 text-xs font-medium text-white/80 hover:border-indigo-400/50 hover:text-white"
+                                onClick={() => handleAddTask(project.id)}
+                              >
+                                <Plus className="mr-1 h-3 w-3" aria-hidden="true" />
+                                Add task
+                              </Button>
+                            </div>
+
+                            {project.tasks.length === 0 ? (
+                              <p className="text-xs text-white/50">
+                                No tasks yet. Break this project down into actionable
+                                steps.
+                              </p>
+                            ) : (
+                              <div className="space-y-3">
+                                {project.tasks.map((task, taskIndex) => (
+                                  <div
+                                    key={task.id}
+                                    className="space-y-3 rounded-xl border border-white/10 bg-white/[0.04] p-3"
+                                  >
+                                    <div className="flex items-start gap-3">
+                                      <div className="flex-1 space-y-1">
+                                        <Label className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/50">
+                                          Task {taskIndex + 1}
+                                        </Label>
+                                        <Input
+                                          value={task.name}
+                                          onChange={(event) =>
+                                            handleTaskNameChange(
+                                              project.id,
+                                              task.id,
+                                              event.target.value
+                                            )
+                                          }
+                                          placeholder="Describe the task"
+                                          className="h-10 rounded-lg border-white/10 bg-white/[0.05] text-sm"
+                                        />
+                                      </div>
+                                      <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="mt-1 size-8 rounded-full border border-white/10 bg-white/[0.05] text-white/60 hover:border-rose-400/50 hover:text-rose-200"
+                                        onClick={() =>
+                                          handleRemoveTask(project.id, task.id)
+                                        }
+                                        aria-label={`Remove task ${taskIndex + 1}`}
+                                      >
+                                        <X className="h-4 w-4" aria-hidden="true" />
+                                      </Button>
+                                    </div>
+
+                                    <div className="grid gap-3 sm:grid-cols-2">
+                                      <div className="space-y-1">
+                                        <Label className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/50">
+                                          Stage
+                                        </Label>
+                                        <Select
+                                          value={task.stage}
+                                          onValueChange={(value) =>
+                                            handleTaskStageChange(
+                                              project.id,
+                                              task.id,
+                                              value
+                                            )
+                                          }
+                                          triggerClassName="h-9 rounded-lg border-white/10 bg-white/[0.05] text-left text-sm"
+                                        >
+                                          <SelectContent className="bg-[#0f172a] text-sm text-white">
+                                            {TASK_STAGE_OPTIONS.map((option) => (
+                                              <SelectItem
+                                                key={option.value}
+                                                value={option.value}
+                                              >
+                                                {option.label}
+                                              </SelectItem>
+                                            ))}
+                                          </SelectContent>
+                                        </Select>
+                                      </div>
+                                      <div className="space-y-1">
+                                        <Label className="text-[10px] font-semibold uppercase tracking-[0.25em] text-white/50">
+                                          Status
+                                        </Label>
+                                        <div className="rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/60">
+                                          {task.stage === "PERFECT"
+                                            ? "Complete"
+                                            : task.stage === "PRODUCE"
+                                            ? "In progress"
+                                            : "Preparing"}
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/app/(app)/goals/types.ts
+++ b/src/app/(app)/goals/types.ts
@@ -2,6 +2,8 @@ export interface Task {
   id: string;
   name: string;
   stage: string;
+  skillId?: string | null;
+  isNew?: boolean;
 }
 
 export interface Project {
@@ -12,6 +14,10 @@ export interface Project {
   dueDate?: string;
   energy: "No" | "Low" | "Medium" | "High" | "Ultra" | "Extreme";
   tasks: Task[];
+  stage?: string;
+  energyCode?: string;
+  priorityCode?: string;
+  isNew?: boolean;
 }
 
 export interface Goal {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,3 +80,15 @@ html,body{
 }
 
 body.modal-open [data-bottom-nav] { display: none !important; }
+
+@keyframes steel-shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}


### PR DESCRIPTION
## Summary
- extend the goal drawer so projects and their tasks can be added, edited, or removed while updating a goal
- persist goal-related project and task changes by synchronizing inserts, updates, and deletions with Supabase
- enrich goal data loading to include project metadata needed for inline editing

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68df6bad4dd4832cb1cb41d999325f3c