### PR TITLE
Fix lint cluster in utils and scheduler scripts

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,7 +8,7 @@ export function cn(...inputs: ClassValue[]) {
 function safeDateTimeFormat(
   locale: string | undefined,
   tz: string | null | undefined,
-  options: any
+  options: Intl.DateTimeFormatOptions
 ) {
   if (!tz) {
     throw new Error("TZ_NULL_SENTINEL");

--- a/scripts/run-scheduler.ts
+++ b/scripts/run-scheduler.ts
@@ -57,7 +57,7 @@ async function main() {
   } catch (error) {
     console.error("Scheduler run failed:", error);
     // Attempt to unwrap causes for fetch failures
-    const cause = (error as any)?.cause;
+    const cause = (error as { cause?: unknown })?.cause;
     if (cause) {
       console.error("Cause:", cause);
     }

--- a/scripts/verify-no-overlap.ts
+++ b/scripts/verify-no-overlap.ts
@@ -32,7 +32,7 @@ async function main() {
     endMs: new Date(row.end_utc).getTime(),
   }));
 
-  let overlaps = [] as Array<{
+  const overlaps = [] as Array<{
     a: typeof instances[number];
     b: typeof instances[number];
   }>;


### PR DESCRIPTION
### Motivation
- Address a small, safe cluster of lint errors to satisfy stricter TypeScript/ESLint rules in utilities and scheduler helper scripts.
- Reduce noisy build-time errors caused by `any` usage and mutable/incorrect declarations in verification and scheduler code.
- Keep behavioral changes to a minimum while improving type safety and lint compliance.

### Description
- In `lib/utils.ts` replaced the broad `any` on `safeDateTimeFormat` with `Intl.DateTimeFormatOptions` to provide a precise type for `options` while preserving runtime behavior.
- In `scripts/verify-no-overlap.ts` changed `let overlaps = []` to `const overlaps = []` to satisfy `prefer-const` since the array reference is never reassigned.
- In `scripts/run-scheduler.ts` narrowed the error cast from `any` to `{ cause?: unknown }` before accessing `.cause` to remove an `@typescript-eslint/no-explicit-any` violation.

### Testing
- Ran `npx eslint lib/utils.ts scripts/verify-no-overlap.ts scripts/run-scheduler.ts`, which completed successfully for the targeted files (no blocking errors for those files).
- Ran the repository lint `npm run lint -- --max-warnings=0` to locate the cluster; the repo still has other unrelated lint violations outside this fix scope.
- Ran environment tests with `npm run test:env` (`vitest` for `test/env.spec.ts`), and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1254384914832ca6c0d0aea0ba856d)