### PR TITLE
Style completed schedule instance cards

### DIFF
--- a/src/app/(app)/schedule/ScheduleTabContent.tsx
+++ b/src/app/(app)/schedule/ScheduleTabContent.tsx
@@ -218,7 +218,15 @@ const TIMELINE_COMPACT_CARD_HEIGHT_PX = 56;
 const TIMELINE_COMPACT_CARD_SHADOW =
   "0 14px 28px rgba(6, 8, 20, 0.45), 0 8px 18px rgba(0, 0, 0, 0.32), inset 0 1px 0 rgba(255, 255, 255, 0.08)";
 const TIMELINE_COMPACT_CARD_COMPLETED_SHADOW =
-  "0 18px 36px rgba(0, 0, 0, 0.48), 0 8px 18px rgba(0, 6, 4, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.06)";
+  "0 18px 34px rgba(0, 0, 0, 0.5), 0 8px 16px rgba(2, 44, 34, 0.36), inset 0 1px 0 rgba(236, 253, 245, 0.34), inset 0 -10px 18px rgba(1, 22, 15, 0.32)";
+const SCHEDULE_INSTANCE_COMPLETED_CARD_CLASS =
+  "schedule-instance-card--completed text-emerald-50 backdrop-blur";
+const SCHEDULE_INSTANCE_COMPLETED_PROGRESS_CLASS =
+  "schedule-instance-card__progress--completed";
+const SCHEDULE_INSTANCE_COMPLETED_BACKGROUND =
+  "radial-gradient(circle at 18% 0%, rgba(187, 247, 208, 0.18), transparent 34%), linear-gradient(180deg, rgba(52, 211, 153, 0.2) 0%, rgba(52, 211, 153, 0) 31%), linear-gradient(155deg, rgba(24, 160, 87, 0.98) 0%, rgba(18, 135, 72, 0.98) 45%, rgba(8, 95, 51, 0.99) 72%, rgba(3, 61, 35, 1) 100%)";
+const SCHEDULE_INSTANCE_COMPLETED_SHADOW =
+  "0 22px 40px rgba(0, 0, 0, 0.42), 0 10px 22px rgba(2, 44, 34, 0.34), inset 0 1px 0 rgba(236, 253, 245, 0.36), inset 0 -12px 20px rgba(1, 22, 15, 0.34)";
 const TIMELINE_RESTING_CARD_SHADOW =
   "0 0 0 1px rgba(255, 255, 255, 0.035), 0 10px 24px rgba(0, 0, 0, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.08)";
 const TIMELINE_STACK_BASE_Z_INDEX = 30;
@@ -8486,18 +8494,18 @@ export default function ScheduleTabContent({
                   }
                 };
                 const projectBackground = isCompleted
-                  ? "linear-gradient(155deg, rgba(34, 197, 94, 0.94) 0%, rgba(22, 163, 74, 0.97) 48%, rgba(21, 128, 61, 0.98) 100%)"
+                  ? SCHEDULE_INSTANCE_COMPLETED_BACKGROUND
                   : "radial-gradient(circle at 0% 0%, rgba(120, 126, 138, 0.28), transparent 58%), linear-gradient(140deg, rgba(8, 8, 10, 0.96) 0%, rgba(22, 22, 26, 0.94) 42%, rgba(88, 90, 104, 0.6) 100%)";
                 const resolvedProjectShadow = isCompleted
                   ? useCompactProjectShadow
                     ? TIMELINE_COMPACT_CARD_COMPLETED_SHADOW
