### PR TITLE
Prevent related habit long-press selection

### DIFF
--- a/src/components/monuments/MonumentRelatedHabits.tsx
+++ b/src/components/monuments/MonumentRelatedHabits.tsx
@@ -1165,12 +1165,18 @@ export function MonumentRelatedHabits({
                     onPointerUp={cancelRelatedHabitLongPress}
                     onPointerCancel={cancelRelatedHabitLongPress}
                     onPointerLeave={handleRelatedHabitPointerLeave}
+                    onSelectStart={(event) => event.preventDefault()}
                     onDoubleClick={(event) =>
                       handleRelatedHabitDoubleClick(event, habit.id)
                     }
                     onTouchEnd={(event) =>
                       handleRelatedHabitTouchEnd(event, habit.id)
                     }
+                    style={{
+                      WebkitTouchCallout: "none",
+                      WebkitUserSelect: "none",
+                      userSelect: "none",
+                    }}
                   >
                     {showStreakBadge ? (
                       <span
@@ -1191,7 +1197,7 @@ export function MonumentRelatedHabits({
                         <span className="tracking-normal">{streakLabel}</span>
                       </span>
                     ) : null}
-                    <div className="relative z-[2] flex min-h-0 flex-1 flex-col items-center justify-between gap-1 text-center">
+                    <div className="relative z-[2] flex min-h-0 flex-1 select-none flex-col items-center justify-between gap-1 text-center">
                       <span
                         className={clsx(
                           "mt-1 flex items-center justify-center rounded-lg border border-white/10 bg-white/5 font-semibold leading-none text-white shadow-[inset_0_-1px_0_rgba(255,255,255,0.06),_0_6px_12px_rgba(0,0,0,0.35)]",
@@ -1206,10 +1212,10 @@ export function MonumentRelatedHabits({
                       >
                         {habitSkillIcon}
                       </span>
-                      <div className="flex min-h-0 w-full min-w-0 flex-1 items-center justify-center">
+                      <div className="flex min-h-0 w-full min-w-0 flex-1 select-none items-center justify-center">
                         <span
                           className={clsx(
-                            "line-clamp-3 w-full min-w-0 break-words px-0.5 text-center font-semibold leading-tight text-white whitespace-normal",
+                            "line-clamp-3 w-full min-w-0 select-none break-words px-0.5 text-center font-semibold leading-tight text-white whitespace-normal",
                             isSmallRelatedHabitDensity
                               ? "text-[8px] sm:text-[9px]"
                               : "text-[9px] sm:text-[10px]"


### PR DESCRIPTION
### Motivation
- Long-pressing a related habit on the Monument details page opened the habit edit modal but also highlighted/selected UI text; the change prevents selection while keeping existing long-press behavior intact.

### Description
- Apply selection suppression to the related habit press surface by adding `onSelectStart={(event) => event.preventDefault()}`, an inline style to suppress mobile Safari callouts (`WebkitTouchCallout`, `WebkitUserSelect`, `userSelect`), and `select-none` on immediate text wrappers in `src/components/monuments/MonumentRelatedHabits.tsx`, while preserving all existing pointer/touch/double-tap handlers and layout.

### Testing
- Ran `pnpm exec eslint src/components/monuments/MonumentRelatedHabits.tsx` which completed for the changed file; `pnpm test:env` (commit hook) passed; running the full `pnpm lint` surfaced unrelated preexisting lint errors elsewhere in the repo but did not indicate issues from the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2baa1f729c832caaa7295cdaa0e49d)