### PR TITLE
Improve habit creation error reporting

### DIFF
--- a/src/app/(app)/habits/new/page.tsx
+++ b/src/app/(app)/habits/new/page.tsx
@@ -9,6 +9,7 @@ import { HabitFormFields, HABIT_RECURRENCE_OPTIONS, HABIT_TYPE_OPTIONS, type Hab
 import { PageHeader } from "@/components/ui";
 import { Button } from "@/components/ui/button";
 import { getSupabaseBrowser } from "@/lib/supabase";
+import { formatSupabaseError } from "@/lib/errors";
 
 interface WindowOption {
   id: string;
@@ -226,9 +227,7 @@ export default function NewHabitPage() {
     } catch (err) {
       console.error("Failed to create habit:", err);
       setError(
-        err instanceof Error
-          ? err.message
-          : "Unable to create the habit right now."
+        formatSupabaseError(err, "Unable to create the habit right now.")
       );
     } finally {
       setLoading(false);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,69 @@
+export interface SupabaseErrorLike {
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+  code?: string | null;
+}
+
+function isSupabaseErrorLike(error: unknown): error is SupabaseErrorLike {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    ("message" in error || "details" in error || "hint" in error || "code" in error)
+  );
+}
+
+export function formatSupabaseError(
+  error: unknown,
+  fallbackMessage: string
+): string {
+  if (!error) {
+    return fallbackMessage;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (isSupabaseErrorLike(error)) {
+    const parts: string[] = [];
+
+    if (typeof error.message === "string" && error.message.trim()) {
+      parts.push(error.message.trim());
+    }
+
+    if (typeof error.details === "string" && error.details.trim()) {
+      const details = error.details.trim();
+      if (!parts.includes(details)) {
+        parts.push(details);
+      }
+    }
+
+    if (typeof error.hint === "string" && error.hint.trim()) {
+      parts.push(error.hint.trim());
+    }
+
+    if (
+      typeof error.code === "string" &&
+      error.code.trim() &&
+      !parts.some((part) => part.includes(error.code as string))
+    ) {
+      parts.push(`(Error code: ${error.code.trim()})`);
+    }
+
+    if (parts.length > 0) {
+      return parts.join(" ");
+    }
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch (jsonError) {
+    console.error("Failed to stringify Supabase error:", jsonError);
+    return fallbackMessage;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared formatter that extracts details from Supabase/PostgREST style errors
- surface formatted error messages when habit creation fails so users see why saves fail

## Testing
- pnpm lint *(fails: existing lint warnings/errors in unrelated files)*
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e131a27898832c931807ba9da6789b