### PR TITLE
Add skill progress mapping helper and tests

### DIFF
--- a/lib/skills/skillProgress.ts
+++ b/lib/skills/skillProgress.ts
@@ -1,0 +1,43 @@
+import { xpRequired } from "./progression";
+
+export interface SkillProgressRow {
+  skill_id: string;
+  level: number | string | null;
+  prestige: number | string | null;
+  xp_into_level: number | string | null;
+}
+
+export interface SkillProgressData {
+  level: number;
+  prestige: number;
+  xpIntoLevel: number;
+  xpRequired: number;
+  progressPercent: number;
+}
+
+function coerceNumber(value: number | string | null | undefined, fallback: number) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export function mapRowToProgress(row: SkillProgressRow | null): SkillProgressData | null {
+  if (!row?.skill_id) return null;
+  const level = coerceNumber(row.level, 1);
+  const prestige = coerceNumber(row.prestige, 0);
+  const xpIntoLevel = Math.max(0, coerceNumber(row.xp_into_level, 0));
+  const required = xpRequired(level, prestige);
+  const safeRequired = required > 0 ? required : 1;
+  const percent = Math.max(0, Math.min(100, (xpIntoLevel / safeRequired) * 100));
+
+  return {
+    level,
+    prestige,
+    xpIntoLevel,
+    xpRequired: safeRequired,
+    progressPercent: percent,
+  };
+}

--- a/test/lib/skills/progression.spec.ts
+++ b/test/lib/skills/progression.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { baseBracket, xpRequired } from "../../../lib/skills/progression";
+import { mapRowToProgress } from "../../../lib/skills/skillProgress";
+
+describe("progression helpers", () => {
+  it("computes base bracket for known ranges", () => {
+    expect(baseBracket(1)).toBe(10);
+    expect(baseBracket(9)).toBe(10);
+    expect(baseBracket(10)).toBe(14);
+    expect(baseBracket(19)).toBe(14);
+    expect(baseBracket(20)).toBe(20);
+    expect(baseBracket(29)).toBe(20);
+    expect(baseBracket(30)).toBe(24);
+    expect(baseBracket(39)).toBe(24);
+    expect(baseBracket(40)).toBe(30);
+    expect(baseBracket(99)).toBe(30);
+    expect(baseBracket(100)).toBe(50);
+  });
+
+  it("adds prestige bonus to xp requirement", () => {
+    expect(xpRequired(10, 0)).toBe(14);
+    expect(xpRequired(10, 3)).toBe(20);
+    expect(xpRequired(25, 5)).toBe(30);
+    expect(xpRequired(100, 2)).toBe(54);
+    expect(xpRequired(8, -3)).toBe(10);
+  });
+});
+
+describe("mapRowToProgress", () => {
+  it("maps xp progress using computed requirement", () => {
+    const progress = mapRowToProgress({
+      skill_id: "skill",
+      level: 12,
+      prestige: 2,
+      xp_into_level: 5,
+    });
+
+    expect(progress).not.toBeNull();
+    expect(progress?.xpRequired).toBe(xpRequired(12, 2));
+    expect(progress?.xpIntoLevel).toBe(5);
+    expect(progress?.progressPercent).toBeCloseTo((5 / xpRequired(12, 2)) * 100);
+  });
+
+  it("falls back when numbers are missing or invalid", () => {
+    const progress = mapRowToProgress({
+      skill_id: "skill",
+      level: null,
+      prestige: "not-a-number",
+      xp_into_level: -10,
+    });
+
+    expect(progress).not.toBeNull();
+    expect(progress?.level).toBe(1);
+    expect(progress?.prestige).toBe(0);
+    expect(progress?.xpIntoLevel).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the skill progress mapping logic into a shared helper that normalizes numeric values and computes the XP requirement
- update the dashboard skill progress hook to consume the helper and streamline realtime update handling
- add Vitest coverage for the progression brackets and mapping edge cases to guard the calculations

## Testing
- pnpm test --run test/lib/skills/progression.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e52937b8c0832c8d21e4eefa8c6ce5