### PR TITLE
Fix lint warnings in list components

### DIFF
--- a/components/TopNavAvatar.tsx
+++ b/components/TopNavAvatar.tsx
@@ -40,7 +40,7 @@ export default function TopNavAvatar({ profile, userId }: TopNavAvatarProps) {
         } else {
           router.push("/profile");
         }
-      } catch (error) {
+      } catch {
         // Fallback to profile page if error
         router.push("/profile");
       }
@@ -59,7 +59,7 @@ export default function TopNavAvatar({ profile, userId }: TopNavAvatarProps) {
         } else {
           router.push("/profile");
         }
-      } catch (error) {
+      } catch {
         router.push("/profile");
       }
     }

--- a/components/ui/GoalList.tsx
+++ b/components/ui/GoalList.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { Badge } from "./badge";
-import { Card, CardContent, CardHeader, CardTitle } from "./card";
+import { Card, CardContent } from "./card";
 import { EmptyState } from "./empty-state";
 
 interface Goal {
@@ -19,11 +19,7 @@ export function GoalList() {
   const [loading, setLoading] = useState(true);
   const supabase = getSupabaseBrowser();
 
-  useEffect(() => {
-    loadGoals();
-  }, []);
-
-  const loadGoals = async () => {
+  const loadGoals = useCallback(async () => {
     if (!supabase) {
       console.error("Supabase client not available");
       setLoading(false);
@@ -61,7 +57,7 @@ export function GoalList() {
       // If no goals, let's check if the table exists
       if (!data || data.length === 0) {
         console.log("No goals found, checking if table exists...");
-        const { data: tableCheck, error: tableError } = await supabase
+        const { error: tableError } = await supabase
           .from("goals")
           .select("count")
           .limit(1);
@@ -82,7 +78,11 @@ export function GoalList() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    void loadGoals();
+  }, [loadGoals]);
 
   if (loading) {
     return (

--- a/components/ui/ProjectList.tsx
+++ b/components/ui/ProjectList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { EmptyState } from "./empty-state";
 import { getProjectsForUser } from "@/lib/queries/projects";
@@ -28,11 +28,7 @@ export function ProjectList() {
   const [loading, setLoading] = useState(true);
   const supabase = getSupabaseBrowser();
 
-  useEffect(() => {
-    loadProjects();
-  }, []);
-
-  const loadProjects = async () => {
+  const loadProjects = useCallback(async () => {
     if (!supabase) {
       console.error("Supabase client not available");
       setLoading(false);
@@ -73,7 +69,11 @@ export function ProjectList() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
 
   if (loading) {
     return (

--- a/components/ui/TaskList.tsx
+++ b/components/ui/TaskList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
 import { Badge } from "./badge";
 import { Card, CardContent } from "./card";
@@ -28,11 +28,7 @@ export function TaskList() {
   const [loading, setLoading] = useState(true);
   const supabase = getSupabaseBrowser();
 
-  useEffect(() => {
-    loadTasks();
-  }, []);
-
-  const loadTasks = async () => {
+  const loadTasks = useCallback(async () => {
     if (!supabase) {
       console.error("Supabase client not available");
       setLoading(false);
@@ -91,7 +87,11 @@ export function TaskList() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [supabase]);
+
+  useEffect(() => {
+    void loadTasks();
+  }, [loadTasks]);
 
   if (loading) {
     return (

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -31,7 +31,7 @@ export async function uploadAvatar(
     const fileName = `${userId}-${Date.now()}.${fileExt}`;
 
     // Upload to avatars bucket
-    const { data, error } = await supabase.storage
+    const { error } = await supabase.storage
       .from("avatars")
       .upload(fileName, file, {
         cacheControl: "3600",
@@ -76,7 +76,7 @@ export async function uploadBanner(
     const fileExt = file.name.split(".").pop();
     const fileName = `${userId}-banner-${Date.now()}.${fileExt}`;
 
-    const { data, error } = await supabase.storage
+    const { error } = await supabase.storage
       .from("banners")
       .upload(fileName, file, {
         cacheControl: "3600",


### PR DESCRIPTION
## Summary
- wrap the goal, project, and task loaders in `useCallback` and clean up unused card imports
- remove unused caught error variables in the top nav avatar and supabase storage helpers

## Testing
- pnpm lint
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5da968b4c832cbf5ff5010907922e