### PR TITLE
Fix duplicate monument roadmap goals

### DIFF
--- a/src/components/monuments/MonumentGoalsList.tsx
+++ b/src/components/monuments/MonumentGoalsList.tsx
@@ -360,6 +360,26 @@ async function fetchGoalWithRelationsById(goalId: string) {
   return (fallback.data as GoalRowWithRelations | null) ?? null;
 }
 
+function collectRoadmapItemGoalIds(
+  roadmapsWithItems: RoadmapWithItems[]
+): Set<string> {
+  const goalIds = new Set<string>();
+
+  for (const roadmap of roadmapsWithItems) {
+    for (const item of roadmap.items) {
+      if (item.goal?.id) {
+        goalIds.add(item.goal.id);
+      }
+
+      for (const campaignGoal of item.campaign?.goals ?? []) {
+        goalIds.add(campaignGoal.id);
+      }
+    }
+  }
+
+  return goalIds;
+}
+
 async function fetchTrueRoadmapsForMonument(
   userId: string,
   monumentId: string
@@ -1169,11 +1189,18 @@ export function MonumentGoalsList({
       );
     }
 
-    // Compute standalone goals by excluding any that belong to a roadmap
-    const roadmapGoalIds = new Set<string>(
+    // Compute standalone goals by excluding any that already render inside a roadmap.
+    // Campaign goals do not always carry a `roadmap_id`, so collect the ids from
+    // the mixed roadmap payload as well as the legacy roadmap grouping.
+    const legacyRoadmapGoalIds = new Set<string>(
       roadmaps.flatMap((r) => (roadmapGoals.get(r.id) ?? []).map((g) => g.id))
     );
-    const standaloneGoals = goals.filter((g) => !roadmapGoalIds.has(g.id));
+    const trueRoadmapGoalIds = collectRoadmapItemGoalIds(
+      monumentRoadmapsWithItems
+    );
+    const standaloneGoals = goals.filter(
+      (g) => !legacyRoadmapGoalIds.has(g.id) && !trueRoadmapGoalIds.has(g.id)
+    );
     const isCompletedGoal = (goal: Goal) => goal.status === "COMPLETED";
     const filterGoalBySection = (goal: Goal) =>
       goalSection === "completed" ? isCompletedGoal(goal) : !isCompletedGoal(goal);


### PR DESCRIPTION
### Motivation
- Campaign goals that are rendered inside mixed roadmap items were also showing up as standalone goal cards on the monument details page because they sometimes lack a `roadmap_id` and weren't excluded when building the standalone goal list.

### Description
- Added `collectRoadmapItemGoalIds` helper to gather goal ids from mixed roadmap payloads (top-level goal items and nested campaign goals) in `MonumentGoalsList.tsx`.
- Updated standalone goal computation to exclude goals that appear in either legacy roadmap groupings or the mixed roadmap items, preventing duplicate rendering of campaign-contained goals.
- Only the monument details goal list was modified (`src/components/monuments/MonumentGoalsList.tsx`).

### Testing
- Ran lint on the modified file with `npx eslint src/components/monuments/MonumentGoalsList.tsx` (no issues reported for the changed file).
- Executed the lightweight test environment check via `vitest run test/env.spec.ts` (passed).
- Ran `npx tsc --noEmit` which failed due to unrelated repo-wide TypeScript errors outside the scope of this change, so type-checking the whole repo was not used to gate this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd50444788832c8e745580c584b231)