### PR TITLE
Update FAB launcher glass styling

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -119,7 +119,6 @@ export default function BottomNav() {
       </div>
       <style jsx>{`
         :global([data-bottom-nav] [data-tour="fab"]) {
-          box-shadow: 0 16px 30px rgba(0, 0, 0, 0.65) !important;
           filter: none !important;
         }
         :global(body.fab-panel-active [data-bottom-nav-bar]),

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -14875,7 +14875,7 @@ export function Fab({
           onClick={handleFabButtonClick}
           aria-label={isOpen ? "Open ILAV" : "Add new item"}
           className={cn(
-            "relative flex h-14 w-14 items-center justify-center overflow-visible rounded-full text-white shadow-lg transition hover:scale-110",
+            "relative flex h-14 w-14 items-center justify-center overflow-visible rounded-full border border-white/20 text-white shadow-lg backdrop-blur-xl transition hover:scale-110 hover:border-white/30",
             isOpen ? "rotate-45" : "",
             shouldAttachCreationControls ? "pointer-events-none opacity-0" : "",
           )}
@@ -14887,9 +14887,9 @@ export function Fab({
           transition={{ type: "spring", stiffness: 500, damping: 25 }}
           style={{
             background:
-              "linear-gradient(145deg, #111827 0%, #0f172a 55%, #020617 100%)",
+              "linear-gradient(145deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.10) 46%, rgba(255,255,255,0.055) 100%)",
             boxShadow:
-              "0 25px 60px rgba(15, 23, 42, 0.85), 0 12px 32px rgba(15, 23, 42, 0.65), inset 0 1px 0 rgba(255, 255, 255, 0.18)",
+              "inset 0 1px 0 rgba(255,255,255,0.32), inset 0 -10px 18px rgba(0,0,0,0.22), 0 18px 38px rgba(0,0,0,0.48), 0 8px 18px rgba(0,0,0,0.34)",
             filter: "none",
           }}
         >

--- a/components/ui/Fab.tsx
+++ b/components/ui/Fab.tsx
@@ -14875,7 +14875,7 @@ export function Fab({
           onClick={handleFabButtonClick}
           aria-label={isOpen ? "Open ILAV" : "Add new item"}
           className={cn(
-            "relative flex h-14 w-14 items-center justify-center overflow-visible rounded-full border border-white/20 text-white shadow-lg backdrop-blur-xl transition hover:scale-110 hover:border-white/30",
+            "relative flex h-14 w-14 items-center justify-center overflow-visible rounded-full border border-white/[0.12] text-white shadow-lg backdrop-blur-xl transition hover:scale-110 hover:border-white/[0.18]",
             isOpen ? "rotate-45" : "",
             shouldAttachCreationControls ? "pointer-events-none opacity-0" : "",
           )}
@@ -14887,9 +14887,9 @@ export function Fab({
           transition={{ type: "spring", stiffness: 500, damping: 25 }}
           style={{
             background:
-              "linear-gradient(145deg, rgba(255,255,255,0.20) 0%, rgba(255,255,255,0.10) 46%, rgba(255,255,255,0.055) 100%)",
+              "linear-gradient(145deg, rgba(18,18,22,0.94) 0%, rgba(8,9,12,0.88) 48%, rgba(2,3,6,0.92) 100%)",
             boxShadow:
-              "inset 0 1px 0 rgba(255,255,255,0.32), inset 0 -10px 18px rgba(0,0,0,0.22), 0 18px 38px rgba(0,0,0,0.48), 0 8px 18px rgba(0,0,0,0.34)",
+              "inset 0 1px 0 rgba(255,255,255,0.18), inset 0 -10px 18px rgba(0,0,0,0.36), 0 18px 38px rgba(0,0,0,0.52), 0 8px 18px rgba(0,0,0,0.38)",
             filter: "none",
           }}
         >


### PR DESCRIPTION
### Motivation
- Align the bottom-nav FAB with the premium liquid-glass style used by schedule top-bar buttons by replacing the dark navy gradient and heavy shadow with a translucent glass surface, subtle white border, backdrop blur, inset highlight, and controlled depth shadow.

### Description
- On the `motion.button` with `data-tour="fab"` updated only the base `className` string and the inline `style` values: replaced the dark gradient and heavy box-shadow with the provided glass gradient, inset highlights, dark depth shadows, `filter: "none"`, and added a subtle white border and backdrop blur while preserving `isOpen ? "rotate-45" : ""`, `shouldAttachCreationControls ? "pointer-events-none opacity-0" : ""`, all event handlers, Framer Motion props, icons, sizing, placement, and open/close behavior.

### Testing
- Ran `git diff -- components/ui/Fab.tsx` to verify the change (diff present).
- Ran `npm run lint` which failed due to pre-existing repository lint errors unrelated to this FAB-only change.
- Ran `npx eslint components/ui/Fab.tsx` which completed successfully with warnings only.
- Commit hook tests executed `npm run test:env` (Vitest) and the environment tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a238560a734832c959a938810b9d6f6)