### PR TITLE
Ensure habit cards render above scheduled projects

### DIFF
--- a/src/lib/scheduler/habits.ts
+++ b/src/lib/scheduler/habits.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getSupabaseBrowser } from '@/lib/supabase'
+import type { Database } from '../../../types/supabase'
+
+export const DEFAULT_HABIT_DURATION_MIN = 15
+
+export type HabitScheduleItem = {
+  id: string
+  name: string
+  durationMinutes: number | null
+  createdAt: string | null
+  updatedAt: string | null
+  windowId: string | null
+  recurrence: string | null
+  window: {
+    id: string
+    label: string | null
+    energy: string | null
+    startLocal: string
+    endLocal: string
+    days: number[] | null
+  } | null
+}
+
+type Client = SupabaseClient<Database>
+
+function ensureClient(client?: Client): Client {
+  if (client) return client
+  const supabase = getSupabaseBrowser()
+  if (!supabase) throw new Error('Supabase client not available')
+  return supabase as Client
+}
+
+export async function fetchHabitsForSchedule(client?: Client): Promise<HabitScheduleItem[]> {
+  const supabase = ensureClient(client)
+
+  const { data, error } = await supabase
+    .from('habits')
+    .select(
+      `id, name, duration_minutes, created_at, updated_at, window_id, recurrence, window:windows(id, label, energy, start_local, end_local, days)`
+    )
+
+  if (error) throw error
+
+  type HabitRecord = {
+    id: string
+    name?: string | null
+    duration_minutes?: number | null
+    created_at?: string | null
+    updated_at?: string | null
+    window_id?: string | null
+    recurrence?: string | null
+    window?: {
+      id?: string
+      label?: string | null
+      energy?: string | null
+      start_local?: string | null
+      end_local?: string | null
+      days?: number[] | null
+    } | null
+  }
+
+  return (data ?? []).map((record: HabitRecord) => ({
+    id: record.id,
+    name: record.name ?? 'Untitled habit',
+    durationMinutes: record.duration_minutes ?? null,
+    createdAt: record.created_at ?? null,
+    updatedAt: record.updated_at ?? null,
+    windowId: record.window_id ?? null,
+    recurrence: record.recurrence ?? null,
+    window: record.window
+      ? {
+          id: record.window.id ?? '',
+          label: record.window.label ?? null,
+          energy: record.window.energy ?? null,
+          startLocal: record.window.start_local ?? '00:00',
+          endLocal: record.window.end_local ?? '00:00',
+          days: record.window.days ?? null,
+        }
+      : null,
+  }))
+}


### PR DESCRIPTION
## Summary
- prioritize habit scheduling in the rescheduler by creating habit draft placements before projects and tracking them on the timeline
- add a habits repository helper and extend schedule timeline models to include habit placements
- render habit cards in the day view timeline alongside existing project instances
- ensure habit cards sit above overlapping project cards in the day timeline so they remain visible

## Testing
- pnpm lint *(not rerun: previously failing because of pre-existing @typescript-eslint/no-explicit-any errors in test specs)*
- vitest run test/env.spec.ts *(run via pre-commit hook)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ff3b1624832cade83dbc8a224ae5