### PR TITLE
Load habits dynamically on habits page

### DIFF
--- a/lib/queries/habits.ts
+++ b/lib/queries/habits.ts
@@ -6,6 +6,7 @@ export interface Habit {
   description: string | null;
   habit_type: string;
   recurrence: string | null;
+  duration_minutes: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -18,7 +19,9 @@ export async function getHabits(userId: string): Promise<Habit[]> {
 
   const { data, error } = await supabase
     .from("habits")
-    .select("id, name, description, habit_type, recurrence, created_at, updated_at")
+    .select(
+      "id, name, description, habit_type, recurrence, duration_minutes, created_at, updated_at"
+    )
     .eq("user_id", userId)
     .order("updated_at", { ascending: false });
 

--- a/lib/queries/habits.ts
+++ b/lib/queries/habits.ts
@@ -1,0 +1,31 @@
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+export interface Habit {
+  id: string;
+  name: string;
+  description: string | null;
+  habit_type: string;
+  recurrence: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getHabits(userId: string): Promise<Habit[]> {
+  const supabase = getSupabaseBrowser();
+  if (!supabase) {
+    throw new Error("Supabase client not available");
+  }
+
+  const { data, error } = await supabase
+    .from("habits")
+    .select("id, name, description, habit_type, recurrence, created_at, updated_at")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false });
+
+  if (error) {
+    console.error("Error fetching habits:", error);
+    throw error;
+  }
+
+  return data || [];
+}

--- a/src/app/(app)/habits/new/page.tsx
+++ b/src/app/(app)/habits/new/page.tsx
@@ -42,6 +42,7 @@ export default function NewHabitPage() {
   const [description, setDescription] = useState("");
   const [habitType, setHabitType] = useState("HABIT");
   const [recurrence, setRecurrence] = useState("none");
+  const [duration, setDuration] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,6 +56,12 @@ export default function NewHabitPage() {
 
     if (!name.trim()) {
       setError("Please provide a name for your habit.");
+      return;
+    }
+
+    const durationMinutes = Number(duration);
+    if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+      setError("Please enter how many minutes the habit should take.");
       return;
     }
 
@@ -85,6 +92,7 @@ export default function NewHabitPage() {
         description: trimmedDescription || null,
         habit_type: habitType,
         recurrence: recurrenceValue,
+        duration_minutes: durationMinutes,
       });
 
       if (insertError) {
@@ -207,6 +215,29 @@ export default function NewHabitPage() {
                   </Select>
                   <p className="text-xs text-white/50">
                     Pick the cadence that fits best. You can adjust this later.
+                  </p>
+                </div>
+                <div className="space-y-3">
+                  <Label
+                    htmlFor="duration"
+                    className="text-xs font-semibold uppercase tracking-[0.2em] text-white/70"
+                  >
+                    Duration (minutes)
+                  </Label>
+                  <Input
+                    id="duration"
+                    type="number"
+                    inputMode="numeric"
+                    min={1}
+                    step={1}
+                    value={duration}
+                    onChange={(event) => setDuration(event.target.value)}
+                    placeholder="e.g. 25"
+                    required
+                    className="h-11 rounded-xl border border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-white/50 focus:border-blue-400/60 focus-visible:ring-0"
+                  />
+                  <p className="text-xs text-white/50">
+                    Estimate how long this habit usually takes so we can track your time investment.
                   </p>
                 </div>
               </div>

--- a/src/app/(app)/habits/new/page.tsx
+++ b/src/app/(app)/habits/new/page.tsx
@@ -1,19 +1,232 @@
 "use client";
 
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { PageHeader } from "@/components/ui";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getSupabaseBrowser } from "@/lib/supabase";
+
+const HABIT_TYPE_OPTIONS = [
+  { label: "Habit", value: "HABIT" },
+  { label: "Chore", value: "CHORE" },
+];
+
+const RECURRENCE_OPTIONS = [
+  { label: "Daily", value: "daily" },
+  { label: "Weekly", value: "weekly" },
+  { label: "Bi-weekly", value: "bi-weekly" },
+  { label: "Monthly", value: "monthly" },
+  { label: "Bi-monthly", value: "bi-monthly" },
+  { label: "Yearly", value: "yearly" },
+  { label: "Every X Days", value: "every x days" },
+];
 
 export default function NewHabitPage() {
+  const router = useRouter();
+  const supabase = getSupabaseBrowser();
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [habitType, setHabitType] = useState("HABIT");
+  const [recurrence, setRecurrence] = useState("none");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!supabase) {
+      setError("Supabase client not available.");
+      return;
+    }
+
+    if (!name.trim()) {
+      setError("Please provide a name for your habit.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+
+      if (userError) {
+        throw userError;
+      }
+
+      if (!user) {
+        setError("You need to be signed in to create a habit.");
+        return;
+      }
+
+      const trimmedDescription = description.trim();
+      const recurrenceValue = recurrence === "none" ? null : recurrence;
+
+      const { error: insertError } = await supabase.from("habits").insert({
+        user_id: user.id,
+        name: name.trim(),
+        description: trimmedDescription || null,
+        habit_type: habitType,
+        recurrence: recurrenceValue,
+      });
+
+      if (insertError) {
+        throw insertError;
+      }
+
+      router.push("/habits");
+      router.refresh();
+    } catch (err) {
+      console.error("Failed to create habit:", err);
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Unable to create the habit right now."
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-gray-900 text-white">
-        <div className="container mx-auto px-4 py-6">
+      <div className="min-h-screen bg-[#05070c] pb-16 text-white">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-10 px-4 pb-10 pt-8 sm:px-6 lg:px-8">
           <PageHeader
-            title="Create New Habit"
-            description="Build a new habit to improve your life"
-          />
-          <div className="text-center py-12">
-            <p className="text-gray-400">Habit creation form coming soon...</p>
+            title={
+              <span className="bg-gradient-to-r from-white to-white/60 bg-clip-text text-transparent">
+                Create a habit
+              </span>
+            }
+            description="Define your routine, set a cadence, and make progress feel tangible."
+          >
+            <Button asChild variant="outline" size="sm" className="text-white">
+              <Link href="/habits">Back to habits</Link>
+            </Button>
+          </PageHeader>
+
+          <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_20px_45px_-25px_rgba(15,23,42,0.85)] sm:p-8">
+            <form onSubmit={handleSubmit} className="space-y-8">
+              <div className="space-y-3">
+                <Label
+                  htmlFor="name"
+                  className="text-xs font-semibold uppercase tracking-[0.2em] text-white/70"
+                >
+                  Habit name
+                </Label>
+                <Input
+                  id="name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="e.g. Morning meditation"
+                  required
+                  className="h-11 rounded-xl border border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-white/50 focus:border-blue-400/60 focus-visible:ring-0"
+                />
+              </div>
+
+              <div className="space-y-3">
+                <Label
+                  htmlFor="description"
+                  className="text-xs font-semibold uppercase tracking-[0.2em] text-white/70"
+                >
+                  Description
+                </Label>
+                <Textarea
+                  id="description"
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  placeholder="Add any notes that will keep you accountable."
+                  className="min-h-[120px] rounded-xl border border-white/10 bg-white/[0.05] text-sm text-white placeholder:text-white/50 focus:border-blue-400/60 focus-visible:ring-0"
+                />
+                <p className="text-xs text-white/50">
+                  Optional, but a clear intention makes it easier to stay consistent.
+                </p>
+              </div>
+
+              <div className="grid gap-6 sm:grid-cols-2">
+                <div className="space-y-3">
+                  <Label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/70">
+                    Type
+                  </Label>
+                  <Select
+                    value={habitType}
+                    onValueChange={(value) => setHabitType(value)}
+                  >
+                    <SelectTrigger className="h-11 rounded-xl border border-white/10 bg-white/[0.05] text-left text-sm text-white focus:border-blue-400/60 focus-visible:ring-0">
+                      <SelectValue placeholder="Choose a type" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#0b101b] text-sm text-white">
+                      {HABIT_TYPE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-white/50">
+                    Use chores for recurring upkeep tasks; habits track personal rituals.
+                  </p>
+                </div>
+
+                <div className="space-y-3">
+                  <Label className="text-xs font-semibold uppercase tracking-[0.2em] text-white/70">
+                    Recurrence
+                  </Label>
+                  <Select
+                    value={recurrence}
+                    onValueChange={(value) => setRecurrence(value)}
+                  >
+                    <SelectTrigger className="h-11 rounded-xl border border-white/10 bg-white/[0.05] text-left text-sm text-white focus:border-blue-400/60 focus-visible:ring-0">
+                      <SelectValue placeholder="How often will you do this?" />
+                    </SelectTrigger>
+                    <SelectContent className="bg-[#0b101b] text-sm text-white">
+                      <SelectItem value="none">No set cadence</SelectItem>
+                      {RECURRENCE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-white/50">
+                    Pick the cadence that fits best. You can adjust this later.
+                  </p>
+                </div>
+              </div>
+
+              {error && (
+                <div className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  disabled={loading}
+                  className="h-11 rounded-xl bg-white text-sm font-semibold text-black transition hover:bg-white/90 disabled:cursor-not-allowed"
+                >
+                  {loading ? "Creating..." : "Create habit"}
+                </Button>
+              </div>
+            </form>
           </div>
         </div>
       </div>

--- a/src/app/(app)/habits/page.tsx
+++ b/src/app/(app)/habits/page.tsx
@@ -1,130 +1,194 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
-import { PageHeader, SectionHeader } from "@/components/ui";
+import {
+  PageHeader,
+  SectionHeader,
+  HabitsEmptyState,
+  Skeleton,
+} from "@/components/ui";
+import { getSupabaseBrowser } from "@/lib/supabase";
+import { getHabits, type Habit } from "@/lib/queries/habits";
 
-const summaryCards = [
+const SUMMARY_STYLES = [
   {
-    id: "streak",
-    label: "Active streak",
-    value: "24 days",
-    detail: "Longest streak in progress",
     accent: "from-emerald-500/25 via-emerald-500/5 to-transparent",
     glow: "bg-emerald-500/40",
   },
   {
-    id: "consistency",
-    label: "Consistency",
-    value: "86%",
-    detail: "Completion over the last 30 days",
     accent: "from-sky-500/25 via-sky-500/5 to-transparent",
     glow: "bg-sky-500/40",
   },
   {
-    id: "checkins",
-    label: "Check-ins",
-    value: "5 today",
-    detail: "Moments of progress logged",
     accent: "from-amber-500/25 via-amber-500/5 to-transparent",
     glow: "bg-amber-500/40",
   },
 ];
 
-const habitHighlights = [
+const CARD_STYLES = [
   {
-    id: "morning-reading",
-    name: "Morning Reading",
-    description: "Ease into the day with focused, intentional reading.",
-    emoji: "📚",
-    frequency: "Daily · Morning",
-    streak: 12,
-    bestStreak: 30,
-    completionRate: 82,
-    lastCompleted: "2 hours ago",
-    tags: ["Mindset", "Focus"],
     iconBg: "bg-amber-500/15 text-amber-200",
-    progressColor: "from-amber-400 via-amber-300 to-amber-200",
     ctaClass: "bg-amber-500/20 text-amber-100 hover:bg-amber-500/30",
   },
   {
-    id: "deep-work",
-    name: "Deep Work Sprint",
-    description: "Protect 90 minutes for uninterrupted creation time.",
-    emoji: "⚡",
-    frequency: "Weekdays · 9am",
-    streak: 7,
-    bestStreak: 18,
-    completionRate: 74,
-    lastCompleted: "Yesterday",
-    tags: ["Creation", "Distraction-free"],
-    iconBg: "bg-purple-500/15 text-purple-200",
-    progressColor: "from-purple-400 via-purple-300 to-purple-200",
-    ctaClass: "bg-purple-500/20 text-purple-100 hover:bg-purple-500/30",
-  },
-  {
-    id: "training",
-    name: "Marathon Prep",
-    description: "Stack endurance with alternating run and strength days.",
-    emoji: "🏃",
-    frequency: "5× weekly",
-    streak: 9,
-    bestStreak: 21,
-    completionRate: 68,
-    lastCompleted: "This morning",
-    tags: ["Energy", "Discipline"],
     iconBg: "bg-emerald-500/15 text-emerald-200",
-    progressColor: "from-emerald-400 via-emerald-300 to-emerald-200",
     ctaClass: "bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30",
   },
   {
-    id: "language",
-    name: "Spanish Sessions",
-    description: "Practice with Duolingo and a five-minute voice note recap.",
-    emoji: "🗣️",
-    frequency: "Daily · Evening",
-    streak: 16,
-    bestStreak: 34,
-    completionRate: 91,
-    lastCompleted: "Last night",
-    tags: ["Language", "Consistency"],
     iconBg: "bg-sky-500/15 text-sky-200",
-    progressColor: "from-sky-400 via-sky-300 to-sky-200",
     ctaClass: "bg-sky-500/20 text-sky-100 hover:bg-sky-500/30",
   },
   {
-    id: "recovery",
-    name: "Wind-Down Ritual",
-    description: "Low lights, reflection journal, and zero screens by 10pm.",
-    emoji: "🌙",
-    frequency: "Daily · Night",
-    streak: 22,
-    bestStreak: 40,
-    completionRate: 88,
-    lastCompleted: "10 hours ago",
-    tags: ["Recovery", "Sleep"],
     iconBg: "bg-indigo-500/15 text-indigo-200",
-    progressColor: "from-indigo-400 via-indigo-300 to-indigo-200",
     ctaClass: "bg-indigo-500/20 text-indigo-100 hover:bg-indigo-500/30",
   },
   {
-    id: "reflection",
-    name: "Daily Reflection",
-    description: "Capture one win, one lesson, and tomorrow's priority.",
-    emoji: "📝",
-    frequency: "Daily · Night",
-    streak: 28,
-    bestStreak: 45,
-    completionRate: 94,
-    lastCompleted: "Last night",
-    tags: ["Clarity", "Momentum"],
+    iconBg: "bg-purple-500/15 text-purple-200",
+    ctaClass: "bg-purple-500/20 text-purple-100 hover:bg-purple-500/30",
+  },
+  {
     iconBg: "bg-rose-500/15 text-rose-200",
-    progressColor: "from-rose-400 via-rose-300 to-rose-200",
     ctaClass: "bg-rose-500/20 text-rose-100 hover:bg-rose-500/30",
   },
 ];
 
+function formatRelativeTime(value: string | null | undefined) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
+  const diff = Date.now() - date.getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(days / 365);
+  return `${years}y ago`;
+}
+
+function formatTitleCase(value: string | null | undefined) {
+  if (!value) return null;
+  return value
+    .replace(/[_-]+/g, " ")
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 export default function HabitsPage() {
+  const router = useRouter();
+  const supabase = getSupabaseBrowser();
+  const [habits, setHabits] = useState<Habit[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchHabits = async () => {
+      if (!supabase) {
+        if (isMounted) {
+          setError("Supabase client not available");
+          setLoading(false);
+        }
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const {
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
+
+        if (userError) throw userError;
+        if (!user) {
+          if (isMounted) {
+            setHabits([]);
+            setError("You need to be signed in to view habits.");
+          }
+          return;
+        }
+
+        const data = await getHabits(user.id);
+        if (isMounted) {
+          setHabits(data);
+          setError(null);
+        }
+      } catch (err) {
+        console.error("Failed to load habits:", err);
+        if (isMounted) {
+          setError("Unable to load habits right now.");
+          setHabits([]);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchHabits();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [supabase]);
+
+  const summaryCards = useMemo(() => {
+    const totalHabits = habits.length;
+    const dailyHabits = habits.filter(
+      (habit) => habit.recurrence?.toLowerCase() === "daily"
+    ).length;
+    const latestUpdate = habits.reduce<string | null>((latest, habit) => {
+      if (!latest) return habit.updated_at;
+      return new Date(habit.updated_at) > new Date(latest)
+        ? habit.updated_at
+        : latest;
+    }, null);
+
+    const formattedLatest = latestUpdate ? formatRelativeTime(latestUpdate) : "—";
+
+    return [
+      {
+        id: "total",
+        label: "Total habits",
+        value: String(totalHabits),
+        detail: "Active routines",
+        ...SUMMARY_STYLES[0],
+      },
+      {
+        id: "daily",
+        label: "Daily cadence",
+        value: String(dailyHabits),
+        detail: "Marked as daily",
+        ...SUMMARY_STYLES[1],
+      },
+      {
+        id: "recent",
+        label: "Recently refreshed",
+        value: formattedLatest,
+        detail: "Last update",
+        ...SUMMARY_STYLES[2],
+      },
+    ];
+  }, [habits]);
+
+  const hasHabits = habits.length > 0;
+
   return (
     <ProtectedRoute>
       <div className="min-h-screen bg-[#05070c] pb-16 text-white">
@@ -143,119 +207,154 @@ export default function HabitsPage() {
           </PageHeader>
 
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {summaryCards.map((card) => (
-              <div
-                key={card.id}
-                className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_20px_35px_-25px_rgba(15,23,42,0.65)]"
-              >
-                <div
-                  className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${card.accent} opacity-80`}
-                  aria-hidden
-                />
-                <div className="relative flex flex-col gap-4">
-                  <div className="flex items-center gap-3 text-sm font-medium uppercase tracking-[0.2em] text-white/60">
-                    <span className="h-1.5 w-1.5 rounded-full bg-white/70 shadow-[0_0_20px_6px_rgba(255,255,255,0.15)]" />
-                    {card.label}
-                  </div>
-                  <div className="flex items-end justify-between">
-                    <span className="text-3xl font-semibold tracking-tight text-white">{card.value}</span>
-                    <span className="rounded-full bg-white/5 px-3 py-1 text-xs text-white/70">{card.detail}</span>
-                  </div>
-                  <div className="h-1 w-full overflow-hidden rounded-full bg-white/10">
-                    <div className={`h-full w-1/3 ${card.glow} blur-md`} aria-hidden />
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          <SectionHeader
-            title="Your daily rhythm"
-            description="Track streaks, consistency, and the rituals that keep you moving."
-            className="text-white"
-          />
-
-          <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
-            {habitHighlights.map((habit) => (
-              <article
-                key={habit.id}
-                className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_18px_45px_-25px_rgba(15,23,42,0.6)] transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_28px_55px_-20px_rgba(15,23,42,0.7)]"
-              >
-                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.18),transparent_60%)] opacity-0 transition duration-300 group-hover:opacity-100" />
-                <div className="relative flex items-start justify-between gap-4">
-                  <div className={`flex h-12 w-12 items-center justify-center rounded-xl text-2xl ${habit.iconBg}`}>
-                    <span role="img" aria-label="habit icon">
-                      {habit.emoji}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70">
-                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                    {habit.frequency}
-                  </div>
-                </div>
-
-                <div className="relative mt-6 space-y-2">
-                  <h3 className="text-xl font-semibold tracking-tight text-white">{habit.name}</h3>
-                  <p className="text-sm text-white/70">{habit.description}</p>
-                </div>
-
-                <div className="relative mt-6 space-y-4">
-                  <div className="grid grid-cols-3 gap-3 text-xs text-white/60">
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-3">
-                      <p className="font-medium text-white/80">{habit.streak} days</p>
-                      <p>Current streak</p>
-                    </div>
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-3">
-                      <p className="font-medium text-white/80">{habit.bestStreak} days</p>
-                      <p>Best streak</p>
-                    </div>
-                    <div className="rounded-xl border border-white/5 bg-white/5 p-3">
-                      <p className="font-medium text-white/80">{habit.completionRate}%</p>
-                      <p>Consistency</p>
-                    </div>
-                  </div>
-
-                  <div>
-                    <div className="flex items-center justify-between text-xs text-white/60">
-                      <span>Progress this week</span>
-                      <span className="font-semibold text-white/80">{habit.completionRate}%</span>
-                    </div>
-                    <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-white/10">
-                      <div
-                        className={`h-full rounded-full bg-gradient-to-r ${habit.progressColor}`}
-                        style={{ width: `${habit.completionRate}%` }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap gap-2">
-                    {habit.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-white/60"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="relative mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-white/5 pt-5 text-xs text-white/60">
-                  <div className="flex items-center gap-2">
-                    <span className="text-base">🕒</span>
-                    <span>Last check-in {habit.lastCompleted}</span>
-                  </div>
-                  <button
-                    type="button"
-                    className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition ${habit.ctaClass}`}
+            {loading
+              ? Array.from({ length: 3 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6"
                   >
-                    <span>Mark complete</span>
-                    <span aria-hidden>→</span>
-                  </button>
-                </div>
-              </article>
-            ))}
+                    <Skeleton className="h-5 w-32" />
+                    <div className="mt-4 space-y-3">
+                      <Skeleton className="h-8 w-1/2" />
+                      <Skeleton className="h-3 w-24" />
+                      <Skeleton className="h-1 w-full" />
+                    </div>
+                  </div>
+                ))
+              : summaryCards.map((card) => (
+                  <div
+                    key={card.id}
+                    className="relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-6 shadow-[0_20px_35px_-25px_rgba(15,23,42,0.65)]"
+                  >
+                    <div
+                      className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${card.accent} opacity-80`}
+                      aria-hidden
+                    />
+                    <div className="relative flex flex-col gap-4">
+                      <div className="flex items-center gap-3 text-sm font-medium uppercase tracking-[0.2em] text-white/60">
+                        <span className="h-1.5 w-1.5 rounded-full bg-white/70 shadow-[0_0_20px_6px_rgba(255,255,255,0.15)]" />
+                        {card.label}
+                      </div>
+                      <div className="flex items-end justify-between">
+                        <span className="text-3xl font-semibold tracking-tight text-white">{card.value}</span>
+                        <span className="rounded-full bg-white/5 px-3 py-1 text-xs text-white/70">{card.detail}</span>
+                      </div>
+                      <div className="h-1 w-full overflow-hidden rounded-full bg-white/10">
+                        <div className={`h-full w-1/3 ${card.glow} blur-md`} aria-hidden />
+                      </div>
+                    </div>
+                  </div>
+                ))}
           </div>
+
+          {error && (
+            <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+              {error}
+            </div>
+          )}
+
+          {loading ? (
+            <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="relative flex h-full flex-col gap-4 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-6"
+                >
+                  <Skeleton className="h-12 w-12 rounded-xl" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-5 w-3/4" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-2/3" />
+                  </div>
+                  <Skeleton className="mt-2 h-3 w-24" />
+                </div>
+              ))}
+            </div>
+          ) : hasHabits ? (
+            <>
+              <SectionHeader
+                title="Your daily rhythm"
+                description="Track streaks, consistency, and the rituals that keep you moving."
+                className="text-white"
+              />
+
+              <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+                {habits.map((habit, index) => {
+                  const palette = CARD_STYLES[index % CARD_STYLES.length];
+                  const initials = habit.name.charAt(0).toUpperCase();
+                  const habitType = formatTitleCase(habit.habit_type);
+                  const recurrence = formatTitleCase(habit.recurrence);
+
+                  return (
+                    <article
+                      key={habit.id}
+                      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-[0_18px_45px_-25px_rgba(15,23,42,0.6)] transition duration-300 hover:-translate-y-1 hover:border-white/20 hover:shadow-[0_28px_55px_-20px_rgba(15,23,42,0.7)]"
+                    >
+                      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.18),transparent_60%)] opacity-0 transition duration-300 group-hover:opacity-100" />
+                      <div className="relative flex items-start justify-between gap-4">
+                        <div
+                          className={`flex h-12 w-12 items-center justify-center rounded-xl text-2xl font-semibold ${palette.iconBg}`}
+                        >
+                          {initials}
+                        </div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {habitType && (
+                            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70">
+                              {habitType}
+                            </span>
+                          )}
+                          {recurrence && (
+                            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70">
+                              {recurrence}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="relative mt-6 space-y-3">
+                        <h3 className="text-xl font-semibold tracking-tight text-white">
+                          {habit.name}
+                        </h3>
+                        {habit.description && (
+                          <p className="text-sm text-white/70">{habit.description}</p>
+                        )}
+                      </div>
+
+                      <div className="relative mt-6 space-y-3 text-xs text-white/60">
+                        <div className="flex items-center gap-2">
+                          <span className="text-base">🕒</span>
+                          <span>Updated {formatRelativeTime(habit.updated_at)}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-base">📅</span>
+                          <span>Created {formatRelativeTime(habit.created_at)}</span>
+                        </div>
+                      </div>
+
+                      <div className="relative mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-white/5 pt-5 text-xs text-white/60">
+                        <div className="flex items-center gap-2">
+                          <span className="text-base">✨</span>
+                          <span>Keep the streak going</span>
+                        </div>
+                        <button
+                          type="button"
+                          className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition ${palette.ctaClass}`}
+                          disabled
+                        >
+                          <span>Mark complete</span>
+                          <span aria-hidden>→</span>
+                        </button>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </>
+          ) : (
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03]">
+              <HabitsEmptyState onAction={() => router.push("/habits/new")} />
+            </div>
+          )}
         </div>
       </div>
     </ProtectedRoute>

--- a/src/app/(app)/habits/page.tsx
+++ b/src/app/(app)/habits/page.tsx
@@ -284,6 +284,12 @@ export default function HabitsPage() {
                   const initials = habit.name.charAt(0).toUpperCase();
                   const habitType = formatTitleCase(habit.habit_type);
                   const recurrence = formatTitleCase(habit.recurrence);
+                  const hasDuration =
+                    typeof habit.duration_minutes === "number" &&
+                    habit.duration_minutes > 0;
+                  const durationLabel = hasDuration
+                    ? `${habit.duration_minutes} min`
+                    : null;
 
                   return (
                     <article
@@ -308,6 +314,11 @@ export default function HabitsPage() {
                               {recurrence}
                             </span>
                           )}
+                          {durationLabel && (
+                            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-wide text-white/70">
+                              {durationLabel}
+                            </span>
+                          )}
                         </div>
                       </div>
 
@@ -325,6 +336,12 @@ export default function HabitsPage() {
                           <span className="text-base">🕒</span>
                           <span>Updated {formatRelativeTime(habit.updated_at)}</span>
                         </div>
+                        {durationLabel && (
+                          <div className="flex items-center gap-2">
+                            <span className="text-base">⏱️</span>
+                            <span>Planned for {durationLabel}</span>
+                          </div>
+                        )}
                         <div className="flex items-center gap-2">
                           <span className="text-base">📅</span>
                           <span>Created {formatRelativeTime(habit.created_at)}</span>


### PR DESCRIPTION
## Summary
- add a Supabase browser query for loading the authenticated user's habits
- update the habits page to fetch live data, show loading and error states, and render the empty state when no habits exist

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68df6e18e57c832cad33f196b51500e4