### PR TITLE
Hide global scrollbars

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -43,6 +43,16 @@ html,body{
   touch-action:pan-y;
   overflow-x:hidden;
 }
+
+html{
+  scrollbar-width:none;
+}
+body{
+  -ms-overflow-style:none;
+}
+body::-webkit-scrollbar{
+  display:none;
+}
 .section{ padding:20px 16px 8px; }
 .h-label{ letter-spacing:.12em; text-transform:uppercase; font-weight:700; color:var(--muted); font-size:12px; }
 .card{ background:linear-gradient(180deg,var(--surface),var(--surface-2));


### PR DESCRIPTION
## Summary
- hide the default scrollbar track globally to remove the tacky scroll slider

## Testing
- vitest run test/env.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5e0c52514832ca266da4231578c8f