### PR TITLE
Backfill skill progress rows for existing and new skills

### DIFF
--- a/supabase/migrations/20251201000000_backfill_skill_progress.sql
+++ b/supabase/migrations/20251201000000_backfill_skill_progress.sql
@@ -1,0 +1,34 @@
+-- Ensure every skill has a matching progress row and keep it in sync for new skills
+
+-- Backfill existing skills into skill_progress
+INSERT INTO public.skill_progress (user_id, skill_id)
+SELECT s.user_id, s.id
+FROM public.skills AS s
+WHERE s.user_id IS NOT NULL
+ON CONFLICT (user_id, skill_id) DO NOTHING;
+
+-- Create a trigger to automatically seed progress when new skills are created
+CREATE OR REPLACE FUNCTION public.on_skill_after_insert_seed_progress()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.user_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.skill_progress (user_id, skill_id)
+  VALUES (NEW.user_id, NEW.id)
+  ON CONFLICT (user_id, skill_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_skill_seed_progress ON public.skills;
+CREATE TRIGGER trg_skill_seed_progress
+AFTER INSERT ON public.skills
+FOR EACH ROW
+EXECUTE FUNCTION public.on_skill_after_insert_seed_progress();


### PR DESCRIPTION
## Summary
- backfill missing skill_progress rows for all existing skills
- add a trigger to automatically create a skill_progress entry whenever a new skill is inserted

## Testing
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5e02439d0832c8262b0bddbc33444