### PR TITLE
Fix bottom bar navigation active state on nested routes

### DIFF
--- a/components/BottomBarNav.tsx
+++ b/components/BottomBarNav.tsx
@@ -15,7 +15,9 @@ export interface BottomBarNavProps {
 
 export function BottomBarNav({ items, currentPath, onNavigate }: BottomBarNavProps) {
   const renderItem = (item: BottomBarNavItem) => {
-    const isActive = item.href === currentPath;
+    const isActive =
+      item.href === currentPath ||
+      (item.href !== "/" && currentPath.startsWith(`${item.href}/`));
     return (
       <a
         key={item.key}


### PR DESCRIPTION
## Summary
- update BottomBarNav so parent tabs stay active while browsing nested routes

## Testing
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfdc255980832cad1c2b3b98640717