### PR TITLE
Add carousel reorder controls for categories

### DIFF
--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -64,9 +64,11 @@ interface Props {
   onIconChange?: (icon: string | null) => void;
   menuOpen?: boolean;
   onMenuOpenChange?: (open: boolean) => void;
-  onReorder?: (direction: "left" | "right") => void;
+  onReorder?: (direction: "left" | "right" | "first" | "last") => void;
   canMoveLeft?: boolean;
   canMoveRight?: boolean;
+  canMoveToStart?: boolean;
+  canMoveToEnd?: boolean;
   isReordering?: boolean;
 }
 
@@ -84,6 +86,8 @@ export default function CategoryCard({
   onReorder,
   canMoveLeft,
   canMoveRight,
+  canMoveToStart,
+  canMoveToEnd,
   isReordering,
 }: Props) {
   const [color, setColor] = useState(colorOverride || category.color_hex || "#000000");
@@ -314,12 +318,21 @@ export default function CategoryCard({
                   ) : orderOpen ? (
                     <div className="space-y-3">
                       <p className="text-xs font-semibold uppercase text-slate-500">Reorder category</p>
-                      <div className="flex items-center justify-between gap-2 rounded-xl border border-black/20 bg-white/90 px-3 py-2">
+                      <div className="flex items-center gap-2 rounded-xl border border-black/20 bg-white/90 px-3 py-2">
+                        <button
+                          type="button"
+                          onClick={() => onReorder?.("first")}
+                          disabled={!onReorder || !canMoveToStart || isReordering}
+                          className="w-[20%] rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          aria-label="Move to first position"
+                        >
+                          <span aria-hidden>⏮</span>
+                        </button>
                         <button
                           type="button"
                           onClick={() => onReorder?.("left")}
                           disabled={!onReorder || !canMoveLeft || isReordering}
-                          className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          className="flex-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
                         >
                           Move left
                         </button>
@@ -327,9 +340,18 @@ export default function CategoryCard({
                           type="button"
                           onClick={() => onReorder?.("right")}
                           disabled={!onReorder || !canMoveRight || isReordering}
-                          className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          className="flex-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
                         >
                           Move right
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onReorder?.("last")}
+                          disabled={!onReorder || !canMoveToEnd || isReordering}
+                          className="w-[20%] rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          aria-label="Move to last position"
+                        >
+                          <span aria-hidden>⏭</span>
                         </button>
                       </div>
                       <p className="text-xs text-slate-500">

--- a/src/app/(app)/dashboard/_skills/CategoryCard.tsx
+++ b/src/app/(app)/dashboard/_skills/CategoryCard.tsx
@@ -318,40 +318,56 @@ export default function CategoryCard({
                   ) : orderOpen ? (
                     <div className="space-y-3">
                       <p className="text-xs font-semibold uppercase text-slate-500">Reorder category</p>
-                      <div className="flex items-center gap-2 rounded-xl border border-black/20 bg-white/90 px-3 py-2">
+                      <div className="flex items-stretch divide-x divide-black/10 overflow-hidden rounded-full border border-black/10 bg-white/90 text-slate-700 shadow-sm backdrop-blur-sm">
                         <button
                           type="button"
                           onClick={() => onReorder?.("first")}
                           disabled={!onReorder || !canMoveToStart || isReordering}
-                          className="w-[20%] rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          className="group relative flex h-9 basis-[18%] items-center justify-center text-xs font-semibold uppercase tracking-wide transition-colors hover:bg-slate-900/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/30 focus-visible:ring-offset-1 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-40"
                           aria-label="Move to first position"
                         >
-                          <span aria-hidden>⏮</span>
+                          <span aria-hidden className="relative text-base">⏮</span>
+                          <span
+                            className="pointer-events-none absolute inset-0 opacity-0 transition group-active:opacity-100 group-focus-visible:opacity-100"
+                            style={{ background: withAlpha("#0f172a", 0.04) }}
+                          />
                         </button>
                         <button
                           type="button"
                           onClick={() => onReorder?.("left")}
                           disabled={!onReorder || !canMoveLeft || isReordering}
-                          className="flex-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          className="group relative flex flex-1 items-center justify-center px-5 text-xs font-semibold uppercase tracking-wide transition-colors hover:bg-slate-900/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/30 focus-visible:ring-offset-1 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                          Move left
+                          <span className="relative">Move left</span>
+                          <span
+                            className="pointer-events-none absolute inset-0 opacity-0 transition group-active:opacity-100 group-focus-visible:opacity-100"
+                            style={{ background: withAlpha("#0f172a", 0.04) }}
+                          />
                         </button>
                         <button
                           type="button"
                           onClick={() => onReorder?.("right")}
                           disabled={!onReorder || !canMoveRight || isReordering}
-                          className="flex-1 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          className="group relative flex flex-1 items-center justify-center px-5 text-xs font-semibold uppercase tracking-wide transition-colors hover:bg-slate-900/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/30 focus-visible:ring-offset-1 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-40"
                         >
-                          Move right
+                          <span className="relative">Move right</span>
+                          <span
+                            className="pointer-events-none absolute inset-0 opacity-0 transition group-active:opacity-100 group-focus-visible:opacity-100"
+                            style={{ background: withAlpha("#0f172a", 0.04) }}
+                          />
                         </button>
                         <button
                           type="button"
                           onClick={() => onReorder?.("last")}
                           disabled={!onReorder || !canMoveToEnd || isReordering}
-                          className="w-[20%] rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide transition disabled:cursor-not-allowed disabled:opacity-40"
+                          className="group relative flex h-9 basis-[18%] items-center justify-center text-xs font-semibold uppercase tracking-wide transition-colors hover:bg-slate-900/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/30 focus-visible:ring-offset-1 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-40"
                           aria-label="Move to last position"
                         >
-                          <span aria-hidden>⏭</span>
+                          <span aria-hidden className="relative text-base">⏭</span>
+                          <span
+                            className="pointer-events-none absolute inset-0 opacity-0 transition group-active:opacity-100 group-focus-visible:opacity-100"
+                            style={{ background: withAlpha("#0f172a", 0.04) }}
+                          />
                         </button>
                       </div>
                       <p className="text-xs text-slate-500">


### PR DESCRIPTION
## Summary
- replace the numeric category ordering input with inline move left/right controls and status messaging
- manage category order locally in the carousel, persist swaps to Supabase, and disable moves while saves are in flight

## Testing
- pnpm lint
- pnpm test:env

------
https://chatgpt.com/codex/tasks/task_e_68df749354c4832cb59fc5955ff85deb