-                    : "0 22px 38px rgba(0, 0, 0, 0.34), 0 9px 18px rgba(3, 83, 45, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.12)"
+                    : SCHEDULE_INSTANCE_COMPLETED_SHADOW
                   : sharedCardShadow;
                 const projectCardStyle: CSSProperties = {
                   ...sharedCardStyle,
                   boxShadow: resolvedProjectShadow,
                   outline: isCompleted
-                    ? "1px solid rgba(22, 101, 52, 0.42)"
+                    ? "1px solid rgba(2, 44, 34, 0.86)"
                     : sharedCardStyle.outline,
                   background: projectBackground,
                   opacity: displacedPreview ? 0.92 : undefined,
@@ -8506,7 +8514,7 @@ export default function ScheduleTabContent({
                     : sharedCardStyle.outlineOffset,
                 };
                 const projectBorderClass = isCompleted
-                  ? "border-green-900/45"
+                  ? "border-emerald-950/90"
                   : "border-black/70";
                 const instanceEnergyLevel = resolveEnergyLevel(
                   instance.energy_resolved
@@ -8659,7 +8667,7 @@ export default function ScheduleTabContent({
                               event.preventDefault();
                               handleProjectPrimaryAction();
                             }}
-                            className={`relative flex h-full w-full items-center justify-between ${projectCornerClass} px-3 ${collapsedCardPaddingClass} text-white backdrop-blur-sm border ${projectBorderClass} transition-[background,box-shadow,border-color] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] select-none${
+                            className={`relative flex h-full w-full items-center justify-between ${projectCornerClass} px-3 ${collapsedCardPaddingClass} text-white backdrop-blur-sm border ${projectBorderClass} ${isCompleted ? SCHEDULE_INSTANCE_COMPLETED_CARD_CLASS : ""} transition-[background,box-shadow,border-color] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] select-none${
                               canExpand || (canToggle && !isPending)
                                 ? " cursor-pointer"
                                 : ""
@@ -8881,6 +8889,8 @@ export default function ScheduleTabContent({
                                 const shinyTaskClasses =
                                   "bg-[linear-gradient(135deg,_rgba(52,52,60,0.95)_0%,_rgba(82,84,94,0.92)_40%,_rgba(158,162,174,0.88)_100%)] text-zinc-50 shadow-[0_18px_38px_rgba(8,8,12,0.55)] ring-1 ring-white/20 backdrop-blur";
                                 const completedTaskClasses =
+                                  SCHEDULE_INSTANCE_COMPLETED_CARD_CLASS;
+                                const fallbackCompletedTaskClasses =
                                   "bg-[linear-gradient(135deg,_rgba(30,204,163,0.95)_0%,_rgba(16,185,129,0.85)_45%,_rgba(4,120,87,0.92)_100%)] text-emerald-50 shadow-[0_18px_38px_rgba(4,47,39,0.55)] ring-1 ring-emerald-300/60 backdrop-blur";
                                 const fallbackTaskClasses =
                                   "bg-[linear-gradient(135deg,_rgba(44,44,52,0.9)_0%,_rgba(68,70,80,0.88)_38%,_rgba(120,126,138,0.82)_100%)] text-zinc-100 shadow-[0_16px_32px_rgba(10,10,14,0.5)] ring-1 ring-white/15 backdrop-blur-[2px]";
@@ -8928,12 +8938,26 @@ export default function ScheduleTabContent({
                                   ? fallbackCompleted
                                   : scheduledCompleted;
                                 const cardClasses = `${baseTaskClasses} ${
-                                  isCompleted
+                                  scheduledCompleted
                                     ? completedTaskClasses
-                                    : isFallbackCard
-                                      ? fallbackTaskClasses
-                                      : shinyTaskClasses
+                                    : fallbackCompleted
+                                      ? fallbackCompletedTaskClasses
+                                      : isFallbackCard
+                                        ? fallbackTaskClasses
+                                        : shinyTaskClasses
                                 }`;
+                                const taskStyle: CSSProperties =
+                                  scheduledCompleted
+                                    ? {
+                                        ...tStyle,
+                                        background:
+                                          SCHEDULE_INSTANCE_COMPLETED_BACKGROUND,
+                                        boxShadow:
+                                          SCHEDULE_INSTANCE_COMPLETED_SHADOW,
+                                        outline:
+                                          "1px solid rgba(2, 44, 34, 0.86)",
+                                      }
+                                    : tStyle;
                                 const progressValue =
                                   kind === "scheduled"
                                     ? Math.max(
@@ -8947,11 +8971,13 @@ export default function ScheduleTabContent({
                                     : isCompleted
                                       ? 100
                                       : 0;
-                                const progressBarClass = isCompleted
-                                  ? "absolute left-0 bottom-0 h-[3px] bg-emerald-300/80"
-                                  : kind === "scheduled"
-                                    ? "absolute left-0 bottom-0 h-[3px] bg-white/40"
-                                    : "absolute left-0 bottom-0 h-[3px] bg-white/25";
+                                const progressBarClass = scheduledCompleted
+                                  ? `${SCHEDULE_INSTANCE_COMPLETED_PROGRESS_CLASS} absolute left-0 bottom-0 h-[3px]`
+                                  : isCompleted
+                                    ? "absolute left-0 bottom-0 h-[3px] bg-emerald-300/80"
+                                    : kind === "scheduled"
+                                      ? "absolute left-0 bottom-0 h-[3px] bg-white/40"
+                                      : "absolute left-0 bottom-0 h-[3px] bg-white/25";
                                 const hasInteractiveRole =
                                   isFallbackCard ||
                                   (kind === "scheduled" && !!instanceId);
@@ -9034,7 +9060,7 @@ export default function ScheduleTabContent({
                                         ? " cursor-pointer"
                                         : ""
                                     }`}
-                                    style={tStyle}
+                                    style={taskStyle}
                                     onPointerDown={(event) => {
                                       if (!instanceId) return;
                                       const taskInstance =
@@ -9222,7 +9248,12 @@ export default function ScheduleTabContent({
                       boxShadow: isCompleted
                         ? completedStandaloneShadow
                         : baseStandaloneShadow,
-                      outline: "1px solid var(--event-border)",
+                      background: isCompleted
+                        ? SCHEDULE_INSTANCE_COMPLETED_BACKGROUND
+                        : undefined,
+                      outline: isCompleted
+                        ? "1px solid rgba(2, 44, 34, 0.86)"
+                        : "1px solid var(--event-border)",
                       outlineOffset: "-1px",
                     },
                     layoutMode,
@@ -9239,7 +9270,7 @@ export default function ScheduleTabContent({
                   const standaloneBaseClass =
                     "absolute flex items-center justify-between px-3 py-2";
                   const standaloneScheduledClass = `${standaloneBaseClass} text-zinc-100 shadow-[0_12px_28px_rgba(24,24,27,0.35)] bg-[linear-gradient(135deg,_rgba(46,46,52,0.94)_0%,_rgba(58,58,66,0.92)_45%,_rgba(82,82,92,0.88)_100%)]`;
-                  const standaloneCompletedClass = `${standaloneBaseClass} text-emerald-50 shadow-[0_22px_42px_rgba(4,47,39,0.55)] ring-1 ring-emerald-300/60 bg-[linear-gradient(135deg,_rgba(6,78,59,0.96)_0%,_rgba(4,120,87,0.94)_42%,_rgba(16,185,129,0.9)_100%)]`;
+                  const standaloneCompletedClass = `${standaloneBaseClass} ${SCHEDULE_INSTANCE_COMPLETED_CARD_CLASS}`;
                   const standaloneCornerClass =
                     getTimelineCardCornerClass(layoutMode);
                   const standaloneClassName = [
@@ -9380,7 +9411,7 @@ export default function ScheduleTabContent({
                       <div
                         className={
                           isCompleted
-                            ? "absolute left-0 bottom-0 h-[3px] bg-emerald-300/80"
+                            ? `${SCHEDULE_INSTANCE_COMPLETED_PROGRESS_CLASS} absolute left-0 bottom-0 h-[3px]`
                             : "absolute left-0 bottom-0 h-[3px] bg-zinc-900/25"
                         }
                         style={{ width: `${progress}%` }}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -746,3 +746,45 @@ body.fab-keyboard-active [data-bottom-nav] [data-tour="fab"] {
   filter: blur(0.35px);
   opacity: 1;
 }
+
+/* Glossy green button treatment scoped to completed Schedule page instance cards. */
+.schedule-instance-card--completed {
+  background: var(--schedule-instance-completed-bg, radial-gradient(circle at 18% 0%, rgba(187, 247, 208, 0.18), transparent 34%), linear-gradient(180deg, rgba(52, 211, 153, 0.2) 0%, rgba(52, 211, 153, 0) 31%), linear-gradient(155deg, rgba(24, 160, 87, 0.98) 0%, rgba(18, 135, 72, 0.98) 45%, rgba(8, 95, 51, 0.99) 72%, rgba(3, 61, 35, 1) 100%));
+  border-color: rgba(1, 24, 16, 0.92);
+  outline: 1px solid rgba(2, 44, 34, 0.86);
+  outline-offset: -1px;
+  color: rgb(247 255 251);
+  box-shadow:
+    0 22px 40px rgba(0, 0, 0, 0.42),
+    0 10px 22px rgba(2, 44, 34, 0.34),
+    inset 0 1px 0 rgba(236, 253, 245, 0.36),
+    inset 0 -12px 20px rgba(1, 22, 15, 0.34);
+  text-shadow: 0 1px 1px rgba(0, 20, 12, 0.45);
+}
+
+.schedule-instance-card--completed::before {
+  content: "";
+  position: absolute;
+  inset: 1px 1px auto;
+  height: 42%;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+}
+
+.schedule-instance-card--completed::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow:
+    inset 0 0 0 1px rgba(187, 247, 208, 0.14),
+    inset 0 -4px 0 rgba(1, 45, 27, 0.68),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.5);
+}
+
+.schedule-instance-card__progress--completed {
+  background: linear-gradient(90deg, rgba(209, 250, 229, 0.88), rgba(52, 211, 153, 0.86), rgba(5, 46, 22, 0.72));
+  box-shadow: 0 -1px 0 rgba(255, 255, 255, 0.16);
+}


### PR DESCRIPTION
### Motivation
- Improve the visual treatment for completed schedule instance cards to a premium glossy green button look while keeping all scheduler logic and behaviors unchanged.

### Description
- Added reusable constants and class names in `ScheduleTabContent.tsx` for completed card background, shadow, progress class, and CSS class usage to centralize the new treatment.
- Applied the new completed class/style to project instance cards, nested scheduled task cards, and standalone timeline task cards on the Schedule page without modifying scheduling, completion, drag/drop, or data logic.
- Introduced scoped CSS in `src/styles/globals.css` for `.schedule-instance-card--completed` and `.schedule-instance-card__progress--completed`, implementing layered green gradients, darker lower edge, inset highlight, dark border/outline, and soft outer/inset shadows.
- Preserved existing non-completed, overdue, selected, dragging, fallback, and compact treatments; fallback/backlog completed styling remains separate.

### Testing
- Ran `git diff --check` with no reported issues for the changed files.
- Ran `pnpm exec eslint 'src/app/(app)/schedule/ScheduleTabContent.tsx' src/styles/globals.css`, which completed and reported only existing warnings in the file and an ignored CSS config warning; no new lint errors introduced by this change.
- Ran repository lint (`pnpm lint`) which fails on unrelated, pre-existing repository lint errors outside this UI-only change.
- Commit hook ran `pnpm test:env` (Vitest) during commit and the environment test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25a98f0f7c832c81cae97b8d70fa5f)