### PR TITLE
Fix FabNexus search results clipping

### DIFF
--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -12308,7 +12308,7 @@ function FabNexus({
 
   return (
     <div
-      className="flex h-full w-full flex-col text-white"
+      className="flex h-full min-h-0 w-full flex-col text-white"
       style={{ backgroundColor: "rgba(0,0,0,0.75)" }}
     >
       <div className="px-4 pt-4">
@@ -12426,7 +12426,7 @@ function FabNexus({
         </div>
       ) : null}
       <div
-        className="flex-1 overflow-y-auto px-4 pb-4 pr-5 pt-3"
+        className="min-h-0 flex-1 overflow-y-auto px-4 pb-4 pr-5 pt-3"
         data-fab-nexus-scroll="true"
         onScroll={handleScroll}
       >


### PR DESCRIPTION
### Motivation
- The Nexus search list inside the FAB overlay was being visually clipped because the Nexus container and its results pane could not shrink to fit the fixed-height FAB panel; the change lets the search list own its scrollable space so results are not cut off.

### Description
- Adjusted `components/ui/Fab.tsx` to allow the Nexus container and results area to shrink and scroll by adding `min-h-0` to the root Nexus container and the results wrapper (`className` updates to `"flex h-full min-h-0 w-full flex-col text-white"` and `"min-h-0 flex-1 overflow-y-auto ..."`).

### Testing
- Ran the environment tests with `pnpm test:env` which passed (`test/env.spec.ts` passed). 
- Ran `pnpm lint` and `pnpm exec eslint components/ui/Fab.tsx`, which reported existing repository lint/type issues unrelated to this change (lint did not pass due to pre-existing errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd50c9d32c832c907f695494e638fb)