### PR TITLE
Update schedule window report styling to silver gray

### DIFF
--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2205,7 +2205,7 @@ export default function SchedulePage() {
                 style={{ top: report.top, height: report.height }}
               >
                 <div
-                  className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-white/60 px-3 py-2 text-slate-100 backdrop-blur-md"
+                  className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] px-3 py-2 text-slate-100 backdrop-blur-md"
                   style={{
                     background:
                       'radial-gradient(140% 160% at 0% 0%, rgba(255,255,255,0.3), rgba(148,163,184,0.06) 60%), linear-gradient(180deg, rgba(148,163,184,0.14), rgba(24,32,48,0.35))',

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2204,41 +2204,25 @@ export default function SchedulePage() {
                 className="absolute left-16 right-2"
                 style={{ top: report.top, height: report.height }}
               >
-                <div
-                  className="relative flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] text-slate-800 backdrop-blur-md"
-                  style={{
-                    boxShadow:
-                      '0 0 46px rgba(220, 230, 255, 0.55), 0 24px 60px rgba(8, 12, 28, 0.46)',
-                  }}
-                >
-                  <div
-                    className="pointer-events-none absolute inset-0"
-                    style={{
-                      background:
-                        'radial-gradient(140% 160% at 6% 4%, rgba(255,255,255,0.9) 0%, rgba(241,245,255,0.55) 48%, rgba(221,231,255,0.35) 100%), linear-gradient(150deg, rgba(248,250,255,0.92) 0%, rgba(232,236,248,0.72) 52%, rgba(200,210,230,0.45) 100%)',
-                      opacity: 0.5,
-                    }}
-                  />
-                  <div className="relative z-10 flex h-full flex-col px-3 py-2">
-                    <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-600">
-                      Window report · {report.windowLabel}
-                    </div>
-                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-slate-600">
-                      <span>{report.rangeLabel}</span>
-                      <span>Energy: {report.energyLabel}</span>
-                      <span>Duration: {report.durationLabel}</span>
-                    </div>
-                    <p className="mt-2 text-[11px] leading-snug text-slate-700">
-                      {report.summary}
-                    </p>
-                    {report.details.length > 0 && (
-                      <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-slate-600">
-                        {report.details.map((detail, index) => (
-                          <li key={`${report.key}-detail-${index}`}>{detail}</li>
-                        ))}
-                      </ul>
-                    )}
+                <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-sky-500/35 bg-sky-500/10 px-3 py-2 text-sky-100 shadow-[0_18px_38px_rgba(8,12,28,0.55)] backdrop-blur-sm">
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-sky-200/80">
+                    Window report · {report.windowLabel}
                   </div>
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-sky-200/70">
+                    <span>{report.rangeLabel}</span>
+                    <span>Energy: {report.energyLabel}</span>
+                    <span>Duration: {report.durationLabel}</span>
+                  </div>
+                  <p className="mt-2 text-[11px] leading-snug text-sky-50">
+                    {report.summary}
+                  </p>
+                  {report.details.length > 0 && (
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-sky-100/85">
+                      {report.details.map((detail, index) => (
+                        <li key={`${report.key}-detail-${index}`}>{detail}</li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
               </div>
             ))}

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2204,20 +2204,20 @@ export default function SchedulePage() {
                 className="absolute left-16 right-2"
                 style={{ top: report.top, height: report.height }}
               >
-                <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-sky-500/35 bg-sky-500/10 px-3 py-2 text-sky-100 shadow-[0_18px_38px_rgba(8,12,28,0.55)] backdrop-blur-sm">
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-sky-200/80">
+                <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-zinc-200/40 bg-zinc-200/10 px-3 py-2 text-zinc-100 shadow-[0_18px_38px_rgba(8,12,28,0.55)] backdrop-blur-sm">
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-zinc-100/80">
                     Window report · {report.windowLabel}
                   </div>
-                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-sky-200/70">
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-zinc-100/70">
                     <span>{report.rangeLabel}</span>
                     <span>Energy: {report.energyLabel}</span>
                     <span>Duration: {report.durationLabel}</span>
                   </div>
-                  <p className="mt-2 text-[11px] leading-snug text-sky-50">
+                  <p className="mt-2 text-[11px] leading-snug text-zinc-50">
                     {report.summary}
                   </p>
                   {report.details.length > 0 && (
-                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-sky-100/85">
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-zinc-100/85">
                       {report.details.map((detail, index) => (
                         <li key={`${report.key}-detail-${index}`}>{detail}</li>
                       ))}

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2204,20 +2204,20 @@ export default function SchedulePage() {
                 className="absolute left-16 right-2"
                 style={{ top: report.top, height: report.height }}
               >
-                <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-zinc-200/40 bg-zinc-200/10 px-3 py-2 text-zinc-100 shadow-[0_18px_38px_rgba(8,12,28,0.55)] backdrop-blur-sm">
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-zinc-100/80">
+                <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-zinc-100/55 bg-zinc-100/16 px-3 py-2 text-zinc-100 shadow-[0_18px_38px_rgba(8,12,28,0.55)] backdrop-blur-sm">
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-zinc-50/85">
                     Window report · {report.windowLabel}
                   </div>
-                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-zinc-100/70">
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-zinc-50/80">
                     <span>{report.rangeLabel}</span>
                     <span>Energy: {report.energyLabel}</span>
                     <span>Duration: {report.durationLabel}</span>
                   </div>
-                  <p className="mt-2 text-[11px] leading-snug text-zinc-50">
+                  <p className="mt-2 text-[11px] leading-snug text-zinc-50/95">
                     {report.summary}
                   </p>
                   {report.details.length > 0 && (
-                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-zinc-100/85">
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-zinc-50/85">
                       {report.details.map((detail, index) => (
                         <li key={`${report.key}-detail-${index}`}>{detail}</li>
                       ))}

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2205,27 +2205,27 @@ export default function SchedulePage() {
                 style={{ top: report.top, height: report.height }}
               >
                 <div
-                  className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] px-3 py-2 text-slate-100 backdrop-blur-md"
+                  className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] px-3 py-2 text-slate-800 backdrop-blur-md"
                   style={{
                     background:
-                      'radial-gradient(140% 160% at 0% 0%, rgba(255,255,255,0.3), rgba(148,163,184,0.06) 60%), linear-gradient(180deg, rgba(148,163,184,0.14), rgba(24,32,48,0.35))',
+                      'radial-gradient(140% 160% at 6% 4%, rgba(255,255,255,0.9) 0%, rgba(241,245,255,0.55) 48%, rgba(221,231,255,0.35) 100%), linear-gradient(150deg, rgba(248,250,255,0.92) 0%, rgba(232,236,248,0.72) 52%, rgba(200,210,230,0.45) 100%)',
                     boxShadow:
-                      '0 0 36px rgba(180, 200, 255, 0.24), 0 20px 44px rgba(8, 12, 28, 0.55)',
+                      '0 0 46px rgba(220, 230, 255, 0.55), 0 24px 60px rgba(8, 12, 28, 0.46)',
                   }}
                 >
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-50/90">
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-600">
                     Window report · {report.windowLabel}
                   </div>
-                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-slate-50/85">
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-slate-600">
                     <span>{report.rangeLabel}</span>
                     <span>Energy: {report.energyLabel}</span>
                     <span>Duration: {report.durationLabel}</span>
                   </div>
-                  <p className="mt-2 text-[11px] leading-snug text-slate-50">
+                  <p className="mt-2 text-[11px] leading-snug text-slate-700">
                     {report.summary}
                   </p>
                   {report.details.length > 0 && (
-                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-slate-100/90">
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-slate-600">
                       {report.details.map((detail, index) => (
                         <li key={`${report.key}-detail-${index}`}>{detail}</li>
                       ))}

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2205,32 +2205,40 @@ export default function SchedulePage() {
                 style={{ top: report.top, height: report.height }}
               >
                 <div
-                  className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] px-3 py-2 text-slate-800 backdrop-blur-md"
+                  className="relative flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] text-slate-800 backdrop-blur-md"
                   style={{
-                    background:
-                      'radial-gradient(140% 160% at 6% 4%, rgba(255,255,255,0.9) 0%, rgba(241,245,255,0.55) 48%, rgba(221,231,255,0.35) 100%), linear-gradient(150deg, rgba(248,250,255,0.92) 0%, rgba(232,236,248,0.72) 52%, rgba(200,210,230,0.45) 100%)',
                     boxShadow:
                       '0 0 46px rgba(220, 230, 255, 0.55), 0 24px 60px rgba(8, 12, 28, 0.46)',
                   }}
                 >
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-600">
-                    Window report · {report.windowLabel}
+                  <div
+                    className="pointer-events-none absolute inset-0"
+                    style={{
+                      background:
+                        'radial-gradient(140% 160% at 6% 4%, rgba(255,255,255,0.9) 0%, rgba(241,245,255,0.55) 48%, rgba(221,231,255,0.35) 100%), linear-gradient(150deg, rgba(248,250,255,0.92) 0%, rgba(232,236,248,0.72) 52%, rgba(200,210,230,0.45) 100%)',
+                      opacity: 0.5,
+                    }}
+                  />
+                  <div className="relative z-10 flex h-full flex-col px-3 py-2">
+                    <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-600">
+                      Window report · {report.windowLabel}
+                    </div>
+                    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-slate-600">
+                      <span>{report.rangeLabel}</span>
+                      <span>Energy: {report.energyLabel}</span>
+                      <span>Duration: {report.durationLabel}</span>
+                    </div>
+                    <p className="mt-2 text-[11px] leading-snug text-slate-700">
+                      {report.summary}
+                    </p>
+                    {report.details.length > 0 && (
+                      <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-slate-600">
+                        {report.details.map((detail, index) => (
+                          <li key={`${report.key}-detail-${index}`}>{detail}</li>
+                        ))}
+                      </ul>
+                    )}
                   </div>
-                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-slate-600">
-                    <span>{report.rangeLabel}</span>
-                    <span>Energy: {report.energyLabel}</span>
-                    <span>Duration: {report.durationLabel}</span>
-                  </div>
-                  <p className="mt-2 text-[11px] leading-snug text-slate-700">
-                    {report.summary}
-                  </p>
-                  {report.details.length > 0 && (
-                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-slate-600">
-                      {report.details.map((detail, index) => (
-                        <li key={`${report.key}-detail-${index}`}>{detail}</li>
-                      ))}
-                    </ul>
-                  )}
                 </div>
               </div>
             ))}

--- a/src/app/(app)/schedule/page.tsx
+++ b/src/app/(app)/schedule/page.tsx
@@ -2204,20 +2204,28 @@ export default function SchedulePage() {
                 className="absolute left-16 right-2"
                 style={{ top: report.top, height: report.height }}
               >
-                <div className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-zinc-100/55 bg-zinc-100/16 px-3 py-2 text-zinc-100 shadow-[0_18px_38px_rgba(8,12,28,0.55)] backdrop-blur-sm">
-                  <div className="text-[10px] font-semibold uppercase tracking-wide text-zinc-50/85">
+                <div
+                  className="flex h-full flex-col overflow-hidden rounded-[var(--radius-lg)] border border-white/60 px-3 py-2 text-slate-100 backdrop-blur-md"
+                  style={{
+                    background:
+                      'radial-gradient(140% 160% at 0% 0%, rgba(255,255,255,0.3), rgba(148,163,184,0.06) 60%), linear-gradient(180deg, rgba(148,163,184,0.14), rgba(24,32,48,0.35))',
+                    boxShadow:
+                      '0 0 36px rgba(180, 200, 255, 0.24), 0 20px 44px rgba(8, 12, 28, 0.55)',
+                  }}
+                >
+                  <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-50/90">
                     Window report · {report.windowLabel}
                   </div>
-                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-zinc-50/80">
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-slate-50/85">
                     <span>{report.rangeLabel}</span>
                     <span>Energy: {report.energyLabel}</span>
                     <span>Duration: {report.durationLabel}</span>
                   </div>
-                  <p className="mt-2 text-[11px] leading-snug text-zinc-50/95">
+                  <p className="mt-2 text-[11px] leading-snug text-slate-50">
                     {report.summary}
                   </p>
                   {report.details.length > 0 && (
-                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-zinc-50/85">
+                    <ul className="mt-2 list-disc space-y-1 pl-4 text-[10px] text-slate-100/90">
                       {report.details.map((detail, index) => (
                         <li key={`${report.key}-detail-${index}`}>{detail}</li>
                       ))}

--- a/src/components/schedule/DayTimeline.tsx
+++ b/src/components/schedule/DayTimeline.tsx
@@ -52,9 +52,9 @@ export function DayTimeline({
   }
 
   const backgroundGradient = [
-    "radial-gradient(140% 140% at 0% 0%, rgba(56, 189, 248, 0.25), rgba(56, 189, 248, 0) 60%)",
-    "radial-gradient(120% 120% at 100% 100%, rgba(192, 132, 252, 0.2), rgba(192, 132, 252, 0) 62%)",
-    "linear-gradient(180deg, rgba(15, 23, 42, 0.94), rgba(15, 23, 42, 0.78))",
+    "radial-gradient(140% 140% at 0% 0%, rgba(24, 24, 27, 0.65), rgba(24, 24, 27, 0) 60%)",
+    "radial-gradient(120% 120% at 100% 100%, rgba(39, 39, 42, 0.5), rgba(39, 39, 42, 0) 62%)",
+    "linear-gradient(180deg, rgba(10, 10, 10, 0.95), rgba(24, 24, 27, 0.85))",
   ].join(", ");
 
   return (


### PR DESCRIPTION
## Summary
- restyle the schedule page window report panels with neutral silver-gray colors instead of blue accents

## Testing
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68df72905904832c8c3ae8c25b5baee4