### PR TITLE
Persist friend messages to Supabase

### DIFF
--- a/src/app/api/friends/[username]/messages/route.ts
+++ b/src/app/api/friends/[username]/messages/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { createSupabaseServerClient } from "@/lib/supabase-server";
+
+const sendMessageSchema = z.object({
+  body: z
+    .string()
+    .trim()
+    .min(1, "Message body is required")
+    .max(2000, "Message is too long"),
+  senderId: z.string().min(1, "Missing sender"),
+  recipientId: z.string().min(1, "Missing recipient"),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { username: string } }
+) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    if (!supabase) {
+      return NextResponse.json(
+        { error: "Supabase client unavailable" },
+        { status: 500 }
+      );
+    }
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const parsedBody = sendMessageSchema.safeParse(await request.json());
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: "Invalid request", details: parsedBody.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const { body, senderId, recipientId } = parsedBody.data;
+
+    if (senderId !== user.id) {
+      return NextResponse.json(
+        { error: "Sender mismatch" },
+        { status: 403 }
+      );
+    }
+
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("user_id")
+      .ilike("username", params.username)
+      .maybeSingle();
+
+    if (!profile) {
+      return NextResponse.json({ error: "Recipient not found" }, { status: 404 });
+    }
+
+    if (profile.user_id !== recipientId) {
+      return NextResponse.json(
+        { error: "Recipient mismatch" },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabase
+      .from("friend_messages")
+      .insert({
+        body,
+        sender_id: senderId,
+        recipient_id: recipientId,
+      })
+      .select("id, created_at")
+      .single();
+
+    if (error) {
+      console.error("Error inserting friend message", error);
+      return NextResponse.json(
+        { error: "Failed to send message" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: {
+        id: data.id,
+        createdAt: data.created_at,
+      },
+    });
+  } catch (error) {
+    console.error("Unhandled error sending friend message", error);
+    return NextResponse.json(
+      { error: "Unexpected error" },
+      { status: 500 }
+    );
+  }
+}

--- a/supabase/migrations/20250919000000_create_friend_messages.sql
+++ b/supabase/migrations/20250919000000_create_friend_messages.sql
@@ -1,0 +1,55 @@
+-- Create friend_messages table for direct messages between users
+CREATE TABLE IF NOT EXISTS public.friend_messages (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    sender_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    recipient_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    body text NOT NULL
+);
+
+-- Keep updated_at current on row updates
+CREATE OR REPLACE FUNCTION public.set_friend_messages_updated_at()
+RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ language plpgsql;
+
+DROP TRIGGER IF EXISTS friend_messages_set_updated_at ON public.friend_messages;
+CREATE TRIGGER friend_messages_set_updated_at
+    BEFORE UPDATE ON public.friend_messages
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_friend_messages_updated_at();
+
+-- Index sender and recipient for faster lookups
+CREATE INDEX IF NOT EXISTS friend_messages_sender_id_idx
+    ON public.friend_messages (sender_id);
+
+CREATE INDEX IF NOT EXISTS friend_messages_recipient_id_idx
+    ON public.friend_messages (recipient_id);
+
+-- Enable row level security and define policies
+ALTER TABLE public.friend_messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "friend_messages_select_visible" ON public.friend_messages;
+DROP POLICY IF EXISTS "friend_messages_insert_own" ON public.friend_messages;
+DROP POLICY IF EXISTS "friend_messages_update_own" ON public.friend_messages;
+DROP POLICY IF EXISTS "friend_messages_delete_own" ON public.friend_messages;
+
+CREATE POLICY "friend_messages_select_visible" ON public.friend_messages
+    FOR SELECT USING (
+        auth.uid() = sender_id OR auth.uid() = recipient_id
+    );
+
+CREATE POLICY "friend_messages_insert_own" ON public.friend_messages
+    FOR INSERT WITH CHECK (auth.uid() = sender_id);
+
+CREATE POLICY "friend_messages_update_own" ON public.friend_messages
+    FOR UPDATE USING (auth.uid() = sender_id);
+
+CREATE POLICY "friend_messages_delete_own" ON public.friend_messages
+    FOR DELETE USING (auth.uid() = sender_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.friend_messages TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -198,6 +198,32 @@ export interface Database {
           user_id?: string | null;
         };
       };
+      friend_messages: {
+        Row: {
+          id: string;
+          created_at: string;
+          updated_at: string;
+          sender_id: string;
+          recipient_id: string;
+          body: string;
+        };
+        Insert: {
+          id?: string;
+          created_at?: string;
+          updated_at?: string;
+          sender_id: string;
+          recipient_id: string;
+          body: string;
+        };
+        Update: {
+          id?: string;
+          created_at?: string;
+          updated_at?: string;
+          sender_id?: string;
+          recipient_id?: string;
+          body?: string;
+        };
+      };
       monument_skills: {
         Row: {
           user_id: string;


### PR DESCRIPTION
## Summary
- add a Supabase migration for the friend_messages table with indexes, RLS policies, and updated_at trigger
- expose a POST /api/friends/[username]/messages endpoint that validates input and stores the message with the authenticated sender
- update the message sheet to call the API with Supabase auth details and refresh generated Database types

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e09a8818cc832c9fc6f5f037335fea