### PR TITLE
Avatar image fit and profile dropdown visual updates

### DIFF
--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -28,7 +28,7 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full object-cover object-center", className)}
       {...props}
     />
   )

--- a/src/app/(app)/profile/LinkMeProfile.tsx
+++ b/src/app/(app)/profile/LinkMeProfile.tsx
@@ -406,7 +406,7 @@ export default function LinkMeProfile({ profile }: LinkMeProfileProps) {
                   <Menu className="h-5 w-5" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuContent align="end" className="w-56 border border-gray-200 bg-gradient-to-b from-gray-100 to-gray-200 text-gray-900">
                 <DropdownMenuLabel>Profile actions</DropdownMenuLabel>
                 <DropdownMenuItem
                   className="flex items-center gap-2"


### PR DESCRIPTION
### Motivation
- Ensure avatar images fill and center inside circular avatar containers to avoid stretching or misalignment.
- Improve visibility and visual separation of the profile actions menu by adding a border, background gradient, and text color.

### Description
- Updated `components/ui/avatar.tsx` to add `object-cover object-center` to the `AvatarImage` `className` so images properly cover and center within the avatar.
- Updated `src/app/(app)/profile/LinkMeProfile.tsx` to replace `className="w-56"` on `DropdownMenuContent` with `className="w-56 border border-gray-200 bg-gradient-to-b from-gray-100 to-gray-200 text-gray-900"` to add a border, gradient background, and explicit text color.

### Testing
- Ran TypeScript type-check and linting, and they completed successfully.
- Executed the existing frontend test suite and visual/interaction smoke checks, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156b10ef8c832c990357cdb867f1ed)