### PR TITLE
Fix goal saving on monument detail edit drawers

### DIFF
--- a/src/app/(app)/goals/components/GoalDrawer.tsx
+++ b/src/app/(app)/goals/components/GoalDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { CalendarDays, ChevronDown, Plus, X } from "lucide-react";
 import { listRoadmaps, createRoadmap } from "@/lib/queries/roadmaps";
 import { getSupabaseBrowser } from "@/lib/supabase";
@@ -293,7 +293,7 @@ export function GoalDrawer({
     "initialGoal:",
     initialGoal?.id
   );
-  const formId = "goal-editor-form";
+  const formId = `goal-editor-form-${useId()}`;
   const [title, setTitle] = useState("");
   const [emoji, setEmoji] = useState("");
   const [hasCustomEmoji, setHasCustomEmoji] = useState(false);


### PR DESCRIPTION
### Motivation
- Fix save failures on monument detail pages where two `GoalDrawer` instances (standalone + roadmap) rendered simultaneously and shared the same `goal-editor-form` id, causing the Save button to target the wrong form.

### Description
- Import `useId` and set `formId` to `` `goal-editor-form-${useId()}` `` in `src/app/(app)/goals/components/GoalDrawer.tsx` so each drawer instance receives a unique form id.

### Testing
- Ran `pnpm -s eslint 'src/app/(app)/goals/components/GoalDrawer.tsx'` (no errors, only existing warnings) and `vitest run test/env.spec.ts` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d880a4bd04832cae23128ddf79ca91)