### PR TITLE
Add schedule jump-to-date and search sheets

### DIFF
--- a/src/components/schedule/JumpToDateSheet.tsx
+++ b/src/components/schedule/JumpToDateSheet.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+interface JumpToDateSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentDate: Date;
+  onSelectDate: (date: Date) => void;
+}
+
+const WEEKDAY_LABELS = (() => {
+  try {
+    return Array.from({ length: 7 }, (_, index) =>
+      new Intl.DateTimeFormat(undefined, {
+        weekday: "short",
+      })
+        .format(new Date(Date.UTC(2024, 6, index + 7)))
+        .slice(0, 2)
+    );
+  } catch (error) {
+    console.warn("Unable to format weekday labels", error);
+    return ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+  }
+})();
+
+export function JumpToDateSheet({
+  open,
+  onOpenChange,
+  currentDate,
+  onSelectDate,
+}: JumpToDateSheetProps) {
+  const initialMonth = useMemo(() => {
+    const base = new Date(currentDate);
+    return new Date(base.getFullYear(), base.getMonth(), 1);
+  }, [currentDate]);
+
+  const [visibleMonth, setVisibleMonth] = useState(initialMonth);
+
+  useEffect(() => {
+    if (open) {
+      setVisibleMonth(initialMonth);
+    }
+  }, [open, initialMonth]);
+
+  const today = useMemo(() => new Date(), []);
+
+  const monthMetadata = useMemo(() => {
+    const year = visibleMonth.getFullYear();
+    const month = visibleMonth.getMonth();
+    const monthStart = new Date(year, month, 1);
+    const monthLabel = monthStart.toLocaleDateString(undefined, {
+      month: "long",
+      year: "numeric",
+    });
+    const firstWeekday = monthStart.getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+    const cells: Array<Date | null> = [];
+    for (let i = 0; i < firstWeekday; i += 1) {
+      cells.push(null);
+    }
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      cells.push(new Date(year, month, day));
+    }
+    while (cells.length % 7 !== 0) {
+      cells.push(null);
+    }
+
+    const weeks: Array<Array<Date | null>> = [];
+    for (let index = 0; index < cells.length; index += 7) {
+      weeks.push(cells.slice(index, index + 7));
+    }
+
+    return { monthLabel, weeks };
+  }, [visibleMonth]);
+
+  const handleSelect = (date: Date) => {
+    onSelectDate(new Date(date));
+  };
+
+  const goToOffsetMonth = (offset: number) => {
+    setVisibleMonth(prev => {
+      const next = new Date(prev);
+      next.setMonth(prev.getMonth() + offset);
+      next.setDate(1);
+      return next;
+    });
+  };
+
+  const handleSelectToday = () => {
+    onSelectDate(new Date(today));
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="bg-[var(--surface-elevated)] border-t border-white/10 p-0 text-[var(--text-primary)]"
+      >
+        <SheetHeader className="px-4 pt-4 pb-2">
+          <SheetTitle className="text-lg font-semibold">Jump to date</SheetTitle>
+          <SheetDescription className="text-sm text-[var(--text-secondary)]">
+            Pick a date to instantly change the schedule view.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex flex-col gap-4 px-4 pb-4">
+          <div className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+            <button
+              type="button"
+              onClick={() => goToOffsetMonth(-1)}
+              className="rounded-full p-2 text-white/70 transition hover:bg-white/10 hover:text-white"
+              aria-label="Previous month"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+            <div className="flex items-center gap-2 text-sm font-medium uppercase tracking-[0.2em] text-white/80">
+              <CalendarDays className="h-4 w-4" />
+              <span>{monthMetadata.monthLabel}</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => goToOffsetMonth(1)}
+              className="rounded-full p-2 text-white/70 transition hover:bg-white/10 hover:text-white"
+              aria-label="Next month"
+            >
+              <ChevronRight className="h-5 w-5" />
+            </button>
+          </div>
+
+          <div className="overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="text-[11px] uppercase tracking-[0.28em] text-white/60">
+                  {WEEKDAY_LABELS.map(label => (
+                    <th key={label} className="py-2 text-center font-medium">
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="text-base">
+                {monthMetadata.weeks.map((week, weekIndex) => (
+                  <tr key={`week-${weekIndex}`} className="h-12 text-center">
+                    {week.map((day, dayIndex) => {
+                      if (!day) {
+                        return <td key={`empty-${weekIndex}-${dayIndex}`} />;
+                      }
+                      const isToday = isSameDay(day, today);
+                      const isSelected = isSameDay(day, currentDate);
+                      const isWeekend = day.getDay() === 0 || day.getDay() === 6;
+                      return (
+                        <td key={day.toISOString()} className="py-1">
+                          <button
+                            type="button"
+                            onClick={() => handleSelect(day)}
+                            className={cn(
+                              "mx-auto flex h-10 w-10 items-center justify-center rounded-xl border text-sm font-semibold transition",
+                              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-white",
+                              isSelected
+                                ? "border-transparent bg-[var(--accent-red)] text-white shadow-[0_14px_34px_rgba(252,165,165,0.45)]"
+                                : "border-transparent bg-transparent text-white/80 hover:bg-white/10",
+                              isToday && !isSelected && "border border-white/40",
+                              isWeekend && !isSelected && "text-white/60"
+                            )}
+                            aria-current={isSelected ? "date" : undefined}
+                            aria-label={day.toLocaleDateString(undefined, {
+                              weekday: "long",
+                              month: "long",
+                              day: "numeric",
+                              year: "numeric",
+                            })}
+                          >
+                            {day.getDate()}
+                          </button>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleSelectToday}
+              className="rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/15"
+            >
+              Today
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+

--- a/src/components/schedule/ScheduleSearchSheet.tsx
+++ b/src/components/schedule/ScheduleSearchSheet.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { CalendarClock, Search, Sparkles } from "lucide-react";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { ScheduleInstance } from "@/lib/scheduler/instanceRepo";
+import type { TaskLite } from "@/lib/scheduler/weight";
+import type { ProjectItem } from "@/lib/scheduler/projects";
+import { toLocal } from "@/lib/time/tz";
+import { cn } from "@/lib/utils";
+
+interface ScheduleSearchSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  instances: ScheduleInstance[];
+  taskMap: Record<string, TaskLite>;
+  projectMap: Record<string, ProjectItem>;
+  onSelectResult: (payload: { instanceId: string; date: Date }) => void;
+}
+
+type SearchableInstance = {
+  instance: ScheduleInstance;
+  label: string;
+  type: "task" | "project";
+  detail: string;
+  dateLabel: string;
+  start: Date;
+  searchableText: string;
+};
+
+export function ScheduleSearchSheet({
+  open,
+  onOpenChange,
+  instances,
+  taskMap,
+  projectMap,
+  onSelectResult,
+}: ScheduleSearchSheetProps) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      const id = requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+    return undefined;
+  }, [open]);
+
+  const searchableItems = useMemo(() => {
+    const items: SearchableInstance[] = [];
+    for (const instance of instances) {
+      const start = toLocal(instance.start_utc);
+      const end = toLocal(instance.end_utc);
+      if (!isValidDate(start) || !isValidDate(end)) {
+        continue;
+      }
+
+      if (!instance.source_id) continue;
+
+      if (instance.source_type === "TASK") {
+        const task = taskMap[instance.source_id];
+        if (!task) continue;
+        const label = task.name || "Untitled task";
+        const detail = formatTimeRange(start, end);
+        const dateLabel = formatDate(start);
+        const searchableText = [label, detail, dateLabel, "task"]
+          .join(" ")
+          .toLowerCase();
+        items.push({
+          instance,
+          label,
+          type: "task",
+          detail,
+          dateLabel,
+          start,
+          searchableText,
+        });
+      } else if (instance.source_type === "PROJECT") {
+        const project = projectMap[instance.source_id];
+        if (!project) continue;
+        const label = project.name || "Untitled project";
+        const detail = formatTimeRange(start, end);
+        const dateLabel = formatDate(start);
+        const searchableText = [label, detail, dateLabel, "project"]
+          .join(" ")
+          .toLowerCase();
+        items.push({
+          instance,
+          label,
+          type: "project",
+          detail,
+          dateLabel,
+          start,
+          searchableText,
+        });
+      }
+    }
+
+    return items.sort((a, b) => a.start.getTime() - b.start.getTime());
+  }, [instances, projectMap, taskMap]);
+
+  const filteredItems = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return searchableItems;
+    return searchableItems.filter(item => item.searchableText.includes(trimmed));
+  }, [query, searchableItems]);
+
+  const showEmptyState = filteredItems.length === 0;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className="bg-[var(--surface-elevated)] border-t border-white/10 p-0 text-[var(--text-primary)]"
+      >
+        <SheetHeader className="px-4 pt-4 pb-2">
+          <SheetTitle className="text-lg font-semibold">Search day schedule</SheetTitle>
+          <SheetDescription className="text-sm text-[var(--text-secondary)]">
+            Find a scheduled task or project and jump straight to it.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="px-4 pb-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/50" />
+            <Input
+              ref={inputRef}
+              value={query}
+              onChange={event => setQuery(event.target.value)}
+              placeholder="Search by title or time"
+              className="border-white/15 bg-white/5 pl-10 text-sm text-white placeholder:text-white/40"
+              aria-label="Search scheduled items"
+            />
+          </div>
+        </div>
+        <ScrollArea className="max-h-[60vh] px-4 pb-6">
+          <div className="flex flex-col gap-2 pb-2">
+            {filteredItems.map(item => (
+              <button
+                key={item.instance.id}
+                type="button"
+                onClick={() =>
+                  onSelectResult({
+                    instanceId: item.instance.id,
+                    date: item.start,
+                  })
+                }
+                className="group flex w-full items-center justify-between gap-4 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-left text-sm text-white transition hover:border-white/20 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium">{item.label}</span>
+                    <span
+                      className={cn(
+                        "flex items-center gap-1 rounded-full border border-white/15 bg-white/10 px-2 py-0.5 text-[11px] uppercase tracking-[0.16em] text-white/70",
+                        item.type === "project" && "border-blue-400/30 text-blue-100",
+                        item.type === "task" && "border-emerald-400/30 text-emerald-100"
+                      )}
+                    >
+                      <Sparkles className="h-3 w-3" />
+                      {item.type}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-[12px] text-white/60">
+                    {item.detail}
+                  </div>
+                </div>
+                <div className="flex flex-col items-end text-right text-[12px] text-white/60">
+                  <span className="flex items-center gap-1">
+                    <CalendarClock className="h-3.5 w-3.5" />
+                    {item.dateLabel}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+          {showEmptyState && (
+            <div className="flex flex-col items-center gap-3 rounded-2xl border border-dashed border-white/15 bg-white/5 px-6 py-10 text-center text-sm text-white/65">
+              <Sparkles className="h-6 w-6 text-white/50" />
+              <div className="space-y-1">
+                <p className="font-medium text-white/80">No matching schedule items</p>
+                <p className="text-xs text-white/60">
+                  {query.trim()
+                    ? "Try a different keyword or check another day."
+                    : "Nothing is scheduled for this day yet."}
+                </p>
+              </div>
+            </div>
+          )}
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function isValidDate(value: Date) {
+  return Number.isFinite(value.getTime());
+}
+
+function formatTimeRange(start: Date, end: Date) {
+  try {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    return `${formatter.format(start)} – ${formatter.format(end)}`;
+  } catch (error) {
+    console.warn("Unable to format time range", error);
+    return `${start.toLocaleTimeString()} – ${end.toLocaleTimeString()}`;
+  }
+}
+
+function formatDate(date: Date) {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    }).format(date);
+  } catch (error) {
+    console.warn("Unable to format date label", error);
+    return date.toLocaleDateString();
+  }
+}
+

--- a/src/components/schedule/ScheduleTopBar.tsx
+++ b/src/components/schedule/ScheduleTopBar.tsx
@@ -26,9 +26,18 @@ interface ScheduleTopBarProps {
   onBack: () => void;
   onToday: () => void;
   canGoBack?: boolean;
+  onOpenJumpToDate?: () => void;
+  onOpenSearch?: () => void;
 }
 
-export function ScheduleTopBar({ year, onBack, onToday, canGoBack = true }: ScheduleTopBarProps) {
+export function ScheduleTopBar({
+  year,
+  onBack,
+  onToday,
+  canGoBack = true,
+  onOpenJumpToDate,
+  onOpenSearch,
+}: ScheduleTopBarProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
 
@@ -56,10 +65,20 @@ export function ScheduleTopBar({ year, onBack, onToday, canGoBack = true }: Sche
         {year}
       </button>
       <div className="flex items-center gap-2">
-        <button className="p-2">
+        <button
+          type="button"
+          onClick={() => onOpenJumpToDate?.()}
+          aria-label="Open jump to date"
+          className="p-2"
+        >
           <Calendar className="h-5 w-5 text-[var(--accent-red)]" />
         </button>
-        <button className="p-2">
+        <button
+          type="button"
+          onClick={() => onOpenSearch?.()}
+          aria-label="Search schedule"
+          className="p-2"
+        >
           <Search className="h-5 w-5 text-[var(--accent-red)]" />
         </button>
         <Sheet open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary
- add new JumpToDateSheet and ScheduleSearchSheet overlays for the schedule view with calendar navigation and filtering
- wire the schedule top bar buttons to open the new sheets, updating the current day and focusing instances when selections are made
- mark rendered schedule instances for scrolling and ensure selecting search results jumps to the right card

## Testing
- pnpm lint
- pnpm test:env


------
https://chatgpt.com/codex/tasks/task_e_68dfdf299630832cb91d105598e7385e