### PR TITLE
Add goal deletion with cascading cleanup

### DIFF
--- a/src/app/(app)/goals/components/GoalCard.tsx
+++ b/src/app/(app)/goals/components/GoalCard.tsx
@@ -15,9 +15,10 @@ interface GoalCardProps {
   goal: Goal;
   onEdit?: () => void;
   onToggleActive?: () => void;
+  onDelete?: () => void;
 }
 
-export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
+export function GoalCard({ goal, onEdit, onToggleActive, onDelete }: GoalCardProps) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -106,6 +107,12 @@ export function GoalCard({ goal, onEdit, onToggleActive }: GoalCardProps) {
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => onToggleActive?.()}>
                 {goal.active ? "Mark Inactive" : "Mark Active"}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-rose-400 focus:text-rose-300"
+                onSelect={() => onDelete?.()}
+              >
+                Delete
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
## Summary
- add a delete action to goal cards on the Goals page
- cascade goal deletion to related projects, tasks, and project skill links before removing the goal itself

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68df7532f8f8832ca14ad15d09ec9957