### PR TITLE
Fix dashboard skills loading timeout

### DIFF
--- a/src/app/(app)/dashboard/_skills/useSkillsData.ts
+++ b/src/app/(app)/dashboard/_skills/useSkillsData.ts
@@ -3,6 +3,34 @@
 import { useCallback, useEffect, useState } from "react";
 import { getSupabaseBrowser } from "@/lib/supabase";
 
+const DASHBOARD_LOAD_TIMEOUT_MS = 10_000;
+const DASHBOARD_SEED_TIMEOUT_MS = 8_000;
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+function timeoutError(label: string, timeoutMs: number): Error {
+  return new Error(`${label} timed out after ${timeoutMs}ms`);
+}
+
+async function withTimeout<T>(
+  promise: PromiseLike<T>,
+  timeoutMs: number,
+  label: string
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(timeoutError(label, timeoutMs)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([Promise.resolve(promise), timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 export interface Category {
   id: string;
   name: string;
@@ -154,29 +182,43 @@ export function useSkillsData() {
 
   const load = useCallback(async () => {
     setIsLoading(true);
+    setError(null);
+    let loadError: Error | null = null;
+
     try {
       const supabase = getSupabaseBrowser();
       if (!supabase) throw new Error("Supabase client not available");
       const {
         data: { user },
-      } = await supabase.auth.getUser();
+      } = await withTimeout(supabase.auth.getUser(), DASHBOARD_LOAD_TIMEOUT_MS, "Supabase auth");
       if (!user) throw new Error("No user");
-      let [cats, skills] = await Promise.all([
-        fetchCategories(user.id).catch(() => []),
-        fetchSkills(user.id).catch(() => []),
-      ]);
+
+      const readCategories = () =>
+        withTimeout(fetchCategories(user.id), DASHBOARD_LOAD_TIMEOUT_MS, "Supabase categories").catch((e) => {
+          loadError = loadError ?? toError(e);
+          return [];
+        });
+      const readSkills = () =>
+        withTimeout(fetchSkills(user.id), DASHBOARD_LOAD_TIMEOUT_MS, "Supabase skills").catch((e) => {
+          loadError = loadError ?? toError(e);
+          return [];
+        });
+
+      let [cats, skills] = await Promise.all([readCategories(), readSkills()]);
 
       if (cats.length === 0 && skills.length === 0) {
         try {
-          await fetch("/api/dashboard", { cache: "no-store" });
-        } catch {
+          await withTimeout(
+            fetch("/api/dashboard", { cache: "no-store" }),
+            DASHBOARD_SEED_TIMEOUT_MS,
+            "/api/dashboard seed"
+          );
+        } catch (e) {
+          loadError = loadError ?? toError(e);
           // ignore seed failures; we'll continue to re-fetch below
         }
 
-        [cats, skills] = await Promise.all([
-          fetchCategories(user.id).catch(() => []),
-          fetchSkills(user.id).catch(() => []),
-        ]);
+        [cats, skills] = await Promise.all([readCategories(), readSkills()]);
       }
       const grouped = groupByCategory(skills);
       setSkillsByCategory(grouped);
@@ -188,8 +230,11 @@ export function useSkillsData() {
       } else {
         setCategories([]);
       }
+      setError(loadError);
     } catch (e) {
-      setError(e as Error);
+      setError(toError(e));
+      setSkillsByCategory({});
+      setCategories([]);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
### Motivation
- The dashboard's SkillsCarousel could get stuck showing the skeleton loader when Supabase auth, Supabase reads, or the `/api/dashboard` seed request hung and `isLoading` remained true indefinitely.
- Add a small client-side timeout pattern so these awaited calls cannot block the hook forever and the UI always resolves to a safe state.

### Description
- Added a lightweight timeout helper (`withTimeout`) plus constants (`DASHBOARD_LOAD_TIMEOUT_MS`, `DASHBOARD_SEED_TIMEOUT_MS`) and a small `toError` helper, and used them to bound client-side waits. (Changed file: `src/app/(app)/dashboard/_skills/useSkillsData.ts`.)
- Wrapped `supabase.auth.getUser()`, the calls to `fetchCategories(user.id)` and `fetchSkills(user.id)`, and the `fetch("/api/dashboard")` seed request with `withTimeout` and per-call error fallbacks so these operations reject after a reasonable delay instead of blocking forever.
- Preserved existing behavior: kept `fetchCategories`, `fetchSkills`, `groupByCategory`, fallback "uncategorized" category, `reload()` API, returned hook shape, and owner filtering by `user.id`; CREATOR product behavior was not changed.
- On failures/timeouts the hook records an `error`, falls back to safe empty state where appropriate, and always clears `isLoading` in the `finally` block.

### Testing
- Ran `git diff --check` on the changed file to ensure no whitespace/errors in the patch and it reported no issues.
- Ran `pnpm exec eslint 'src/app/(app)/dashboard/_skills/useSkillsData.ts'` which completed with no file-level lint errors.
- The repository pre-commit test hook that executes `pnpm test:env` ran and the environment test passed.
- `pnpm lint` and `pnpm exec tsc --noEmit` were executed but failed due to pre-existing repo-wide lint/type errors unrelated to this changed file; these failures are not caused by the change to `useSkillsData.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2506abb184832ca6adbd1596cb2ac4)